### PR TITLE
A few fixes to 'named_tuple'.

### DIFF
--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -1083,7 +1083,7 @@ consteval auto make_named_tuple(std::meta::info type, Tags... tags) {
     std::vector<std::meta::info> nsdms;
     auto f = [&]<class Tag>(Tag tag){
         nsdms.push_back(std::meta::data_member_spec(
-            dealias(^typename Tag::type),
+            dealias(^Tag::type),
             {.name=Tag::name()}));
 
     };

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -1082,7 +1082,7 @@ template <class... Tags>
 consteval auto make_named_tuple(std::meta::info type, Tags... tags) {
     std::vector<std::meta::info> nsdms;
     auto f = [&]<class Tag>(Tag tag){
-        nsdms.push_back(std::meta::data_member_spec(
+        nsdms.push_back(data_member_spec(
             dealias(^Tag::type),
             {.name=Tag::name()}));
 

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -1080,10 +1080,10 @@ struct pair {
 
 template <class... Tags>
 consteval auto make_named_tuple(std::meta::info type, Tags... tags) {
-    std::vector<std::meta::nsdm_description> nsdms;
+    std::vector<std::meta::info> nsdms;
     auto f = [&]<class Tag>(Tag tag){
-        nsdms.push_back(std::meta::nsdm_description(
-            dealias(^Tag::type),
+        nsdms.push_back(std::meta::data_member_spec(
+            dealias(^typename Tag::type),
             {.name=Tag::name()}));
 
     };


### PR DESCRIPTION
I'm not actually sure why `^Tag::type` works for EDG without a `typename`?