### PR TITLE
Suggestion for removing UB in the library wording of P2996

### DIFF
--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3020,7 +3020,7 @@ consteval vector<info> enumerators_of(info enum_type);
 ::: addu
 [1]{.pnum} Subclause [meta.reflection.unary] contains consteval functions that may be used to query the properties of a type at compile time.
 
-[2]{.pnum} For each function taking an argument of type `meta::info` whose name contains `type`, that argument shall be a reflection of a type or type alias. For each function taking an argument of type `span<const meta::info>` named `type_args`, each `meta::info` in that `span` shall be a reflection of a type or a type alias.
+[2]{.pnum} For each function taking an argument of type `meta::info` whose name contains `type`, a call to the function is a non-constant library call ([defns.nonconst.libcall]{.sref}) if that argument is not a reflection of a type or type alias. For each function taking an argument of type `span<const meta::info>` named `type_args`, a call to the function is a non-constant library call if any `meta::info` in that `span` is not a reflection of a type or a type alias.
 :::
 :::
 


### PR DESCRIPTION
"Shall" in the library wording means that the behavior is undefined when such a requirement is not met by default.

Perhaps we just want ill-formedness, and "non-constant library call" ([[defns.nonconst.libcall]](https://eel.is/c++draft/defns.nonconst.libcall)) looks appropriate to me since these functions are all `consteval`.