### PR TITLE
'^int & true' is also ambiguous.

### DIFF
--- a/2996_reflection/p2996r4.html
+++ b/2996_reflection/p2996r4.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-05-28" />
+  <meta name="dcterms.date" content="2024-05-29" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -560,7 +560,7 @@ code del { border: 1px solid #ECB3C7; }
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-05-28</td>
+    <td>2024-05-29</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -4709,11 +4709,12 @@ value</em>.</p>
 <span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a>bool operator&lt;(std::meta::info, X&lt;false&gt;);</span>
 <span id="cb105-5"><a href="#cb105-5" aria-hidden="true" tabindex="-1"></a>consteval void g(std::meta::info r, X&lt;false&gt; xv) {</span>
 <span id="cb105-6"><a href="#cb105-6" aria-hidden="true" tabindex="-1"></a>  if (r == ^int &amp;&amp; true);    // error: ^ applies to the type-id &quot;int&amp;&amp;&quot;</span>
-<span id="cb105-7"><a href="#cb105-7" aria-hidden="true" tabindex="-1"></a>  if (r == (^int) &amp;&amp; true);  // OK</span>
-<span id="cb105-8"><a href="#cb105-8" aria-hidden="true" tabindex="-1"></a>  if (^X &lt; xv);       // error: &lt; starts template argument list</span>
-<span id="cb105-9"><a href="#cb105-9" aria-hidden="true" tabindex="-1"></a>  if ((^X) &lt; xv);     // OK</span>
-<span id="cb105-10"><a href="#cb105-10" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb105-11"><a href="#cb105-11" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
+<span id="cb105-7"><a href="#cb105-7" aria-hidden="true" tabindex="-1"></a>  if (r == ^int &amp; true);     // error: ^ applies to the type-id &quot;int&amp;&quot;</span>
+<span id="cb105-8"><a href="#cb105-8" aria-hidden="true" tabindex="-1"></a>  if (r == (^int) &amp;&amp; true);  // OK</span>
+<span id="cb105-9"><a href="#cb105-9" aria-hidden="true" tabindex="-1"></a>  if (^X &lt; xv);       // error: &lt; starts template argument list</span>
+<span id="cb105-10"><a href="#cb105-10" aria-hidden="true" tabindex="-1"></a>  if ((^X) &lt; xv);     // OK</span>
+<span id="cb105-11"><a href="#cb105-11" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb105-12"><a href="#cb105-12" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">4</a></span>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3029,6 +3029,7 @@ template<bool> struct X {};
 bool operator<(std::meta::info, X<false>);
 consteval void g(std::meta::info r, X<false> xv) {
   if (r == ^int && true);    // error: ^ applies to the type-id "int&&"
+  if (r == ^int & true);     // error: ^ applies to the type-id "int&"
   if (r == (^int) && true);  // OK
   if (^X < xv);       // error: < starts template argument list
   if ((^X) < xv);     // OK


### PR DESCRIPTION
Figured it was worth adding the example. Forgot this could happen too.