### PR TITLE
Some 2024-06-27 and 2024-06-28 CWG updates.

### DIFF
--- a/2996_reflection/d2996r5.html
+++ b/2996_reflection/d2996r5.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-07-01" />
+  <meta name="dcterms.date" content="2024-07-03" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-07-01</td>
+    <td>2024-07-03</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -817,6 +817,9 @@ definitions<span></span></a></li>
 <li><a href="#enum.udecl-the-using-enum-declaration" id="toc-enum.udecl-the-using-enum-declaration"><span>9.7.2
 <span>[enum.udecl]</span></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
 declaration<span></span></a></li>
+<li><a href="#namespace.alias-namespace-alias" id="toc-namespace.alias-namespace-alias"><span>9.8.3
+<span>[namespace.alias]</span></span> Namespace
+alias<span></span></a></li>
 <li><a href="#namespace.udir-using-namespace-directive" id="toc-namespace.udir-using-namespace-directive"><span>9.8.4
 <span>[namespace.udir]</span></span> Using namespace
 directive<span></span></a></li>
@@ -1300,7 +1303,7 @@ reach of this proposal.</p>
 <p>Note that a “member access splice” like <code class="sourceCode cpp">s<span class="op">.[:</span>member_number<span class="op">(</span><span class="dv">1</span><span class="op">):]</span></code>
 is a more direct member access mechanism than the traditional syntax. It
 doesn’t involve member name lookup, access checking, or — if the spliced
-reflection value denotes a member function — overload resolution.</p>
+reflection value represents a member function — overload resolution.</p>
 <p>This proposal includes a number of consteval “metafunctions” that
 enable the introspection of various language constructs. Among those
 metafunctions is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>nonstatic_data_members_of</code>
@@ -1329,7 +1332,7 @@ the <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="o
 qualification can therefore be omitted in the example above.</p>
 <p>Another frequently-useful metafunction is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>name_of</code>,
 which returns a <code class="sourceCode cpp">std<span class="op">::</span>string_view</code>
-describing the unqualified name of an entity denoted by a given
+describing the unqualified name of an entity represented by a given
 reflection value. With such a facility, we could conceivably access
 non-static data members “by string”:</p>
 <div class="std">
@@ -2590,7 +2593,7 @@ isn’t just the same as <code class="sourceCode cpp"><span class="op">&amp;</sp
 function or function template that is part of an overload set, overload
 resolution will not consider the whole overload set, just the specific
 function or function template that <code class="sourceCode cpp">r</code>
-reflects:</p>
+represents:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb41"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> C <span class="op">{</span></span>
@@ -2711,9 +2714,9 @@ declarations of template parameters<a href="#splicing-concepts-in-declarations-o
 <span id="cb47-4"><a href="#cb47-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">template</span> <span class="op">[:</span>R<span class="op">:]</span> S<span class="op">&gt;</span> <span class="kw">struct</span> Inner <span class="op">{</span> <span class="co">/* ... */</span> <span class="op">}</span>;</span>
 <span id="cb47-5"><a href="#cb47-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <p>What kind of parameter is <code class="sourceCode cpp">S</code>? If
-<code class="sourceCode cpp">R</code> reflects a class template, then it
-is a non-type template parameter of deduced type, but if
-<code class="sourceCode cpp">R</code> reflects a concept, it is a type
+<code class="sourceCode cpp">R</code> represents a class template, then
+it is a non-type template parameter of deduced type, but if
+<code class="sourceCode cpp">R</code> represents a concept, it is a type
 template parameter. There is no other circumstance in the language for
 which it is not possible to decide at parse time whether a template
 parameter is a type or a non-type, and we don’t wish to introduce one
@@ -3020,7 +3023,7 @@ meaningful, but for which no ordering relation is defined.</p>
 <p>When the
 <code class="sourceCode cpp"><span class="op">^</span></code> operator
 is followed by an <em>id-expression</em>, the resulting <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-reflects the entity named by the expression. Such reflections are
+represents the entity named by the expression. Such reflections are
 equivalent only if they reflect the same entity.</p>
 <div class="std">
 <blockquote>
@@ -3745,7 +3748,7 @@ literal encoding only; if any character cannot be represented, it is not
 a constant expression. If the class of reflected entity cannot possibly
 have a name, the expression fails to be a constant expression.</p>
 <p>Given a reflection <code class="sourceCode cpp">r</code> that
-designates a declared entity <code class="sourceCode cpp">X</code>,
+represents a declared entity <code class="sourceCode cpp">X</code>,
 <code class="sourceCode cpp">name_of<span class="op">(</span>r<span class="op">)</span></code>
 and <code class="sourceCode cpp">qualified_name_of</code> return a
 <code class="sourceCode cpp">string_view</code> holding the unqualified
@@ -3798,12 +3801,12 @@ qualifiers):</p>
 <span id="cb79-5"><a href="#cb79-5" aria-hidden="true" tabindex="-1"></a><span class="pp">#define typeof</span><span class="op">(</span>e<span class="op">)</span><span class="pp"> </span><span class="op">[:</span><span class="pp"> </span>type_doof<span class="op">(^</span>e<span class="op">)</span><span class="pp"> </span><span class="op">:]</span></span></code></pre></div>
 </blockquote>
 </div>
-<p>If <code class="sourceCode cpp">r</code> designates a member of a
+<p>If <code class="sourceCode cpp">r</code> represents a member of a
 class or namespace, <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection designating its immediately enclosing class or (possibly
 inline or anonymous) namespace.</p>
-<p>If <code class="sourceCode cpp">r</code> designates an alias, <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
-designates the underlying entity. Otherwise, <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
+<p>If <code class="sourceCode cpp">r</code> represents an alias, <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
+represents the underlying entity. Otherwise, <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 produces <code class="sourceCode cpp">r</code>.
 <code class="sourceCode cpp">dealias</code> is recursive - it strips all
 aliases:</p>
@@ -4585,7 +4588,7 @@ One-definition rule<a href="#basic.def.odr-one-definition-rule" class="self-link
 A function is named by an expression or conversion if it is the selected
 member of an overload set ([basic.lookup], [over.match], [over.over]) in
 an overload resolution performed as part of forming that expression or
-conversion, <span class="addu">or if it is denoted by a
+conversion, <span class="addu">or if it is designated by a
 <em>splice-expression</em> ([expr.prim.splice]),</span> unless it is a
 pure virtual function and either the expression is not an
 <em>id-expression</em> naming the function with an explicitly qualified
@@ -4601,7 +4604,7 @@ variables:</p>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_4" id="pnum_4">5</a></span>
 A variable is named by an expression if the expression is an
 <em>id-expression</em> <span class="addu">or <em>splice-expression</em>
-([expr.prim.splice])</span> that denotes it.</li>
+([expr.prim.splice])</span> that designates it.</li>
 </ul>
 </blockquote>
 </div>
@@ -4625,7 +4628,7 @@ of it is the operand of a potentially-evaluated
 If a class <code class="sourceCode cpp">C</code> is defined in a
 translation unit with a call to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>define_class</code>,
 every definition of that class shall be the result of a call to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>define_class</code>
-such that its respective members are equal in number and have
+such that its corresponding members are equal in number and have
 respectively the same types, alignments, <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
 attributes (if any), bit-field widths (if any), and specified names (if
 any).</p>
@@ -4637,11 +4640,8 @@ definitions …</p>
 </div>
 <h3 class="unnumbered" id="basic.lookup.argdep-argument-dependent-name-lookup"><span>6.5.4 <a href="https://wg21.link/basic.lookup.argdep">[basic.lookup.argdep]</a></span>
 Argument-dependent name lookup<a href="#basic.lookup.argdep-argument-dependent-name-lookup" class="self-link"></a></h3>
-<p>Add a bullet to paragraph 3 of <span>6.5.4 <a href="https://wg21.link/basic.lookup.argdep">[basic.lookup.argdep]</a></span>
-as follows <span class="ednote" style="color: #0000ff">[ Editor&#39;s note:
-this must precede the fundamental type bullet, because
-<code class="sourceCode default">meta::info</code> is a fundamental type
-]</span>:</p>
+<p>Modify the first bullet of paragraph 3 of <span>6.5.4 <a href="https://wg21.link/basic.lookup.argdep">[basic.lookup.argdep]</a></span>
+as follows:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_8" id="pnum_8">3</a></span>
@@ -4649,19 +4649,14 @@ this must precede the fundamental type bullet, because
 <code class="sourceCode cpp"><em>using-declaration</em></code>s used to
 specify the types do not contribute to this set. The set of entities is
 determined in the following way:</p>
-<div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_9" id="pnum_9">(3.0)</a></span>
-If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_9" id="pnum_9">(3.1)</a></span>
+<span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 its associated set of entities is the singleton containing the function
-<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>is_type</code>.</li>
-</ul>
-</div>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_10" id="pnum_10">(3.1)</a></span>
-If <code class="sourceCode cpp">T</code> is a fundamental type, its
-associated set of entities is empty.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_11" id="pnum_11">(3.2)</a></span>
+<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>is_type</code>.</span>
+If <code class="sourceCode cpp">T</code> is any <span class="addu">other</span> fundamental type, its associated set of
+entities is empty.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_10" id="pnum_10">(3.2)</a></span>
 If <code class="sourceCode cpp">T</code> is a class type …</li>
 </ul>
 </blockquote>
@@ -4677,7 +4672,7 @@ to cover
 <code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_12" id="pnum_12">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_11" id="pnum_11">1</a></span>
 Lookup of an <em>identifier</em> followed by a
 ​<code class="sourceCode cpp"><span class="op">::</span></code>​ scope
 resolution operator considers only namespaces, types, and templates
@@ -4689,13 +4684,13 @@ is followed by a
 ​<code class="sourceCode cpp"><span class="op">::</span></code>​, it shall
 designate a namespace, class, enumeration, or dependent type, and the ​::​
 is never interpreted as a complete nested-name-specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_13" id="pnum_13">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_12" id="pnum_12">2</a></span>
 A member-qualified name is the (unique) component name
 ([expr.prim.id.unqual]), if any, of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_13" id="pnum_13">(2.1)</a></span>
 an <em>unqualified-id</em> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">(2.2)</a></span>
 a <code class="sourceCode cpp"><em>nested-name-specifier</em></code> of
 the form <code class="sourceCode cpp"><em>type-name</em> <span class="op">::</span></code>
 <span class="rm" style="color: #bf0303"><del>or</del></span><span class="addu">,</span> <code class="sourceCode cpp"><em>namespace-name</em> <span class="op">::</span></code><span class="addu">, or <code class="sourceCode cpp"><em>splice-namespace-qualifier</em> <span class="op">::</span></code></span></li>
@@ -4709,29 +4704,29 @@ Linkage<a href="#basic.link-program-and-linkage" class="self-link"></a></h3>
 <p>Add a bullet to paragraph 4, and renumber accordingly:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">4</a></span>
 An unnamed namespace or a namespace declared directly or indirectly
 within an unnamed namespace has internal linkage. All other namespaces
 have external linkage. The name of an entity that belongs to a namespace
 scope that has not been given internal linkage above and that is the
-name of * <span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(4.1)</a></span>
+name of * <span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">(4.1)</a></span>
 a variable; or</p>
 <p>…</p>
 <p>has its linkage determined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(4.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(4.7)</a></span>
 if the enclosing namespace has internal linkage, the name has internal
 linkage;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(4.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(4.8)</a></span>
 otherwise, if the declaration of the name is attached to a named module
 ([module.unit]) and is not exported ([module.interface]), the name has
 module linkage;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(4.9)</a></span>
-<span class="addu">otherwise, if the declaration is a variable having
-<em>consteval-only type</em> ([basic.types.general]), or is of a class
-template specialization type having a <em>consteval-only type</em> as a
-non-type template argument, the name has internal linkage.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">(4.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(4.9)</a></span>
+<span class="addu">otherwise, if the declaration introduces a variable
+whose type is a consteval-only type ([basic.types.general]) or a class
+template specialization where one or more non-type template arguments
+are of consteval-only type, the name has internal linkage.</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(4.10)</a></span>
 otherwise, the name has external linkage.</li>
 </ul>
 </blockquote>
@@ -4742,7 +4737,7 @@ General<a href="#basic.types.general-general" class="self-link"></a></h3>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">9</a></span>
 Arithmetic types (6.8.2), enumeration types, pointer types,
 pointer-to-member types (6.8.4), <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -4755,7 +4750,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">*</a></span>
 A <em>consteval-only type</em> is one of the following:</p>
 <ul>
 <li><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
@@ -4763,21 +4758,22 @@ or</li>
 <li>a pointer or reference to a consteval-only type, or</li>
 <li>an (possibly multi-dimensional) array of a consteval-only type,
 or</li>
+<li>a class type with a base class or non-static data member of
+consteval-only type, or</li>
+<li>a function type with a return type or parameter type of
+consteval-only type, or</li>
 <li>a pointer-to-member type to a class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">M</code> where either
 <code class="sourceCode cpp">C</code> or
-<code class="sourceCode cpp">M</code> is a consteval-only type, or</li>
-<li>a function type with a consteval-only return type or a
-consteval-only parameter type, or</li>
-<li>a class type with a consteval-only base class type or consteval-only
-non-static data member type.</li>
+<code class="sourceCode cpp">M</code> is a consteval-only type.</li>
 </ul>
 <p>An object of consteval-only type shall either end its lifetime during
 the evaluation of a manifestly constant-evaluated expression or
 conversion (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>), or be a
-constexpr variable that is not odr-used (<span>6.3 <a href="https://wg21.link/basic.def.odr">[basic.def.odr]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">*</a></span>
+constexpr variable for which every expression that names the variable is
+within an immediate function context.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">*</a></span>
 Consteval-only types may not be used to declare a static data member of
 a class having module or external linkage. Furthermore, specializations
 of a class template having a non-type template argument of
@@ -4793,41 +4789,30 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">17 - 2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">17 - 1</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-is called a <em>reflection</em> and represents a language element such
-as a type, a value, an object, a non-static data member, etc. An
-expression convertible to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-is said to <em>reflect</em> the language element represented by the
-resulting value; the language element is said to be <em>reflected
-by</em> the expression. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
-shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span><span class="dt">void</span><span class="op">*)</span></code>.
-<span class="note"><span>[ <em>Note 1:</em> </span>Reflections are only
-meaningful during translation. The notion of consteval-only types (see
-<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>)
-exists to diagnose attempts at using such values outside the translation
-process.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">17 - 1</a></span>
-Every value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-is either a reflection of:</p>
+is called a <em>reflection</em>. There exists a unique <em>null
+reflection</em>; every other reflection is a representation of</p>
 <ul>
-<li>a value,</li>
-<li>an object,</li>
-<li>a reference,</li>
-<li>a structured bindings,</li>
+<li>a value with structural type,</li>
+<li>an object with static storage duration,</li>
+<li>a variable,</li>
+<li>a structured binding,</li>
 <li>a function,</li>
 <li>an enumerator,</li>
 <li>a type,</li>
 <li>a class member,</li>
 <li>a bit-field,</li>
-<li>a template,</li>
-<li>a template specialization,</li>
+<li>a class template, function template, variable template, alias
+template, or concept,</li>
 <li>a namespace,</li>
-<li>a pack,</li>
-<li>an alias or description of any of the above,</li>
+<li>an alias of a type or namespace,</li>
 <li>a base specifier, or</li>
-<li>a <em>null reflection value</em>.</li>
+<li>a description of a non-static data member.</li>
 </ul>
+<p>An expression convertible to a reflection is said to
+<em>represent</em> the corresponding entity, variable, alias, base
+specifier, or description of a non-static data member.</p>
 </div>
 </blockquote>
 </div>
@@ -4861,16 +4846,21 @@ as follows:</p>
 <div class="addu">
 <div class="sourceCode" id="cb108"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><em>splice-specifier</em>:</span>
 <span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">1</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> shall be
 a converted constant expression ([expr.const]) contextually convertible
 to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">2</a></span>
 Let <code class="sourceCode cpp">E</code> be the value of the converted
-<code class="sourceCode cpp"><em>constant-expression</em></code>. A
+<code class="sourceCode cpp"><em>constant-expression</em></code>. The
 <code class="sourceCode cpp"><em>splice-specifier</em></code> designates
 what <code class="sourceCode cpp">E</code> represents.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">3</a></span>
+A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
+dependent if the converted
+<code class="sourceCode cpp"><em>constant-expression</em></code> is
+value-dependent.</p>
 </div>
 </blockquote>
 </div>
@@ -4880,26 +4870,26 @@ General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
 <p>Add a carve-out for reflection in <span>7.5.4.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">4</a></span>
 An <code class="sourceCode cpp"><em>id-expression</em></code> that
 denotes a non-static data member or implicit object member function of a
 class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">(4.1)</a></span>
 as part of a class member access (after any implicit transformation (see
 above)) in which the object expression refers to the member’s class or a
 class derived from that class, or</li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(4.2)</a></span>
 as an operand to the reflection operator ([expr.reflect]), or</li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(4.3)</a></span>
 to form a pointer to member ([expr.unary.op]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(4.4)</a></span>
 if that id-expression denotes a non-static data member and it appears in
 an unevaluated operand.</li>
 </ul>
@@ -4917,54 +4907,82 @@ follows:</p>
 <span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
 <span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
 <span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
-<span id="cb109-5"><a href="#cb109-5" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
-<span id="cb109-6"><a href="#cb109-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-qualifier</em> ::</span></span>
+<span id="cb109-5"><a href="#cb109-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-qualifier</em> ::</span></span>
+<span id="cb109-6"><a href="#cb109-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
 <span id="cb109-7"><a href="#cb109-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
 <span id="cb109-8"><a href="#cb109-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span>
 <span id="cb109-9"><a href="#cb109-9" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
 <span id="cb109-10"><a href="#cb109-10" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-qualifier</em>:</span></span>
-<span id="cb109-11"><a href="#cb109-11" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>constant-expression</em> :]</span></span></code></pre></div>
+<span id="cb109-11"><a href="#cb109-11" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Add a restriction to <span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
-for the constraint on
-<code class="sourceCode cpp"><em>constant-expression</em></code>.</p>
+<p>Add a new paragraph restricting
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>,
+and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">0</a></span>
-For a
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>,
-the <code class="sourceCode cpp"><em>constant-expression</em></code>
-shall be a converted constant expression of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-that is a reflection of either a namespace or a namespace alias.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">1</a></span>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
+shall designate a namespace or namespace alias.</p>
 </div>
 </blockquote>
 </div>
-<p>Extend <span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>/3
-to also cover splices:</p>
+<p>Clarify that a splice cannot appear in a declarative
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">3</a></span>
+A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
+<em>declarative</em> if it is part of</p>
+<ul>
+<li>a <code class="sourceCode cpp"><em>class-head-name</em></code>,</li>
+<li>an <code class="sourceCode cpp"><em>enum-head-name</em></code>,</li>
+<li>a <code class="sourceCode cpp"><em>qualified-id</em></code> that is
+the <code class="sourceCode cpp"><em>id-expression</em></code> of a
+<code class="sourceCode cpp"><em>declarator-id</em></code>, or</li>
+<li>a declarative
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>.</li>
+</ul>
+<p>A declarative
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> shall
+not have a
+<code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or a
+<code class="sourceCode cpp"><em>splice-specifier</em></code></span>. A
+declaration that uses a declarative
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> shall
+be a friend declaration or inhabit a scope that contains the entity
+being redeclared or specialized.</p>
+</blockquote>
+</div>
+<p>Extend paragraph 3 to also cover splices, and prefer the verb
+“designate” over “nominate”:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">3</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
-<code class="sourceCode cpp">​<span class="op">::</span></code>​ nominates
-the global namespace. A
+<code class="sourceCode cpp">​<span class="op">::</span></code>​ <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
 a <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
-nominates the type denoted by the
+<span class="rm" style="color: #bf0303"><del>nominates</del></span>
+<span class="addu">designates</span> the type denoted by the
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>,
 which shall be a class or enumeration type. <span class="addu">A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
 a
 <code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
-nominates the entity reflected by the
-<code class="sourceCode cpp"><em>constant-expression</em></code> of the
+<span class="rm" style="color: #bf0303"><del>nominates</del></span>
+<span class="addu">designates</span> the same namespace or namespace
+alias as the
 <code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>.</span>
-If a nested-name-specifier N is declarative and has a simple-template-id
-with a template argument list A that involves a template parameter, let
-T be the template nominated by N without A. T shall be a class
-template.</p>
+If a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
+<em>N</em> is declarative and has a
+<code class="sourceCode cpp"><em>simple-template-id</em></code> with a
+template argument list <em>A</em> that involves a template parameter,
+let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nominated</del></span> <span class="addu">designated</span> by <em>N</em> without <em>A</em>.
+<em>T</em> shall be a class template.</p>
 <p>…</p>
 </blockquote>
 </div>
@@ -5059,15 +5077,18 @@ For the first option, if the <span class="addu">dot is followed by
 an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code>
-naming</span> a static member or an enumerator, the first expression is
-a discarded-value expression ([expr.context]); if the
+designating</span> a static member or an enumerator, the first
+expression is a discarded-value expression ([expr.context]); if the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-expression</em></code></span>
-names a non-static data member, the first expression shall be a glvalue.
-For the second option (arrow), the first expression shall be a prvalue
-having pointer type. The expression E1-&gt;E2 is converted to the
-equivalent form (*(E1)).E2; the remainder of [expr.ref] will address
-only the first option (dot).</p>
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+designates</span> <span class="rm" style="color: #bf0303"><del>names</del></span> a non-static data member,
+the first expression shall be a glvalue. For the second option (arrow),
+the first expression shall be a prvalue having pointer type. The
+expression
+<code class="sourceCode cpp">E1<span class="op">-&gt;</span>E2</code> is
+converted to the equivalent form <code class="sourceCode cpp"><span class="op">(*(</span>E1<span class="op">)).</span>E2</code>;
+the remainder of [expr.ref] will address only the first option
+(dot).</p>
 </blockquote>
 </div>
 <p>Modify paragraph 3 to account for splices in member access
@@ -5075,7 +5096,7 @@ expressions:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">3</a></span>
-The postfix expression before the dot is evaluated the result of that
+The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>,
@@ -5142,9 +5163,8 @@ template argument parsing section.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
-type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.
-The result is called a <em>reflection</em> and it represents its
-operand.</p>
+type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
+(<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">2</a></span>
 A <em>reflect-expression</em> is parsed as the longest possible sequence
 of tokens that could syntactically form a
@@ -5344,27 +5364,32 @@ constant-evaluated</em> <span>7.7 <a href="https://wg21.link/expr.const">[expr.c
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
-or</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(21.2)</a></span>
-the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(21.3)</a></span>
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(21.2)</a></span>
+the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(21.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
-variable, or</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(21.4)</a></span>
-an immediate invocation, unless it</p>
+variable, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(21.4)</a></span>
+an immediate invocation, unless it
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(21.4.1)</a></span>
-results from the substitution of template parameters in a
-<code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), a
+results from the substitution of template parameters
+<ul>
+<li>during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
+<li>in a <code class="sourceCode cpp"><em>concept-id</em></code>
+(<span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
+<li>in a
 <code class="sourceCode cpp"><em>requires-expression</em></code>
-(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>), or
-during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>), or</li>
+(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>),
+or</li>
+</ul></li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(21.4.2)</a></span>
 is a manifestly constant-evaluated initializer of a variable that is
 neither
@@ -5417,16 +5442,7 @@ follows:</p>
 <div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
 <span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
 <span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
-<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span>
-<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-enum-name</em>:</span></span>
-<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a><span class="va">+    [: <em>constant-expression</em> :]</span></span>
-<span id="cb116-9"><a href="#cb116-9" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb116-10"><a href="#cb116-10" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
-<span id="cb116-11"><a href="#cb116-11" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
-<span id="cb116-12"><a href="#cb116-12" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
-<span id="cb116-13"><a href="#cb116-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-enum-name</em></span></span></code></pre></div>
+<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5439,30 +5455,25 @@ follows:</p>
 <div class="addu">
 <div>
 <div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
-<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename [: <em>constant-expression</em> :]</span></span>
-<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a><span class="va">+      [: <em>constant-expression</em> :]</span></span></code></pre></div>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">1</a></span>
-The <code class="sourceCode cpp"><em>constant-expression</em></code>
-shall be a converted constant expression (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>) of type
-<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.</p>
+The <code class="sourceCode cpp"><span class="kw">typename</span></code>
+may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">2</a></span>
-The form <code class="sourceCode cpp"><span class="op">[:</span> <em>constant-expression</em> <span class="op">:]</span></code>
-shall only be parsed as a
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
-within a <em>type-only context</em> (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+designate a type.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">3</a></span>
-The <code class="sourceCode cpp"><em>constant-expression</em></code>
-shall evaluate to a reflection of a type, and the type designated by the
+The type designated by the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
-the same as the type reflected by the
-<code class="sourceCode cpp"><em>constant-expression</em></code>.</p>
+the type designated by the
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 Initializers (General)<a href="#dcl.init.general-initializers-general" class="self-link"></a></h3>
-<p>Change paragraphs 6-9 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<p>Change paragraphs 6-7 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 <span class="ednote" style="color: #0000ff">[ Editor&#39;s note: No changes
 are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
@@ -5474,11 +5485,12 @@ To <em>zero-initialize</em> an object or reference of type
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
-the object is initialied to a null reflection value;</span></li>
+the object is initialized to a null reflection value;</span></li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(6.1)</a></span>
-if <code class="sourceCode cpp">T</code> is a scalar type
-([basic.types.general]), the object is initialized to the value obtained
-by converting the integer literal
+if <code class="sourceCode cpp">T</code> is any scalar type
+([basic.types.general]) <span class="addu">other than <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code></span>,
+the object is initialized to the value obtained by converting the
+integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(6.2)</a></span>
@@ -5499,18 +5511,6 @@ the object is zero-initialized.</span></li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">8</a></span>
-A class type <code class="sourceCode cpp">T</code> is
-<em>const-default-constructible</em> if <span class="addu"><code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
-default-initialization of <code class="sourceCode cpp">T</code> would
-invoke a user-provided constructor of T (not inherited from a base
-class)<span class="addu">,</span> or if</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(8.1)</a></span>
-[…]</li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">9</a></span>
-To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.fct-functions"><span>9.3.4.6 <a href="https://wg21.link/dcl.fct">[dcl.fct]</a></span> Functions<a href="#dcl.fct-functions" class="self-link"></a></h3>
@@ -5518,22 +5518,22 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">9</a></span>
 A function type with a <em>cv-qualifier-seq</em> or a
 <em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(9.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(9.5)</a></span>
 the <em>type-id</em> of a <em>template-argument</em> for a
 <em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(9.6)</a></span>
 the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
@@ -5545,7 +5545,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator</span>, is ill-formed.</p>
@@ -5562,13 +5562,10 @@ follows:</p>
 <div class="sourceCode" id="cb118"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
 <span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
 <span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-enum-name</em>:</span></span>
-<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a><span class="va">+    [: <em>constant-expression</em> :]</span></span>
-<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
-<span id="cb118-8"><a href="#cb118-8" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
-<span id="cb118-9"><a href="#cb118-9" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
-<span id="cb118-10"><a href="#cb118-10" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-enum-name</em></span></span></code></pre></div>
+<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
+<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
+<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
+<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5576,69 +5573,130 @@ follows:</p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">1</a></span>
 A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
 <span class="addu">not consisting of a
-<code class="sourceCode cpp"><em>splice-enum-name</em></code></span>
+<code class="sourceCode cpp"><em>splice-specifier</em></code></span>
 names the set of declarations found by lookup (<span>6.5.3 <a href="https://wg21.link/basic.lookup.unqual">[basic.lookup.unqual]</a></span>,
 <span>6.5.5 <a href="https://wg21.link/basic.lookup.qual">[basic.lookup.qual]</a></span>)
 for the
-<code class="sourceCode cpp"><em>using-enum-declarator</em></code>.
-<span class="addu">A
-<code class="sourceCode cpp"><em>using-enum-declarator</em></code>
-containing a
-<code class="sourceCode cpp"><em>splice-enum-name</em></code> names the
-entity reflected by the
-<code class="sourceCode cpp"><em>constant-expression</em></code>.</span>
-The <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
-shall designate a non-dependent type with a reachable
+<code class="sourceCode cpp"><em>using-enum-declarator</em></code>. The
+<code class="sourceCode cpp"><em>using-enum-declarator</em></code> shall
+designate a non-dependent type with a reachable
 <code class="sourceCode cpp"><em>enum-specifier</em></code>.</p>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="namespace.alias-namespace-alias"><span>9.8.3
+<a href="https://wg21.link/namespace.alias">[namespace.alias]</a></span>
+Namespace alias<a href="#namespace.alias-namespace-alias" class="self-link"></a></h3>
+<p>Add a production to the grammar for
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+as follows:</p>
+<div class="std">
+<blockquote>
+<div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias</em>:</span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>      <em>identifier</em></span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
+<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
+<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a>  <em>qualified-namespace-specifier</em>:</span>
+<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+</div>
+</blockquote>
+</div>
+<p>Add the following prior to paragraph 1, and renumber accordingly:</p>
+<div class="std">
+<blockquote>
+<div class="addu">
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">1</a></span>
+If a
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+consists of a
+<code class="sourceCode cpp"><em>splice-specifier</em></code>, the
+<code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+designate a namespace or namespace alias; the
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+designates the same namespace or namespace alias designated by the
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.
+Otherwise, the
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link/basic.lookup.unqual">[basic.lookup.unqual]</a></span>,
+<span>6.5.5 <a href="https://wg21.link/basic.lookup.qual">[basic.lookup.qual]</a></span>).</p>
+</div>
+</blockquote>
+</div>
+<p>Prefer the verb “designate” for
+<code class="sourceCode cpp"><em>qualified-namespace-specifiers</em></code>
+in the paragraph that immediately follows:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">2</a></span>
+The <code class="sourceCode cpp"><em>identifier</em></code> in a
+<code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
+becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
+and denotes the namespace <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> by the
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
 Using namespace directive<a href="#namespace.udir-using-namespace-directive" class="self-link"></a></h3>
-<p>Modify the grammar for
-<code class="sourceCode cpp"><em>using-directive</em></code> as
-follows:</p>
+<p>Use
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+in the grammar for
+<code class="sourceCode cpp"><em>using-directive</em></code>:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-name</em>:</span></span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a><span class="va">+    [: <em>constant-expression</em> :]</span></span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>namespace-declarator</em>:</span></span>
-<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
-<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-namespace-name</em></span></span>
-<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
-<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
-<span id="cb119-10"><a href="#cb119-10" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>namespace-declarator</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>qualified-namespace-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Add the following to paragraph 1 of <span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>,
-prior to the note:</p>
+<p>Add the following prior to the first paragraph of <span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>, and
+renumber accordingly:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">1</a></span>
+<div class="addu">
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">1</a></span>
+The
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+shall neither contain a dependent
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> nor a
+dependent
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
+</div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">2</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
-scope. <span class="addu">A
-<code class="sourceCode cpp"><em>namespace-declarator</em></code> not
-consisting of a
-<code class="sourceCode cpp"><em>splice-namespace-name</em></code>
-nominates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link/basic.lookup.unqual">[basic.lookup.unqual]</a></span>,
-<span>6.5.5 <a href="https://wg21.link/basic.lookup.qual">[basic.lookup.qual]</a></span>)
-and shall not contain a dependent
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code>. A
-<code class="sourceCode cpp"><em>namespace-declarator</em></code>
-consisting of a
-<code class="sourceCode cpp"><em>splice-namespace-name</em></code> shall
-contain a non-dependent
-<code class="sourceCode cpp"><em>constant-expression</em></code> that
-reflects a namespace or namespace alias, and nominates the entity
-reflected by the
-<code class="sourceCode cpp"><em>constant-expression</em></code>.</span></p>
+scope.</p>
+<p>[…]</p>
+</blockquote>
+</div>
+<p>Prefer the verb “designate” rather than “nominate” in the notes that
+follow:</p>
+<div class="std">
+<blockquote>
+<p>[<em>Note 2</em>: A
+<code class="sourceCode cpp"><em>using-directive</em></code> makes the
+names in the <span class="rm" style="color: #bf0303"><del>nominated</del></span> <span class="addu">designated</span> namespace usable in the scope […]. During
+unqualified name lookup, the names appear as if they were declared in
+the nearest enclosing namespace which contains both the
+<code class="sourceCode cpp"><em>using-directive</em></code> and the
+<span class="rm" style="color: #bf0303"><del>nomindated</del></span>
+<span class="addu">designated</span> namespace. — <em>end note</em>]</p>
+<p>[…]</p>
+<p>[<em>Note 4</em>: A
+<code class="sourceCode cpp"><em>using-directive</em></code> is
+transitive: if a scope contains a
+<code class="sourceCode cpp"><em>using-directive</em></code> that <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> a namespace that itself contains
+<code class="sourceCode cpp"><em>using-directives</em></code>, the
+namespaces <span class="rm" style="color: #bf0303"><del>nominated</del></span> <span class="addu">designated</span> by those
+<code class="sourceCode cpp"><em>using-directives</em></code> are also
+eligible to be considered. — <em>end note</em>]</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
@@ -5649,10 +5707,10 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
-<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
-<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
-<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
+<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5660,13 +5718,13 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
-<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
-<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
-<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
+<div class="sourceCode" id="cb122"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
+<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
+<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
+<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5702,8 +5760,8 @@ For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 there exist candidate operator functions of the form</p>
-<div class="sourceCode" id="cb122"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
-<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb123"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
+<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.param-template-parameters"><span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span> Template
@@ -5727,22 +5785,22 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb123"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-name</em>:</span></span>
-<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a><span class="va">+     template [: constant-expression :]</span></span>
-<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
-<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: constant-expression :]</span></span>
-<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
-<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a>      identifier</span>
-<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-name</em></span></span>
-<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
-<span id="cb123-12"><a href="#cb123-12" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
-<span id="cb123-13"><a href="#cb123-13" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
-<span id="cb123-14"><a href="#cb123-14" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
-<span id="cb123-15"><a href="#cb123-15" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
-<span id="cb123-16"><a href="#cb123-16" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb124"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-name</em>:</span></span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a><span class="va">+     template [: constant-expression :]</span></span>
+<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
+<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: constant-expression :]</span></span>
+<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb124-7"><a href="#cb124-7" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
+<span id="cb124-8"><a href="#cb124-8" aria-hidden="true" tabindex="-1"></a>      identifier</span>
+<span id="cb124-9"><a href="#cb124-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-name</em></span></span>
+<span id="cb124-10"><a href="#cb124-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb124-11"><a href="#cb124-11" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
+<span id="cb124-12"><a href="#cb124-12" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
+<span id="cb124-13"><a href="#cb124-13" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
+<span id="cb124-14"><a href="#cb124-14" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
+<span id="cb124-15"><a href="#cb124-15" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
+<span id="cb124-16"><a href="#cb124-16" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5903,9 +5961,9 @@ splicing reflections of concepts:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb124"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
-<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
-<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-name</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-name</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5929,19 +5987,19 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
-<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
-<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
-<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
-<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
-<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
-<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
-<span id="cb125-11"><a href="#cb125-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
-<span id="cb125-12"><a href="#cb125-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
-<span id="cb125-13"><a href="#cb125-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
+<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
+<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
+<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
+<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
+<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
+<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
+<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
+<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
+<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
+<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
+<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5977,12 +6035,12 @@ An <em>id-expression</em> is value-dependent if:</p>
 <p>Expressions of the following form are value-dependent if the
 <em>unary-expression</em> or <em>expression</em> is type-dependent or
 the <em>type-id</em> is dependent:</p>
-<div class="sourceCode" id="cb126"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
-<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
-<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
-<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
+<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
+<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
+<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
+<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
+<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
 <p><span class="addu">A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is value
 dependent if the operand of the reflection operator is a type-dependent
@@ -6074,20 +6132,20 @@ synopsis<a href="#meta.type.synop-header-type_traits-synopsis" class="self-link"
 synopsis</strong></p>
 <p>…</p>
 <div>
-<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
-<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
-<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
-<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_reflection_v = is_function&lt;T&gt;::value;</span>
-<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
-<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_function&lt;T&gt;::value;</span></span></code></pre></div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
+<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
+<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
+<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb128-11"><a href="#cb128-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb128-12"><a href="#cb128-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_reflection_v = is_function&lt;T&gt;::value;</span>
+<span id="cb128-13"><a href="#cb128-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
+<span id="cb128-14"><a href="#cb128-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_function&lt;T&gt;::value;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6109,8 +6167,8 @@ Comments
 </tr>
 <tr>
 <td>
-<div class="sourceCode" id="cb128"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
+<div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
 </td>
 <td style="text-align:center; vertical-align: middle">
 <code class="sourceCode cpp">T</code> is
@@ -6133,8 +6191,8 @@ Comments
 <tr>
 <td>
 <div class="addu">
-<div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
+<div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
 </div>
 </td>
 <td style="text-align:center; vertical-align: middle">
@@ -6158,321 +6216,321 @@ synopsis<a href="#meta.synop-header-meta-synopsis" class="self-link"></a></h3>
 <div class="addu">
 <p><strong>Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
 synopsis</strong></p>
-<div class="sourceCode" id="cb130"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a>#include &lt;span&gt;</span>
-<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
-<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
-<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
-<span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
-<span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>  consteval string_view name_of(info r);</span>
-<span id="cb130-10"><a href="#cb130-10" aria-hidden="true" tabindex="-1"></a>  consteval string_view qualified_name_of(info r);</span>
-<span id="cb130-11"><a href="#cb130-11" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
-<span id="cb130-12"><a href="#cb130-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-13"><a href="#cb130-13" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8name_of(info r);</span>
-<span id="cb130-14"><a href="#cb130-14" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8qualified_name_of(info r);</span>
-<span id="cb130-15"><a href="#cb130-15" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8display_string_of(info r);</span>
-<span id="cb130-16"><a href="#cb130-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-17"><a href="#cb130-17" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
-<span id="cb130-18"><a href="#cb130-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-19"><a href="#cb130-19" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
-<span id="cb130-20"><a href="#cb130-20" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
-<span id="cb130-21"><a href="#cb130-21" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
-<span id="cb130-22"><a href="#cb130-22" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
-<span id="cb130-23"><a href="#cb130-23" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
-<span id="cb130-24"><a href="#cb130-24" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
-<span id="cb130-25"><a href="#cb130-25" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
-<span id="cb130-26"><a href="#cb130-26" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
-<span id="cb130-27"><a href="#cb130-27" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
-<span id="cb130-28"><a href="#cb130-28" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
-<span id="cb130-29"><a href="#cb130-29" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
-<span id="cb130-30"><a href="#cb130-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
-<span id="cb130-31"><a href="#cb130-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
-<span id="cb130-32"><a href="#cb130-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
-<span id="cb130-33"><a href="#cb130-33" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
-<span id="cb130-34"><a href="#cb130-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
-<span id="cb130-35"><a href="#cb130-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
-<span id="cb130-36"><a href="#cb130-36" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
-<span id="cb130-37"><a href="#cb130-37" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
-<span id="cb130-38"><a href="#cb130-38" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
-<span id="cb130-39"><a href="#cb130-39" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
-<span id="cb130-40"><a href="#cb130-40" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
-<span id="cb130-41"><a href="#cb130-41" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-42"><a href="#cb130-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
-<span id="cb130-43"><a href="#cb130-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
-<span id="cb130-44"><a href="#cb130-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
-<span id="cb130-45"><a href="#cb130-45" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
-<span id="cb130-46"><a href="#cb130-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias(info r);</span>
-<span id="cb130-47"><a href="#cb130-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_incomplete_type(info r);</span>
-<span id="cb130-48"><a href="#cb130-48" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
-<span id="cb130-49"><a href="#cb130-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
-<span id="cb130-50"><a href="#cb130-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
-<span id="cb130-51"><a href="#cb130-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
-<span id="cb130-52"><a href="#cb130-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
-<span id="cb130-53"><a href="#cb130-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
-<span id="cb130-54"><a href="#cb130-54" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
-<span id="cb130-55"><a href="#cb130-55" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
-<span id="cb130-56"><a href="#cb130-56" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
-<span id="cb130-57"><a href="#cb130-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
-<span id="cb130-58"><a href="#cb130-58" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info entity);</span>
-<span id="cb130-59"><a href="#cb130-59" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info entity);</span>
-<span id="cb130-60"><a href="#cb130-60" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
-<span id="cb130-61"><a href="#cb130-61" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
-<span id="cb130-62"><a href="#cb130-62" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
-<span id="cb130-63"><a href="#cb130-63" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
-<span id="cb130-64"><a href="#cb130-64" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-65"><a href="#cb130-65" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member(info r);</span>
-<span id="cb130-66"><a href="#cb130-66" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
-<span id="cb130-67"><a href="#cb130-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
-<span id="cb130-68"><a href="#cb130-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
-<span id="cb130-69"><a href="#cb130-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
-<span id="cb130-70"><a href="#cb130-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
-<span id="cb130-71"><a href="#cb130-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
-<span id="cb130-72"><a href="#cb130-72" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
-<span id="cb130-73"><a href="#cb130-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
-<span id="cb130-74"><a href="#cb130-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
-<span id="cb130-75"><a href="#cb130-75" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-76"><a href="#cb130-76" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
-<span id="cb130-77"><a href="#cb130-77" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
-<span id="cb130-78"><a href="#cb130-78" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
-<span id="cb130-79"><a href="#cb130-79" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
-<span id="cb130-80"><a href="#cb130-80" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
-<span id="cb130-81"><a href="#cb130-81" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
-<span id="cb130-82"><a href="#cb130-82" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
-<span id="cb130-83"><a href="#cb130-83" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-84"><a href="#cb130-84" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
-<span id="cb130-85"><a href="#cb130-85" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info type);</span>
-<span id="cb130-86"><a href="#cb130-86" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
-<span id="cb130-87"><a href="#cb130-87" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
-<span id="cb130-88"><a href="#cb130-88" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
-<span id="cb130-89"><a href="#cb130-89" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; subobjects_of(info type);</span>
-<span id="cb130-90"><a href="#cb130-90" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
-<span id="cb130-91"><a href="#cb130-91" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-92"><a href="#cb130-92" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.access], reflection member access queries</span>
-<span id="cb130-93"><a href="#cb130-93" aria-hidden="true" tabindex="-1"></a>  class access_context {</span>
-<span id="cb130-94"><a href="#cb130-94" aria-hidden="true" tabindex="-1"></a>    info <em>context_</em>; // exposition-only</span>
-<span id="cb130-95"><a href="#cb130-95" aria-hidden="true" tabindex="-1"></a>  public:</span>
-<span id="cb130-96"><a href="#cb130-96" aria-hidden="true" tabindex="-1"></a>    consteval access_context();</span>
-<span id="cb130-97"><a href="#cb130-97" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb130-98"><a href="#cb130-98" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-99"><a href="#cb130-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_accessible(info r, access_context from = {});</span>
-<span id="cb130-100"><a href="#cb130-100" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-101"><a href="#cb130-101" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_members_of(info target, access_context from = {});</span>
-<span id="cb130-102"><a href="#cb130-102" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_bases_of(info target, access_context from = {});</span>
-<span id="cb130-103"><a href="#cb130-103" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_nonstatic_data_members_of(info target,</span>
-<span id="cb130-104"><a href="#cb130-104" aria-hidden="true" tabindex="-1"></a>                                                              access_context from = {});</span>
-<span id="cb130-105"><a href="#cb130-105" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_static_data_members_of(info target,</span>
-<span id="cb130-106"><a href="#cb130-106" aria-hidden="true" tabindex="-1"></a>                                                           access_context from = {});</span>
-<span id="cb130-107"><a href="#cb130-107" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_subobjects_of(info target, access_context from = {});</span>
-<span id="cb130-108"><a href="#cb130-108" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-109"><a href="#cb130-109" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
-<span id="cb130-110"><a href="#cb130-110" aria-hidden="true" tabindex="-1"></a>  consteval size_t offset_of(info entity);</span>
-<span id="cb130-111"><a href="#cb130-111" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info entity);</span>
-<span id="cb130-112"><a href="#cb130-112" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info entity);</span>
-<span id="cb130-113"><a href="#cb130-113" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_offset_of(info entity);</span>
-<span id="cb130-114"><a href="#cb130-114" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info entity);</span>
-<span id="cb130-115"><a href="#cb130-115" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-116"><a href="#cb130-116" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
-<span id="cb130-117"><a href="#cb130-117" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb130-118"><a href="#cb130-118" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
-<span id="cb130-119"><a href="#cb130-119" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-120"><a href="#cb130-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
-<span id="cb130-121"><a href="#cb130-121" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-122"><a href="#cb130-122" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb130-123"><a href="#cb130-123" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-124"><a href="#cb130-124" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb130-125"><a href="#cb130-125" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-126"><a href="#cb130-126" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
-<span id="cb130-127"><a href="#cb130-127" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
-<span id="cb130-128"><a href="#cb130-128" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
-<span id="cb130-129"><a href="#cb130-129" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-130"><a href="#cb130-130" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb130-131"><a href="#cb130-131" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
-<span id="cb130-132"><a href="#cb130-132" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb130-133"><a href="#cb130-133" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
-<span id="cb130-134"><a href="#cb130-134" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb130-135"><a href="#cb130-135" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
-<span id="cb130-136"><a href="#cb130-136" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-137"><a href="#cb130-137" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-138"><a href="#cb130-138" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R&amp;&amp; args);</span>
-<span id="cb130-139"><a href="#cb130-139" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R1 = initializer_list&lt;info&gt;, reflection_range R2 = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-140"><a href="#cb130-140" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R1&amp;&amp; tmpl_args, R2&amp;&amp; args);</span>
-<span id="cb130-141"><a href="#cb130-141" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-142"><a href="#cb130-142" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define_class], class definition generation</span>
-<span id="cb130-143"><a href="#cb130-143" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
-<span id="cb130-144"><a href="#cb130-144" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
-<span id="cb130-145"><a href="#cb130-145" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;u8string, T&gt;</span>
-<span id="cb130-146"><a href="#cb130-146" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb130-147"><a href="#cb130-147" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-148"><a href="#cb130-148" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;string, T&gt;</span>
-<span id="cb130-149"><a href="#cb130-149" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb130-150"><a href="#cb130-150" aria-hidden="true" tabindex="-1"></a>    };</span>
-<span id="cb130-151"><a href="#cb130-151" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-152"><a href="#cb130-152" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
-<span id="cb130-153"><a href="#cb130-153" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
-<span id="cb130-154"><a href="#cb130-154" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; width;</span>
-<span id="cb130-155"><a href="#cb130-155" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
-<span id="cb130-156"><a href="#cb130-156" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb130-157"><a href="#cb130-157" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
-<span id="cb130-158"><a href="#cb130-158" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
-<span id="cb130-159"><a href="#cb130-159" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-160"><a href="#cb130-160" aria-hidden="true" tabindex="-1"></a>  consteval info define_class(info type_class, R&amp;&amp;);</span>
-<span id="cb130-161"><a href="#cb130-161" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-162"><a href="#cb130-162" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
-<span id="cb130-163"><a href="#cb130-163" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type);</span>
-<span id="cb130-164"><a href="#cb130-164" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_null_pointer(info type);</span>
-<span id="cb130-165"><a href="#cb130-165" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_integral(info type);</span>
-<span id="cb130-166"><a href="#cb130-166" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_floating_point(info type);</span>
-<span id="cb130-167"><a href="#cb130-167" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_array(info type);</span>
-<span id="cb130-168"><a href="#cb130-168" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer(info type);</span>
-<span id="cb130-169"><a href="#cb130-169" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_lvalue_reference(info type);</span>
-<span id="cb130-170"><a href="#cb130-170" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_rvalue_reference(info type);</span>
-<span id="cb130-171"><a href="#cb130-171" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_object_pointer(info type);</span>
-<span id="cb130-172"><a href="#cb130-172" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_function_pointer(info type);</span>
-<span id="cb130-173"><a href="#cb130-173" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_enum(info type);</span>
-<span id="cb130-174"><a href="#cb130-174" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_union(info type);</span>
-<span id="cb130-175"><a href="#cb130-175" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_class(info type);</span>
-<span id="cb130-176"><a href="#cb130-176" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_function(info type);</span>
-<span id="cb130-177"><a href="#cb130-177" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reflection(info type);</span>
-<span id="cb130-178"><a href="#cb130-178" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-179"><a href="#cb130-179" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
-<span id="cb130-180"><a href="#cb130-180" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reference(info type);</span>
-<span id="cb130-181"><a href="#cb130-181" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_arithmetic(info type);</span>
-<span id="cb130-182"><a href="#cb130-182" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_fundamental(info type);</span>
-<span id="cb130-183"><a href="#cb130-183" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_object(info type);</span>
-<span id="cb130-184"><a href="#cb130-184" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scalar(info type);</span>
-<span id="cb130-185"><a href="#cb130-185" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_compound(info type);</span>
-<span id="cb130-186"><a href="#cb130-186" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_pointer(info type);</span>
-<span id="cb130-187"><a href="#cb130-187" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-188"><a href="#cb130-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
-<span id="cb130-189"><a href="#cb130-189" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_const(info type);</span>
-<span id="cb130-190"><a href="#cb130-190" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_volatile(info type);</span>
-<span id="cb130-191"><a href="#cb130-191" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivial(info type);</span>
-<span id="cb130-192"><a href="#cb130-192" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copyable(info type);</span>
-<span id="cb130-193"><a href="#cb130-193" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_standard_layout(info type);</span>
-<span id="cb130-194"><a href="#cb130-194" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_empty(info type);</span>
-<span id="cb130-195"><a href="#cb130-195" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_polymorphic(info type);</span>
-<span id="cb130-196"><a href="#cb130-196" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_abstract(info type);</span>
-<span id="cb130-197"><a href="#cb130-197" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_final(info type);</span>
-<span id="cb130-198"><a href="#cb130-198" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_aggregate(info type);</span>
-<span id="cb130-199"><a href="#cb130-199" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_signed(info type);</span>
-<span id="cb130-200"><a href="#cb130-200" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unsigned(info type);</span>
-<span id="cb130-201"><a href="#cb130-201" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_bounded_array(info type);</span>
-<span id="cb130-202"><a href="#cb130-202" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unbounded_array(info type);</span>
-<span id="cb130-203"><a href="#cb130-203" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scoped_enum(info type);</span>
-<span id="cb130-204"><a href="#cb130-204" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-205"><a href="#cb130-205" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-206"><a href="#cb130-206" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb130-207"><a href="#cb130-207" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_default_constructible(info type);</span>
-<span id="cb130-208"><a href="#cb130-208" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_constructible(info type);</span>
-<span id="cb130-209"><a href="#cb130-209" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_constructible(info type);</span>
-<span id="cb130-210"><a href="#cb130-210" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-211"><a href="#cb130-211" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_assignable(info type_dst, info type_src);</span>
-<span id="cb130-212"><a href="#cb130-212" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_assignable(info type);</span>
-<span id="cb130-213"><a href="#cb130-213" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_assignable(info type);</span>
-<span id="cb130-214"><a href="#cb130-214" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-215"><a href="#cb130-215" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable_with(info type_dst, info type_src);</span>
-<span id="cb130-216"><a href="#cb130-216" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable(info type);</span>
-<span id="cb130-217"><a href="#cb130-217" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-218"><a href="#cb130-218" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_destructible(info type);</span>
-<span id="cb130-219"><a href="#cb130-219" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-220"><a href="#cb130-220" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-221"><a href="#cb130-221" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_trivially_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb130-222"><a href="#cb130-222" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_default_constructible(info type);</span>
-<span id="cb130-223"><a href="#cb130-223" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_constructible(info type);</span>
-<span id="cb130-224"><a href="#cb130-224" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_constructible(info type);</span>
-<span id="cb130-225"><a href="#cb130-225" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-226"><a href="#cb130-226" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_assignable(info type_dst, info type_src);</span>
-<span id="cb130-227"><a href="#cb130-227" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_assignable(info type);</span>
-<span id="cb130-228"><a href="#cb130-228" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_assignable(info type);</span>
-<span id="cb130-229"><a href="#cb130-229" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_destructible(info type);</span>
-<span id="cb130-230"><a href="#cb130-230" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-231"><a href="#cb130-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-232"><a href="#cb130-232" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb130-233"><a href="#cb130-233" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_default_constructible(info type);</span>
-<span id="cb130-234"><a href="#cb130-234" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_constructible(info type);</span>
-<span id="cb130-235"><a href="#cb130-235" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_constructible(info type);</span>
-<span id="cb130-236"><a href="#cb130-236" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-237"><a href="#cb130-237" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_assignable(info type_dst, info type_src);</span>
-<span id="cb130-238"><a href="#cb130-238" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_assignable(info type);</span>
-<span id="cb130-239"><a href="#cb130-239" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_assignable(info type);</span>
-<span id="cb130-240"><a href="#cb130-240" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-241"><a href="#cb130-241" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable_with(info type_dst, info type_src);</span>
-<span id="cb130-242"><a href="#cb130-242" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable(info type);</span>
-<span id="cb130-243"><a href="#cb130-243" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-244"><a href="#cb130-244" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_destructible(info type);</span>
-<span id="cb130-245"><a href="#cb130-245" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-246"><a href="#cb130-246" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_implicit_lifetime(info type);</span>
-<span id="cb130-247"><a href="#cb130-247" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-248"><a href="#cb130-248" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_virtual_destructor(info type);</span>
-<span id="cb130-249"><a href="#cb130-249" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-250"><a href="#cb130-250" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_unique_object_representations(info type);</span>
-<span id="cb130-251"><a href="#cb130-251" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-252"><a href="#cb130-252" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_constructs_from_temporary(info type_dst, info type_src);</span>
-<span id="cb130-253"><a href="#cb130-253" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_converts_from_temporary(info type_dst, info type_src);</span>
-<span id="cb130-254"><a href="#cb130-254" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-255"><a href="#cb130-255" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
-<span id="cb130-256"><a href="#cb130-256" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_alignment_of(info type);</span>
-<span id="cb130-257"><a href="#cb130-257" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_rank(info type);</span>
-<span id="cb130-258"><a href="#cb130-258" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_extent(info type, unsigned i = 0);</span>
-<span id="cb130-259"><a href="#cb130-259" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-260"><a href="#cb130-260" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
-<span id="cb130-261"><a href="#cb130-261" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_same(info type1, info type2);</span>
-<span id="cb130-262"><a href="#cb130-262" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_base_of(info type_base, info type_derived);</span>
-<span id="cb130-263"><a href="#cb130-263" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_convertible(info type_src, info type_dst);</span>
-<span id="cb130-264"><a href="#cb130-264" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_convertible(info type_src, info type_dst);</span>
-<span id="cb130-265"><a href="#cb130-265" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_layout_compatible(info type1, info type2);</span>
-<span id="cb130-266"><a href="#cb130-266" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer_interconvertible_base_of(info type_base, info type_derived);</span>
-<span id="cb130-267"><a href="#cb130-267" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-268"><a href="#cb130-268" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-269"><a href="#cb130-269" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable(info type, R&amp;&amp; type_args);</span>
-<span id="cb130-270"><a href="#cb130-270" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-271"><a href="#cb130-271" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb130-272"><a href="#cb130-272" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-273"><a href="#cb130-273" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-274"><a href="#cb130-274" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable(info type, R&amp;&amp; type_args);</span>
-<span id="cb130-275"><a href="#cb130-275" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-276"><a href="#cb130-276" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb130-277"><a href="#cb130-277" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-278"><a href="#cb130-278" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
-<span id="cb130-279"><a href="#cb130-279" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_const(info type);</span>
-<span id="cb130-280"><a href="#cb130-280" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_volatile(info type);</span>
-<span id="cb130-281"><a href="#cb130-281" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cv(info type);</span>
-<span id="cb130-282"><a href="#cb130-282" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_const(info type);</span>
-<span id="cb130-283"><a href="#cb130-283" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_volatile(info type);</span>
-<span id="cb130-284"><a href="#cb130-284" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_cv(info type);</span>
-<span id="cb130-285"><a href="#cb130-285" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-286"><a href="#cb130-286" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
-<span id="cb130-287"><a href="#cb130-287" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_reference(info type);</span>
-<span id="cb130-288"><a href="#cb130-288" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_lvalue_reference(info type);</span>
-<span id="cb130-289"><a href="#cb130-289" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_rvalue_reference(info type);</span>
-<span id="cb130-290"><a href="#cb130-290" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-291"><a href="#cb130-291" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
-<span id="cb130-292"><a href="#cb130-292" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_signed(info type);</span>
-<span id="cb130-293"><a href="#cb130-293" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_unsigned(info type);</span>
-<span id="cb130-294"><a href="#cb130-294" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-295"><a href="#cb130-295" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
-<span id="cb130-296"><a href="#cb130-296" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_extent(info type);</span>
-<span id="cb130-297"><a href="#cb130-297" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_all_extents(info type);</span>
-<span id="cb130-298"><a href="#cb130-298" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-299"><a href="#cb130-299" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
-<span id="cb130-300"><a href="#cb130-300" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_pointer(info type);</span>
-<span id="cb130-301"><a href="#cb130-301" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_pointer(info type);</span>
-<span id="cb130-302"><a href="#cb130-302" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-303"><a href="#cb130-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
-<span id="cb130-304"><a href="#cb130-304" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cvref(info type);</span>
-<span id="cb130-305"><a href="#cb130-305" aria-hidden="true" tabindex="-1"></a>  consteval info type_decay(info type);</span>
-<span id="cb130-306"><a href="#cb130-306" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-307"><a href="#cb130-307" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_type(R&amp;&amp; type_args);</span>
-<span id="cb130-308"><a href="#cb130-308" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-309"><a href="#cb130-309" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_reference(R&amp;&amp; type_args);</span>
-<span id="cb130-310"><a href="#cb130-310" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
-<span id="cb130-311"><a href="#cb130-311" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb130-312"><a href="#cb130-312" aria-hidden="true" tabindex="-1"></a>    `consteval info type_invoke_result(info type, R&amp;&amp; type_args);</span>
-<span id="cb130-313"><a href="#cb130-313" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_reference(info type);</span>
-<span id="cb130-314"><a href="#cb130-314" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_ref_decay(info type);</span>
-<span id="cb130-315"><a href="#cb130-315" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb131"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a>#include &lt;span&gt;</span>
+<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
+<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
+<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
+<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
+<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a>  consteval string_view name_of(info r);</span>
+<span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a>  consteval string_view qualified_name_of(info r);</span>
+<span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
+<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8name_of(info r);</span>
+<span id="cb131-14"><a href="#cb131-14" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8qualified_name_of(info r);</span>
+<span id="cb131-15"><a href="#cb131-15" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8display_string_of(info r);</span>
+<span id="cb131-16"><a href="#cb131-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-17"><a href="#cb131-17" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
+<span id="cb131-18"><a href="#cb131-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-19"><a href="#cb131-19" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
+<span id="cb131-20"><a href="#cb131-20" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
+<span id="cb131-21"><a href="#cb131-21" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
+<span id="cb131-22"><a href="#cb131-22" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
+<span id="cb131-23"><a href="#cb131-23" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
+<span id="cb131-24"><a href="#cb131-24" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
+<span id="cb131-25"><a href="#cb131-25" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
+<span id="cb131-26"><a href="#cb131-26" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
+<span id="cb131-27"><a href="#cb131-27" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
+<span id="cb131-28"><a href="#cb131-28" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
+<span id="cb131-29"><a href="#cb131-29" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
+<span id="cb131-30"><a href="#cb131-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
+<span id="cb131-31"><a href="#cb131-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
+<span id="cb131-32"><a href="#cb131-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
+<span id="cb131-33"><a href="#cb131-33" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
+<span id="cb131-34"><a href="#cb131-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
+<span id="cb131-35"><a href="#cb131-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
+<span id="cb131-36"><a href="#cb131-36" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
+<span id="cb131-37"><a href="#cb131-37" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
+<span id="cb131-38"><a href="#cb131-38" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
+<span id="cb131-39"><a href="#cb131-39" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
+<span id="cb131-40"><a href="#cb131-40" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
+<span id="cb131-41"><a href="#cb131-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-42"><a href="#cb131-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
+<span id="cb131-43"><a href="#cb131-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
+<span id="cb131-44"><a href="#cb131-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
+<span id="cb131-45"><a href="#cb131-45" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
+<span id="cb131-46"><a href="#cb131-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias(info r);</span>
+<span id="cb131-47"><a href="#cb131-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_incomplete_type(info r);</span>
+<span id="cb131-48"><a href="#cb131-48" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
+<span id="cb131-49"><a href="#cb131-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
+<span id="cb131-50"><a href="#cb131-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
+<span id="cb131-51"><a href="#cb131-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
+<span id="cb131-52"><a href="#cb131-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
+<span id="cb131-53"><a href="#cb131-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
+<span id="cb131-54"><a href="#cb131-54" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
+<span id="cb131-55"><a href="#cb131-55" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
+<span id="cb131-56"><a href="#cb131-56" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
+<span id="cb131-57"><a href="#cb131-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
+<span id="cb131-58"><a href="#cb131-58" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info entity);</span>
+<span id="cb131-59"><a href="#cb131-59" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info entity);</span>
+<span id="cb131-60"><a href="#cb131-60" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
+<span id="cb131-61"><a href="#cb131-61" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
+<span id="cb131-62"><a href="#cb131-62" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
+<span id="cb131-63"><a href="#cb131-63" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
+<span id="cb131-64"><a href="#cb131-64" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-65"><a href="#cb131-65" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member(info r);</span>
+<span id="cb131-66"><a href="#cb131-66" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
+<span id="cb131-67"><a href="#cb131-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
+<span id="cb131-68"><a href="#cb131-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
+<span id="cb131-69"><a href="#cb131-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
+<span id="cb131-70"><a href="#cb131-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
+<span id="cb131-71"><a href="#cb131-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
+<span id="cb131-72"><a href="#cb131-72" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
+<span id="cb131-73"><a href="#cb131-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
+<span id="cb131-74"><a href="#cb131-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
+<span id="cb131-75"><a href="#cb131-75" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-76"><a href="#cb131-76" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
+<span id="cb131-77"><a href="#cb131-77" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
+<span id="cb131-78"><a href="#cb131-78" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
+<span id="cb131-79"><a href="#cb131-79" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
+<span id="cb131-80"><a href="#cb131-80" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
+<span id="cb131-81"><a href="#cb131-81" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
+<span id="cb131-82"><a href="#cb131-82" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
+<span id="cb131-83"><a href="#cb131-83" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-84"><a href="#cb131-84" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
+<span id="cb131-85"><a href="#cb131-85" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info type);</span>
+<span id="cb131-86"><a href="#cb131-86" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
+<span id="cb131-87"><a href="#cb131-87" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
+<span id="cb131-88"><a href="#cb131-88" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
+<span id="cb131-89"><a href="#cb131-89" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; subobjects_of(info type);</span>
+<span id="cb131-90"><a href="#cb131-90" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
+<span id="cb131-91"><a href="#cb131-91" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-92"><a href="#cb131-92" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.access], reflection member access queries</span>
+<span id="cb131-93"><a href="#cb131-93" aria-hidden="true" tabindex="-1"></a>  class access_context {</span>
+<span id="cb131-94"><a href="#cb131-94" aria-hidden="true" tabindex="-1"></a>    info <em>context_</em>; // exposition-only</span>
+<span id="cb131-95"><a href="#cb131-95" aria-hidden="true" tabindex="-1"></a>  public:</span>
+<span id="cb131-96"><a href="#cb131-96" aria-hidden="true" tabindex="-1"></a>    consteval access_context();</span>
+<span id="cb131-97"><a href="#cb131-97" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb131-98"><a href="#cb131-98" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-99"><a href="#cb131-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_accessible(info r, access_context from = {});</span>
+<span id="cb131-100"><a href="#cb131-100" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-101"><a href="#cb131-101" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_members_of(info target, access_context from = {});</span>
+<span id="cb131-102"><a href="#cb131-102" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_bases_of(info target, access_context from = {});</span>
+<span id="cb131-103"><a href="#cb131-103" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_nonstatic_data_members_of(info target,</span>
+<span id="cb131-104"><a href="#cb131-104" aria-hidden="true" tabindex="-1"></a>                                                              access_context from = {});</span>
+<span id="cb131-105"><a href="#cb131-105" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_static_data_members_of(info target,</span>
+<span id="cb131-106"><a href="#cb131-106" aria-hidden="true" tabindex="-1"></a>                                                           access_context from = {});</span>
+<span id="cb131-107"><a href="#cb131-107" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_subobjects_of(info target, access_context from = {});</span>
+<span id="cb131-108"><a href="#cb131-108" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-109"><a href="#cb131-109" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
+<span id="cb131-110"><a href="#cb131-110" aria-hidden="true" tabindex="-1"></a>  consteval size_t offset_of(info entity);</span>
+<span id="cb131-111"><a href="#cb131-111" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info entity);</span>
+<span id="cb131-112"><a href="#cb131-112" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info entity);</span>
+<span id="cb131-113"><a href="#cb131-113" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_offset_of(info entity);</span>
+<span id="cb131-114"><a href="#cb131-114" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info entity);</span>
+<span id="cb131-115"><a href="#cb131-115" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-116"><a href="#cb131-116" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
+<span id="cb131-117"><a href="#cb131-117" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-118"><a href="#cb131-118" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
+<span id="cb131-119"><a href="#cb131-119" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-120"><a href="#cb131-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
+<span id="cb131-121"><a href="#cb131-121" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-122"><a href="#cb131-122" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb131-123"><a href="#cb131-123" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-124"><a href="#cb131-124" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb131-125"><a href="#cb131-125" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-126"><a href="#cb131-126" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
+<span id="cb131-127"><a href="#cb131-127" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
+<span id="cb131-128"><a href="#cb131-128" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
+<span id="cb131-129"><a href="#cb131-129" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-130"><a href="#cb131-130" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-131"><a href="#cb131-131" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
+<span id="cb131-132"><a href="#cb131-132" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-133"><a href="#cb131-133" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
+<span id="cb131-134"><a href="#cb131-134" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-135"><a href="#cb131-135" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
+<span id="cb131-136"><a href="#cb131-136" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-137"><a href="#cb131-137" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-138"><a href="#cb131-138" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R&amp;&amp; args);</span>
+<span id="cb131-139"><a href="#cb131-139" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R1 = initializer_list&lt;info&gt;, reflection_range R2 = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-140"><a href="#cb131-140" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R1&amp;&amp; tmpl_args, R2&amp;&amp; args);</span>
+<span id="cb131-141"><a href="#cb131-141" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-142"><a href="#cb131-142" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define_class], class definition generation</span>
+<span id="cb131-143"><a href="#cb131-143" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
+<span id="cb131-144"><a href="#cb131-144" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
+<span id="cb131-145"><a href="#cb131-145" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;u8string, T&gt;</span>
+<span id="cb131-146"><a href="#cb131-146" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb131-147"><a href="#cb131-147" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-148"><a href="#cb131-148" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;string, T&gt;</span>
+<span id="cb131-149"><a href="#cb131-149" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb131-150"><a href="#cb131-150" aria-hidden="true" tabindex="-1"></a>    };</span>
+<span id="cb131-151"><a href="#cb131-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-152"><a href="#cb131-152" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
+<span id="cb131-153"><a href="#cb131-153" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
+<span id="cb131-154"><a href="#cb131-154" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; width;</span>
+<span id="cb131-155"><a href="#cb131-155" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
+<span id="cb131-156"><a href="#cb131-156" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb131-157"><a href="#cb131-157" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
+<span id="cb131-158"><a href="#cb131-158" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
+<span id="cb131-159"><a href="#cb131-159" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-160"><a href="#cb131-160" aria-hidden="true" tabindex="-1"></a>  consteval info define_class(info type_class, R&amp;&amp;);</span>
+<span id="cb131-161"><a href="#cb131-161" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-162"><a href="#cb131-162" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
+<span id="cb131-163"><a href="#cb131-163" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type);</span>
+<span id="cb131-164"><a href="#cb131-164" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_null_pointer(info type);</span>
+<span id="cb131-165"><a href="#cb131-165" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_integral(info type);</span>
+<span id="cb131-166"><a href="#cb131-166" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_floating_point(info type);</span>
+<span id="cb131-167"><a href="#cb131-167" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_array(info type);</span>
+<span id="cb131-168"><a href="#cb131-168" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer(info type);</span>
+<span id="cb131-169"><a href="#cb131-169" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_lvalue_reference(info type);</span>
+<span id="cb131-170"><a href="#cb131-170" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_rvalue_reference(info type);</span>
+<span id="cb131-171"><a href="#cb131-171" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_object_pointer(info type);</span>
+<span id="cb131-172"><a href="#cb131-172" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_function_pointer(info type);</span>
+<span id="cb131-173"><a href="#cb131-173" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_enum(info type);</span>
+<span id="cb131-174"><a href="#cb131-174" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_union(info type);</span>
+<span id="cb131-175"><a href="#cb131-175" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_class(info type);</span>
+<span id="cb131-176"><a href="#cb131-176" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_function(info type);</span>
+<span id="cb131-177"><a href="#cb131-177" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reflection(info type);</span>
+<span id="cb131-178"><a href="#cb131-178" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-179"><a href="#cb131-179" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
+<span id="cb131-180"><a href="#cb131-180" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reference(info type);</span>
+<span id="cb131-181"><a href="#cb131-181" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_arithmetic(info type);</span>
+<span id="cb131-182"><a href="#cb131-182" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_fundamental(info type);</span>
+<span id="cb131-183"><a href="#cb131-183" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_object(info type);</span>
+<span id="cb131-184"><a href="#cb131-184" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scalar(info type);</span>
+<span id="cb131-185"><a href="#cb131-185" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_compound(info type);</span>
+<span id="cb131-186"><a href="#cb131-186" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_pointer(info type);</span>
+<span id="cb131-187"><a href="#cb131-187" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-188"><a href="#cb131-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
+<span id="cb131-189"><a href="#cb131-189" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_const(info type);</span>
+<span id="cb131-190"><a href="#cb131-190" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_volatile(info type);</span>
+<span id="cb131-191"><a href="#cb131-191" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivial(info type);</span>
+<span id="cb131-192"><a href="#cb131-192" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copyable(info type);</span>
+<span id="cb131-193"><a href="#cb131-193" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_standard_layout(info type);</span>
+<span id="cb131-194"><a href="#cb131-194" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_empty(info type);</span>
+<span id="cb131-195"><a href="#cb131-195" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_polymorphic(info type);</span>
+<span id="cb131-196"><a href="#cb131-196" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_abstract(info type);</span>
+<span id="cb131-197"><a href="#cb131-197" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_final(info type);</span>
+<span id="cb131-198"><a href="#cb131-198" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_aggregate(info type);</span>
+<span id="cb131-199"><a href="#cb131-199" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_signed(info type);</span>
+<span id="cb131-200"><a href="#cb131-200" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unsigned(info type);</span>
+<span id="cb131-201"><a href="#cb131-201" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_bounded_array(info type);</span>
+<span id="cb131-202"><a href="#cb131-202" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unbounded_array(info type);</span>
+<span id="cb131-203"><a href="#cb131-203" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scoped_enum(info type);</span>
+<span id="cb131-204"><a href="#cb131-204" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-205"><a href="#cb131-205" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-206"><a href="#cb131-206" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-207"><a href="#cb131-207" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_default_constructible(info type);</span>
+<span id="cb131-208"><a href="#cb131-208" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_constructible(info type);</span>
+<span id="cb131-209"><a href="#cb131-209" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_constructible(info type);</span>
+<span id="cb131-210"><a href="#cb131-210" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-211"><a href="#cb131-211" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_assignable(info type_dst, info type_src);</span>
+<span id="cb131-212"><a href="#cb131-212" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_assignable(info type);</span>
+<span id="cb131-213"><a href="#cb131-213" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_assignable(info type);</span>
+<span id="cb131-214"><a href="#cb131-214" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-215"><a href="#cb131-215" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable_with(info type_dst, info type_src);</span>
+<span id="cb131-216"><a href="#cb131-216" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable(info type);</span>
+<span id="cb131-217"><a href="#cb131-217" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-218"><a href="#cb131-218" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_destructible(info type);</span>
+<span id="cb131-219"><a href="#cb131-219" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-220"><a href="#cb131-220" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-221"><a href="#cb131-221" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_trivially_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-222"><a href="#cb131-222" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_default_constructible(info type);</span>
+<span id="cb131-223"><a href="#cb131-223" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_constructible(info type);</span>
+<span id="cb131-224"><a href="#cb131-224" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_constructible(info type);</span>
+<span id="cb131-225"><a href="#cb131-225" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-226"><a href="#cb131-226" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_assignable(info type_dst, info type_src);</span>
+<span id="cb131-227"><a href="#cb131-227" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_assignable(info type);</span>
+<span id="cb131-228"><a href="#cb131-228" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_assignable(info type);</span>
+<span id="cb131-229"><a href="#cb131-229" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_destructible(info type);</span>
+<span id="cb131-230"><a href="#cb131-230" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-231"><a href="#cb131-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-232"><a href="#cb131-232" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-233"><a href="#cb131-233" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_default_constructible(info type);</span>
+<span id="cb131-234"><a href="#cb131-234" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_constructible(info type);</span>
+<span id="cb131-235"><a href="#cb131-235" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_constructible(info type);</span>
+<span id="cb131-236"><a href="#cb131-236" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-237"><a href="#cb131-237" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_assignable(info type_dst, info type_src);</span>
+<span id="cb131-238"><a href="#cb131-238" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_assignable(info type);</span>
+<span id="cb131-239"><a href="#cb131-239" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_assignable(info type);</span>
+<span id="cb131-240"><a href="#cb131-240" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-241"><a href="#cb131-241" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable_with(info type_dst, info type_src);</span>
+<span id="cb131-242"><a href="#cb131-242" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable(info type);</span>
+<span id="cb131-243"><a href="#cb131-243" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-244"><a href="#cb131-244" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_destructible(info type);</span>
+<span id="cb131-245"><a href="#cb131-245" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-246"><a href="#cb131-246" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_implicit_lifetime(info type);</span>
+<span id="cb131-247"><a href="#cb131-247" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-248"><a href="#cb131-248" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_virtual_destructor(info type);</span>
+<span id="cb131-249"><a href="#cb131-249" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-250"><a href="#cb131-250" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_unique_object_representations(info type);</span>
+<span id="cb131-251"><a href="#cb131-251" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-252"><a href="#cb131-252" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_constructs_from_temporary(info type_dst, info type_src);</span>
+<span id="cb131-253"><a href="#cb131-253" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_converts_from_temporary(info type_dst, info type_src);</span>
+<span id="cb131-254"><a href="#cb131-254" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-255"><a href="#cb131-255" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
+<span id="cb131-256"><a href="#cb131-256" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_alignment_of(info type);</span>
+<span id="cb131-257"><a href="#cb131-257" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_rank(info type);</span>
+<span id="cb131-258"><a href="#cb131-258" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_extent(info type, unsigned i = 0);</span>
+<span id="cb131-259"><a href="#cb131-259" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-260"><a href="#cb131-260" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
+<span id="cb131-261"><a href="#cb131-261" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_same(info type1, info type2);</span>
+<span id="cb131-262"><a href="#cb131-262" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_base_of(info type_base, info type_derived);</span>
+<span id="cb131-263"><a href="#cb131-263" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_convertible(info type_src, info type_dst);</span>
+<span id="cb131-264"><a href="#cb131-264" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_convertible(info type_src, info type_dst);</span>
+<span id="cb131-265"><a href="#cb131-265" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_layout_compatible(info type1, info type2);</span>
+<span id="cb131-266"><a href="#cb131-266" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer_interconvertible_base_of(info type_base, info type_derived);</span>
+<span id="cb131-267"><a href="#cb131-267" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-268"><a href="#cb131-268" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-269"><a href="#cb131-269" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-270"><a href="#cb131-270" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-271"><a href="#cb131-271" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb131-272"><a href="#cb131-272" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-273"><a href="#cb131-273" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-274"><a href="#cb131-274" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-275"><a href="#cb131-275" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-276"><a href="#cb131-276" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb131-277"><a href="#cb131-277" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-278"><a href="#cb131-278" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
+<span id="cb131-279"><a href="#cb131-279" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_const(info type);</span>
+<span id="cb131-280"><a href="#cb131-280" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_volatile(info type);</span>
+<span id="cb131-281"><a href="#cb131-281" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cv(info type);</span>
+<span id="cb131-282"><a href="#cb131-282" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_const(info type);</span>
+<span id="cb131-283"><a href="#cb131-283" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_volatile(info type);</span>
+<span id="cb131-284"><a href="#cb131-284" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_cv(info type);</span>
+<span id="cb131-285"><a href="#cb131-285" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-286"><a href="#cb131-286" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
+<span id="cb131-287"><a href="#cb131-287" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_reference(info type);</span>
+<span id="cb131-288"><a href="#cb131-288" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_lvalue_reference(info type);</span>
+<span id="cb131-289"><a href="#cb131-289" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_rvalue_reference(info type);</span>
+<span id="cb131-290"><a href="#cb131-290" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-291"><a href="#cb131-291" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
+<span id="cb131-292"><a href="#cb131-292" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_signed(info type);</span>
+<span id="cb131-293"><a href="#cb131-293" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_unsigned(info type);</span>
+<span id="cb131-294"><a href="#cb131-294" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-295"><a href="#cb131-295" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
+<span id="cb131-296"><a href="#cb131-296" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_extent(info type);</span>
+<span id="cb131-297"><a href="#cb131-297" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_all_extents(info type);</span>
+<span id="cb131-298"><a href="#cb131-298" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-299"><a href="#cb131-299" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
+<span id="cb131-300"><a href="#cb131-300" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_pointer(info type);</span>
+<span id="cb131-301"><a href="#cb131-301" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_pointer(info type);</span>
+<span id="cb131-302"><a href="#cb131-302" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-303"><a href="#cb131-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
+<span id="cb131-304"><a href="#cb131-304" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cvref(info type);</span>
+<span id="cb131-305"><a href="#cb131-305" aria-hidden="true" tabindex="-1"></a>  consteval info type_decay(info type);</span>
+<span id="cb131-306"><a href="#cb131-306" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-307"><a href="#cb131-307" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_type(R&amp;&amp; type_args);</span>
+<span id="cb131-308"><a href="#cb131-308" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-309"><a href="#cb131-309" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_reference(R&amp;&amp; type_args);</span>
+<span id="cb131-310"><a href="#cb131-310" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
+<span id="cb131-311"><a href="#cb131-311" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-312"><a href="#cb131-312" aria-hidden="true" tabindex="-1"></a>    `consteval info type_invoke_result(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-313"><a href="#cb131-313" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_reference(info type);</span>
+<span id="cb131-314"><a href="#cb131-314" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_ref_decay(info type);</span>
+<span id="cb131-315"><a href="#cb131-315" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6481,40 +6539,44 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view name_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8name_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view name_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8name_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">1</a></span>
 <em>Constant When</em>: If returning
 <code class="sourceCode cpp">string_view</code>, the unqualified name is
 representable using the ordinary string literal encoding.
-<code class="sourceCode cpp">r</code> designates a declared entity.</p>
+<code class="sourceCode cpp">r</code> represents a declared entity.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">2</a></span>
 <em>Returns</em>: The unqualified name of the entity designated by
 <code class="sourceCode cpp">r</code>. If this entity has no name, then
 an empty <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view qualified_name_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8qualified_name_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view qualified_name_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8qualified_name_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">3</a></span>
 <em>Constant When</em>: If returning
 <code class="sourceCode cpp">string_view</code>, the qualified name is
 representable using the ordinary string literal encoding.
-<code class="sourceCode cpp">r</code> designates a declared entity.</p>
+<code class="sourceCode cpp">r</code> represents a declared entity.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">4</a></span>
 <em>Returns</em>: The qualified name of the entity designated by
 <code class="sourceCode cpp">r</code>. If this entity has no name, then
 an empty <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p>consteval string_view display_string_of(info r); consteval
-u8string_view u8display_string_of(info r);</p>
-<div class="sourceCode" id="cb133"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>[#]{.pnum} *Constant When*: If returning `string_view`, the implementation-defined name is representable using the ordinary string literal encoding.</span>
-<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>[#]{.pnum} *Returns*: An implementation-defined `string_view` or `u8string_view`, respectively, suitable for identifying the reflected construct.</span>
-<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a>```cpp</span>
-<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a>consteval source_location source_location_of(info r);</span></code></pre></div>
+<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">5</a></span>
+<em>Constant When</em>: If returning
+<code class="sourceCode cpp">string_view</code>, the
+implementation-defined name is representable using the ordinary string
+literal encoding.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">6</a></span>
+<em>Returns</em>: An implementation-defined
+<code class="sourceCode cpp">string_view</code> or
+<code class="sourceCode cpp">u8string_view</code>, respectively,
+suitable for identifying the reflected construct.</p>
+<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">7</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">source_location</code> corresponding to the
 reflected construct.</p>
@@ -6526,60 +6588,60 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">1</a></span>
+<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a class member or base
+<code class="sourceCode cpp">r</code> represents a class member or base
 class that is public, protected, or private, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">2</a></span>
+<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates either a virtual member
+<code class="sourceCode cpp">r</code> represents either a virtual member
 function or a virtual base class. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">3</a></span>
+<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a member function that
+<code class="sourceCode cpp">r</code> represents a member function that
 is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">4</a></span>
+<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a final class or a
+<code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">5</a></span>
+<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a function that is
+<code class="sourceCode cpp">r</code> represents a function that is
 defined as deleted ([dcl.fct.def.delete]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">6</a></span>
+<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a function that is
+<code class="sourceCode cpp">r</code> represents a function that is
 defined as defaulted ([dcl.fct.def.default]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">7</a></span>
+<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a member function that
+<code class="sourceCode cpp">r</code> represents a member function that
 is declared explicit. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>. <span class="note"><span>[ <em>Note 1:</em> </span>If
-<code class="sourceCode cpp">r</code> designates a member function
+<code class="sourceCode cpp">r</code> represents a member function
 template that is declared
 <code class="sourceCode cpp"><span class="kw">explicit</span></code>,
 <code class="sourceCode cpp">is_explicit<span class="op">(</span>r<span class="op">)</span></code>
@@ -6587,17 +6649,17 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">8</a></span>
+<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a
+<code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><span class="kw">noexcept</span></code>
 function type or a function or member function that is declared
 <code class="sourceCode cpp"><span class="kw">noexcept</span></code>.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>. <span class="note"><span>[ <em>Note 2:</em> </span>If
-<code class="sourceCode cpp">r</code> designates a function template
+<code class="sourceCode cpp">r</code> represents a function template
 that is declared
 <code class="sourceCode cpp"><span class="kw">noexcept</span></code>,
 <code class="sourceCode cpp">is_noexcept<span class="op">(</span>r<span class="op">)</span></code>
@@ -6605,105 +6667,105 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">9</a></span>
+<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a bit-field. Otherwise,
+<code class="sourceCode cpp">r</code> represents a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">10</a></span>
+<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a const or volatile
+<code class="sourceCode cpp">r</code> represents a const or volatile
 type (respectively), a const- or volatile-qualified function type
 (respectively), or an object, variable, non-static data member, or
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">11</a></span>
+<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> designates a lvalue- or
 rvalue-reference qualified function type (respectively), or a member
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">12</a></span>
+<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates an object or variable
+<code class="sourceCode cpp">r</code> represents an object or variable
 that has static storage duration. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb146-3"><a href="#cb146-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb146-4"><a href="#cb146-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">13</a></span>
+<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb148-3"><a href="#cb148-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb148-4"><a href="#cb148-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates an entity that has
+<code class="sourceCode cpp">r</code> represents an entity that has
 internal linkage, module linkage, external linkage, or any linkage,
 respectively ([basic.link]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">14</a></span>
+<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a namespace or
+<code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">15</a></span>
+<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a function or member
+<code class="sourceCode cpp">r</code> represents a function or member
 function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">16</a></span>
+<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a variable. Otherwise,
+<code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">17</a></span>
+<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a type or a type alias.
+<code class="sourceCode cpp">r</code> represents a type or a type alias.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">18</a></span>
+<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a type alias, alias
+<code class="sourceCode cpp">r</code> represents a type alias, alias
 template, or namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_incomplete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">19</a></span>
+<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_incomplete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">19</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">20</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
-designates a class template specialization with a reachable definition,
+represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 type designated by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">22</a></span>
+<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a function template,
+<code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, or alias template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">23</a></span>
 <span class="note"><span>[ <em>Note 3:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -6711,87 +6773,87 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code> but
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-3"><a href="#cb154-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-4"><a href="#cb154-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-5"><a href="#cb154-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-6"><a href="#cb154-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-7"><a href="#cb154-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">24</a></span>
+<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-4"><a href="#cb156-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-5"><a href="#cb156-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-6"><a href="#cb156-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-7"><a href="#cb156-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a function template,
+<code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, concept, structured
 binding, or value respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">25</a></span>
+<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates an object. Otherwise,
+<code class="sourceCode cpp">r</code> represents an object. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">26</a></span>
+<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates an instantiation of a
+<code class="sourceCode cpp">r</code> represents an instantiation of a
 function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb157-3"><a href="#cb157-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb157-4"><a href="#cb157-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb157-5"><a href="#cb157-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">27</a></span>
+<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-5"><a href="#cb159-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a class member,
+<code class="sourceCode cpp">r</code> represents a class member,
 namespace member, non-static data member, static member, or base class
 member, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">28</a></span>
+<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">28</a></span>
 <em>Returns</em>
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a non-static data
+<code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-5"><a href="#cb159-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-6"><a href="#cb159-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-7"><a href="#cb159-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-8"><a href="#cb159-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-9"><a href="#cb159-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">29</a></span>
+<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-3"><a href="#cb161-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-4"><a href="#cb161-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-5"><a href="#cb161-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-6"><a href="#cb161-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-7"><a href="#cb161-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-8"><a href="#cb161-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-9"><a href="#cb161-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a special member
+<code class="sourceCode cpp">r</code> represents a special member
 function, constructor, default constructor, copy constructor, move
 constructor, assignment operator, copy assignment operator, move
 assignment operator, or destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">30</a></span>
-<em>Constant When</em>: <code class="sourceCode cpp">r</code> designates
+<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">30</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a function.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> designates a user-provided
+<code class="sourceCode cpp">r</code> represents a user-provided
 (<span>9.5.2 <a href="https://wg21.link/dcl.fct.def.default">[dcl.fct.def.default]</a></span>)
 function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">32</a></span>
-<em>Constant When</em>: <code class="sourceCode cpp">r</code> designates
+<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">32</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a typed entity. <code class="sourceCode cpp">r</code> does not designate
 a constructor, destructor, or structured binding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">33</a></span>
 <em>Returns</em>: A reflection of the type of that entity. If every
 declaration of that entity was declared with the same type alias (but
 not a template parameter substituted by a type alias), the reflection
@@ -6800,21 +6862,21 @@ entity was declared with an alias it is unspecified whether the
 reflection returned is for that alias or for the type underlying that
 alias. Otherwise, the reflection returned shall not be a type alias
 reflection.</p>
-<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">34</a></span>
+<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">34</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating either an object or a variable denoting an object
 with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">35</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">36</a></span>
+<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">36</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating either an object or variable usable in constant
 expressions ([expr.const]), an enumerator, or a value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">37</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of an object <code class="sourceCode cpp">o</code>, or a
 reflection of a variable which designates an object
@@ -6825,49 +6887,49 @@ with the cv-qualifiers removed if this is a scalar type. Otherwise, if
 <code class="sourceCode cpp">r</code> is a reflection of an enumerator,
 then a reflection of the value of the enumerator. Otherwise,
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">38</a></span>
-<em>Constant When</em>: <code class="sourceCode cpp">r</code> designates
+<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">38</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a member of either a class or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">39</a></span>
 <em>Returns</em>: A reflection of that entity’s immediately enclosing
 class or namespace.</p>
-<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">40</a></span>
-<em>Returns</em>: If <code class="sourceCode cpp">r</code> designates a
+<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">40</a></span>
+<em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 type alias or a namespace alias, a reflection designating the underlying
 entity. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">41</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">41</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb166"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
-<span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
-<span id="cb166-3"><a href="#cb166-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
-<span id="cb166-4"><a href="#cb166-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
-<span id="cb166-5"><a href="#cb166-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
+<div class="sourceCode" id="cb168"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
+<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
+<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
+<span id="cb168-4"><a href="#cb168-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
+<span id="cb168-5"><a href="#cb168-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">42</a></span>
+<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">42</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">43</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization designated by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb168"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
-<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
-<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb168-4"><a href="#cb168-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
-<span id="cb168-5"><a href="#cb168-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
-<span id="cb168-6"><a href="#cb168-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
-<span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
+<div class="sourceCode" id="cb170"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
+<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
+<span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
+<span id="cb170-5"><a href="#cb170-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
+<span id="cb170-6"><a href="#cb170-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
+<span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6878,15 +6940,15 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">1</a></span>
+<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating either a complete class type or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">2</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
-designates a class template specialization with a reachable definition,
+represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">3</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of all the direct members
 <code class="sourceCode cpp">m</code> of the entity, excluding any
@@ -6896,15 +6958,15 @@ indexed in the order in which they are declared, but the order of other
 kinds of members is unspecified. <span class="note"><span>[ <em>Note
 1:</em> </span>Base classes are not members.<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">4</a></span>
+<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code> is a
 reflection designating a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">5</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
-designates a class template specialization with a reachable definition,
+represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">6</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 designated by <code class="sourceCode cpp">type</code>. A
 <code class="sourceCode cpp">vector</code> containing the reflections of
@@ -6913,48 +6975,48 @@ any, of <code class="sourceCode cpp">C</code>. The base classes are
 indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
-<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">7</a></span>
+<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code>
 designates a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">8</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">9</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the static data members of the type
 designated by <code class="sourceCode cpp">type</code>.</p>
-<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">10</a></span>
+<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code>
 designates a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">11</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">12</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the non-static data members of the type
 designated by <code class="sourceCode cpp">type</code>, in the order in
 which they are declared.</p>
-<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> subobjects_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">13</a></span>
+<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> subobjects_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">13</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code> is a
 reflection designating a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">14</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
-designates a class template specialization with a reachable definition,
+represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">15</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing all the reflections in <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 followed by all the reflections in <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">16</a></span>
+<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">16</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type_enum</code> is
 a reflection designating an enumeration.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">17</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 designated by <code class="sourceCode cpp">type_enum</code>, in the
@@ -6967,101 +7029,101 @@ order in which they are declared.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> access_context <span class="op">{</span></span>
-<span id="cb175-2"><a href="#cb175-2" aria-hidden="true" tabindex="-1"></a>  info <em>context_</em>; <span class="co">// exposition-only</span></span>
-<span id="cb175-3"><a href="#cb175-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb175-4"><a href="#cb175-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> access_context<span class="op">()</span>;</span>
-<span id="cb175-5"><a href="#cb175-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">1</a></span>
+<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> access_context <span class="op">{</span></span>
+<span id="cb177-2"><a href="#cb177-2" aria-hidden="true" tabindex="-1"></a>  info <em>context_</em>; <span class="co">// exposition-only</span></span>
+<span id="cb177-3"><a href="#cb177-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb177-4"><a href="#cb177-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> access_context<span class="op">()</span>;</span>
+<span id="cb177-5"><a href="#cb177-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">1</a></span>
 The type <code class="sourceCode cpp">access_context</code> is suitable
 for ensuring that only accessible members are reflected on.</p>
-<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context<span class="op">::</span>access_context<span class="op">()</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">2</a></span>
+<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context<span class="op">::</span>access_context<span class="op">()</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp">context_</code> to a reflection of the
 function, class, or namespace scope most nearly enclosing the function
 call.</p>
-<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">3</a></span>
+<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a member of a class.
-<code class="sourceCode cpp">from</code> designates a function, class,
+<code class="sourceCode cpp">from</code> represents a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 class member designated by <code class="sourceCode cpp">target</code>
 can be named within the scope of <code class="sourceCode cpp">from<span class="op">.</span><em>context_</em></code>.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_members_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">5</a></span>
+<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_members_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
-<code class="sourceCode cpp">from</code> designates a function, class,
+<code class="sourceCode cpp">from</code> represents a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">6</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">7</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_bases_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">8</a></span>
+<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_bases_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">8</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
-<code class="sourceCode cpp">from</code> designates a function, class,
+<code class="sourceCode cpp">from</code> represents a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">9</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">10</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_nonstatic_data_members_of<span class="op">(</span>info target,</span>
-<span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a>                                                            access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">11</a></span>
+<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_nonstatic_data_members_of<span class="op">(</span>info target,</span>
+<span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a>                                                            access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">11</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
 <code class="sourceCode cpp">from</code> designates a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">12</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">13</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_static_data_members_of<span class="op">(</span>info target,</span>
-<span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a>                                                         access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">14</a></span>
+<div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_static_data_members_of<span class="op">(</span>info target,</span>
+<span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a>                                                         access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">14</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
 <code class="sourceCode cpp">from</code> designates a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">15</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_subobjects_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">17</a></span>
+<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_subobjects_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">17</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing all the reflections in <code class="sourceCode cpp">accessible_bases_of<span class="op">(</span>target, from<span class="op">)</span></code>
 followed by all the reflections in <code class="sourceCode cpp">accessible_nonstatic_data_members_of<span class="op">(</span>target, from<span class="op">)</span></code>.</p>
@@ -7073,58 +7135,58 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">1</a></span>
+<div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a non-static data member or non-virtual base
 class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">2</a></span>
 <em>Returns</em>: The offset in bytes from the beginning of an object of
 type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity reflected by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">3</a></span>
+<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, non-static data member, base class, object, value,
 or variable.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">4</a></span>
-<em>Returns</em> If <code class="sourceCode cpp">r</code> designates a
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">4</a></span>
+<em>Returns</em> If <code class="sourceCode cpp">r</code> represents a
 type <code class="sourceCode cpp">T</code>, then <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span></code>.
 Otherwise, <code class="sourceCode cpp">size_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</p>
-<div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">5</a></span>
+<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating an object, variable, type, non-static data
 member, or base class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">6</a></span>
-<em>Returns</em>: If <code class="sourceCode cpp">r</code> designates a
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">6</a></span>
+<em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 type, object, or variable, then the alignment requirement of the entity.
-Otherwise, if <code class="sourceCode cpp">r</code> designates a base
+Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.
 Otherwise, the alignment requirement of the subobject associated with
 the reflected non-static data member within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">7</a></span>
+<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a non-static data member or a non-virtual base
 class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">8</a></span>
 Let <code class="sourceCode cpp">V</code> be the offset in bits from the
 beginning of an object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity reflected by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">9</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">V <span class="op">-</span> offset_of<span class="op">(</span>r<span class="op">)</span> <span class="op">*</span> CHAR_BIT</code>.</p>
-<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">10</a></span>
+<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, non-static data member, base class, object, value,
 or variable.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">11</a></span>
-<em>Returns</em> If <code class="sourceCode cpp">r</code> designates a
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">11</a></span>
+<em>Returns</em> If <code class="sourceCode cpp">r</code> represents a
 type, then the size in bits of any object having the reflected type.
-Otherwise, if <code class="sourceCode cpp">r</code> reflects a
+Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, then the width of the
 reflected bit-field. Otherwise, <code class="sourceCode cpp">bit_size_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</p>
 </div>
@@ -7135,21 +7197,21 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb188-2"><a href="#cb188-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">1</a></span>
+<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb190-2"><a href="#cb190-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a value, object, variable, function, enumerator,
 or non-static data member that is not a bit-field. If
-<code class="sourceCode cpp">r</code> reflects a value or enumerator,
+<code class="sourceCode cpp">r</code> represents a value or enumerator,
 then <code class="sourceCode cpp">T</code> is not a reference type. If
-<code class="sourceCode cpp">r</code> reflects a value or enumerator of
-type <code class="sourceCode cpp">U</code>, or if
-<code class="sourceCode cpp">r</code> reflects a variable or object of
+<code class="sourceCode cpp">r</code> represents a value or enumerator
+of type <code class="sourceCode cpp">U</code>, or if
+<code class="sourceCode cpp">r</code> represents a variable or object of
 non-reference type <code class="sourceCode cpp">U</code>, then the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same. If
-<code class="sourceCode cpp">r</code> reflects a variable, object, or
+<code class="sourceCode cpp">r</code> represents a variable, object, or
 function with type <code class="sourceCode cpp">U</code>, and
 <code class="sourceCode cpp">T</code> is a reference type, then the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
@@ -7157,29 +7219,29 @@ cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">T</code> is either
 <code class="sourceCode cpp">U</code> or more cv-qualified than
 <code class="sourceCode cpp">U</code>. If
-<code class="sourceCode cpp">r</code> reflects a non-static data member,
-or if <code class="sourceCode cpp">r</code> reflects a function and
-<code class="sourceCode cpp">T</code> is a reference type, then the
-statement <code class="sourceCode cpp">T v <span class="op">=</span> <span class="op">&amp;</span>expr</code>,
+<code class="sourceCode cpp">r</code> represents a non-static data
+member, or if <code class="sourceCode cpp">r</code> represents a
+function and <code class="sourceCode cpp">T</code> is a reference type,
+then the statement <code class="sourceCode cpp">T v <span class="op">=</span> <span class="op">&amp;</span>expr</code>,
 where <code class="sourceCode cpp">expr</code> is an lvalue naming the
 entity designated by <code class="sourceCode cpp">r</code>, is
 well-formed.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">2</a></span>
-<em>Returns</em>: If <code class="sourceCode cpp">r</code> designates a
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">2</a></span>
+<em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value or enumerator, then the entity reflected by
 <code class="sourceCode cpp">r</code>. Otherwise, if
-<code class="sourceCode cpp">r</code> reflects an object, variable, or
+<code class="sourceCode cpp">r</code> represents an object, variable, or
 enumerator and <code class="sourceCode cpp">T</code> is not a reference
 type, then the result of an lvalue-to-rvalue conversion applied to an
 expression naming the entity reflected by
 <code class="sourceCode cpp">r</code>. Otherwise, if
-<code class="sourceCode cpp">r</code> reflects an object, variable, or
+<code class="sourceCode cpp">r</code> represents an object, variable, or
 function and <code class="sourceCode cpp">T</code> is a reference type,
 then the result of an lvalue naming the entity reflected by
 <code class="sourceCode cpp">r</code>. Otherwise, if
-<code class="sourceCode cpp">r</code> reflects a function or non-static
-data member, then a pointer value designating the entity reflected by
-<code class="sourceCode cpp">r</code>.</p>
+<code class="sourceCode cpp">r</code> represents a function or
+non-static data member, then a pointer value designating the entity
+reflected by <code class="sourceCode cpp">r</code>.</p>
 </div>
 </blockquote>
 </div>
@@ -7188,43 +7250,43 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
-<span id="cb189-2"><a href="#cb189-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
-<span id="cb189-3"><a href="#cb189-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb189-4"><a href="#cb189-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb189-5"><a href="#cb189-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb190-2"><a href="#cb190-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">1</a></span>
+<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
+<span id="cb191-2"><a href="#cb191-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
+<span id="cb191-3"><a href="#cb191-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb191-4"><a href="#cb191-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb191-5"><a href="#cb191-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb192-2"><a href="#cb192-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
-designates a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">2</a></span>
+represents a template.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template designated by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities or aliases designated by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
-<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb191-2"><a href="#cb191-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">5</a></span>
+<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template designated by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities or aliases designated by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -7234,44 +7296,44 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb192-2"><a href="#cb192-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">1</a></span>
+<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">T</code> is a
 structural type that is not a reference type. Any subobject of the value
 computed by <code class="sourceCode cpp">expr</code> having reference or
 pointer type designates an entity that is a permitted result of a
 constant expression ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">2</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the reflected
 value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">3</a></span>
+<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">T</code> is not a
 function type. <code class="sourceCode cpp">expr</code> designates an
 entity that is a permitted result of a constant expression.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">4</a></span>
 <em>Returns</em>: A reflection of the object referenced by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">5</a></span>
+<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">T</code> is a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function referenced by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
-<span id="cb195-3"><a href="#cb195-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb195-4"><a href="#cb195-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">7</a></span>
+<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb197-2"><a href="#cb197-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
+<span id="cb197-3"><a href="#cb197-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb197-4"><a href="#cb197-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">7</a></span>
 Let <code class="sourceCode cpp">F</code> be the entity reflected by
 <code class="sourceCode cpp">target</code>, let
 <code class="sourceCode cpp">Arg0</code> be the entity reflected by the
@@ -7282,7 +7344,7 @@ the sequence of entities reflected by the elements of
 <code class="sourceCode cpp">TArgs<span class="op">...</span></code> be
 the sequence of entities or aliases designated by the elements of
 <code class="sourceCode cpp">tmpl_args</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">8</a></span>
 If <code class="sourceCode cpp">F</code> is a non-member function, a
 value of pointer to function type, a value of pointer to member type, or
 a value of closure type, then let
@@ -7312,17 +7374,16 @@ considered by overload resolution, and
 <code class="sourceCode cpp">TArgs<span class="op">...</span></code> are
 inferred as explicit template arguments for
 <code class="sourceCode cpp">F</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code>
-designates a reflection of a function, a constructor, a constructor
-template, a value, or a function template. If
-<code class="sourceCode cpp">target</code> reflects a value of type
-<code class="sourceCode cpp">T</code>, then
+represents a function, a constructor, a constructor template, a value,
+or a function template. If <code class="sourceCode cpp">target</code>
+represents a value of type <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">T</code> is a pointer to function type,
 pointer to member type, or closure type. The expression
 <code class="sourceCode cpp">INVOKE<span class="op">-</span>EXPR</code>
 is a well-formed constant expression of structural type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">10</a></span>
 <em>Returns</em>: A reflection of the result of the expression
 <code class="sourceCode cpp">INVOKE<span class="op">-</span>EXPR</code>.</p>
 </div>
@@ -7333,31 +7394,31 @@ Reflection class definition generation<a href="#meta.reflection.define_class-ref
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">1</a></span>
+<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
+<span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code>
-designates a type. If
+represents a type. If
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, the <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> value that was used to
 initialize
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a valid identifier (<span>5.10 <a href="https://wg21.link/lex.name">[lex.name]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">2</a></span>
 <em>Returns</em>: A reflection of a description of the declaration of
 non-static data member with a type designated by
 <code class="sourceCode cpp">type</code> and optional characteristics
 designated by <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">3</a></span>
 <em>Remarks</em>: The reflection value being returned is only useful for
 consumption by <code class="sourceCode cpp">define_class</code>. No
 other function in
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>
 recognizes such a value.</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb197-2"><a href="#cb197-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span>  mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">4</a></span>
+<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span>  mdescrs<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">4</a></span>
 Let <code class="sourceCode cpp"><em>d</em><sub>1</sub></code>,
 <code class="sourceCode cpp"><em>d</em><sub>2</sub></code>, …,
 <code class="sourceCode cpp"><em>d</em><sub>N</sub></code> denote the
@@ -7373,16 +7434,16 @@ reflection values of the range
 <code class="sourceCode cpp"><em>o</em><sub>2</sub></code>, …
 <code class="sourceCode cpp"><em>o</em><sub>N</sub></code>
 respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">class_type</code>
-designates an incomplete class type.
+represents an incomplete class type.
 <code class="sourceCode cpp">mdescrs</code> is a (possibly empty) range
 of reflection values obtained by calls to
 <code class="sourceCode cpp">data_member_spec</code>. <span class="note"><span>[ <em>Note 1:</em> </span>For example,
 <code class="sourceCode cpp">class_type</code> could be a specialization
 of a class template that has not been instantiated or explicitly
 specialized.<span> — <em>end note</em> ]</span></span> Each
-<code class="sourceCode cpp"><em>t</em><sub>i</sub></code> designates a
+<code class="sourceCode cpp"><em>t</em><sub>i</sub></code> represents a
 type that is valid types for data members. If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>width</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) contains a
 value <code class="sourceCode cpp"><em>w</em></code>, the corresponding
@@ -7395,43 +7456,43 @@ is a valid
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> for a
 non-static data member of type
 <code class="sourceCode cpp"><em>t</em><sub>K</sub></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">6</a></span>
 <em>Effects</em>: Defines <code class="sourceCode cpp">class_type</code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(6.1)</a></span>
-If <code class="sourceCode cpp">class_type</code> designates a
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(6.1)</a></span>
+If <code class="sourceCode cpp">class_type</code> represents a
 specialization of a class template, the specialization is explicitly
 specialized.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(6.2)</a></span>
 Non-static data members are declared in the definition of
 <code class="sourceCode cpp">class_type</code> according to
 <code class="sourceCode cpp"><em>d</em><sub>1</sub></code>,
 <code class="sourceCode cpp"><em>d</em><sub>2</sub></code>, …,
 <code class="sourceCode cpp"><em>d</em><sub>N</sub></code>, in that
 order.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(6.3)</a></span>
-The type of the respective members are the types denoted by the
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(6.3)</a></span>
+The type of the respective members are the types represented by the
 reflection values
 <code class="sourceCode cpp"><em>t</em><sub>1</sub></code>,
 <code class="sourceCode cpp"><em>t</em><sub>2</sub></code>, …
 <code class="sourceCode cpp"><em>t</em><sub>N</sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(6.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(6.4)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>no_unique_address</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) is
 <code class="sourceCode cpp"><span class="kw">true</span></code>, the
 corresponding member is declared with attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(6.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(6.5)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>width</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) contains a
 value, the corresponding member is declared as a bit field with that
 value as its width.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(6.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(6.6)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>alignment</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) contains a
 value <code class="sourceCode cpp"><em>a</em></code>, the corresponding
 member is aligned as if declared with <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><em>a</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(6.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(6.7)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>name</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) does not
 contain a value, the corresponding member is declared with an
@@ -7440,7 +7501,7 @@ declared with a name corresponding to the
 <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> value that was used to
 initialize <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>name</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(6.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(6.8)</a></span>
 If <code class="sourceCode cpp">class_type</code> is a union type and
 any of its members is not trivially default constructible, then it has a
 default constructor that is user-provided and has no effect. If
@@ -7448,7 +7509,7 @@ default constructor that is user-provided and has no effect. If
 of its members is not trivially default destructible, then it has a
 default destructor that is user-provided and has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -7458,10 +7519,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -7480,43 +7541,43 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.unary.cat]</a></span>.</p>
-<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_void<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_null_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-3"><a href="#cb198-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_integral<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-4"><a href="#cb198-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_floating_point<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-5"><a href="#cb198-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_array<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-6"><a href="#cb198-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-7"><a href="#cb198-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-8"><a href="#cb198-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-9"><a href="#cb198-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_object_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-10"><a href="#cb198-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_function_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-11"><a href="#cb198-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-12"><a href="#cb198-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_union<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-13"><a href="#cb198-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-14"><a href="#cb198-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb198-15"><a href="#cb198-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">2</a></span></p>
+<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_void<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_null_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-3"><a href="#cb200-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_integral<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-4"><a href="#cb200-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_floating_point<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-5"><a href="#cb200-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_array<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-6"><a href="#cb200-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-7"><a href="#cb200-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-8"><a href="#cb200-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-9"><a href="#cb200-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_object_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-10"><a href="#cb200-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_function_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-11"><a href="#cb200-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-12"><a href="#cb200-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_union<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-13"><a href="#cb200-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-14"><a href="#cb200-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb200-15"><a href="#cb200-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb199"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type) {</span>
-<span id="cb199-3"><a href="#cb199-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
-<span id="cb199-4"><a href="#cb199-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
-<span id="cb199-5"><a href="#cb199-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb199-6"><a href="#cb199-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
-<span id="cb199-7"><a href="#cb199-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
-<span id="cb199-8"><a href="#cb199-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
-<span id="cb199-9"><a href="#cb199-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
-<span id="cb199-10"><a href="#cb199-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
-<span id="cb199-11"><a href="#cb199-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
-<span id="cb199-12"><a href="#cb199-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb199-13"><a href="#cb199-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb201"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type) {</span>
+<span id="cb201-3"><a href="#cb201-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
+<span id="cb201-4"><a href="#cb201-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
+<span id="cb201-5"><a href="#cb201-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb201-6"><a href="#cb201-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
+<span id="cb201-7"><a href="#cb201-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
+<span id="cb201-8"><a href="#cb201-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
+<span id="cb201-9"><a href="#cb201-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
+<span id="cb201-10"><a href="#cb201-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
+<span id="cb201-11"><a href="#cb201-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
+<span id="cb201-12"><a href="#cb201-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb201-13"><a href="#cb201-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -7527,19 +7588,19 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.3 <a href="https://wg21.link/meta.unary.comp">[meta.unary.comp]</a></span>.</p>
-<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_arithmetic<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb200-3"><a href="#cb200-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_fundamental<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb200-4"><a href="#cb200-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_object<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb200-5"><a href="#cb200-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scalar<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb200-6"><a href="#cb200-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_compound<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb200-7"><a href="#cb200-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_arithmetic<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb202-3"><a href="#cb202-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_fundamental<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb202-4"><a href="#cb202-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_object<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb202-5"><a href="#cb202-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scalar<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb202-6"><a href="#cb202-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_compound<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb202-7"><a href="#cb202-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7548,21 +7609,21 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7572,71 +7633,71 @@ each function template <code class="sourceCode cpp">std<span class="op">::</span
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-TRAIT</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-3"><a href="#cb201-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivial<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-4"><a href="#cb201-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copyable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-5"><a href="#cb201-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_standard_layout<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-6"><a href="#cb201-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_empty<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-7"><a href="#cb201-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_polymorphic<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-8"><a href="#cb201-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_abstract<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-9"><a href="#cb201-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_final<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-10"><a href="#cb201-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_aggregate<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-11"><a href="#cb201-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-12"><a href="#cb201-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-13"><a href="#cb201-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_bounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-14"><a href="#cb201-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unbounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-15"><a href="#cb201-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scoped_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-16"><a href="#cb201-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-17"><a href="#cb201-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb201-18"><a href="#cb201-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb201-19"><a href="#cb201-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-20"><a href="#cb201-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-21"><a href="#cb201-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-22"><a href="#cb201-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-23"><a href="#cb201-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb201-24"><a href="#cb201-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-25"><a href="#cb201-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-26"><a href="#cb201-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-27"><a href="#cb201-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb201-28"><a href="#cb201-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-29"><a href="#cb201-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-30"><a href="#cb201-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-31"><a href="#cb201-31" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-32"><a href="#cb201-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb201-33"><a href="#cb201-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb201-34"><a href="#cb201-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-35"><a href="#cb201-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-36"><a href="#cb201-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-37"><a href="#cb201-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-38"><a href="#cb201-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb201-39"><a href="#cb201-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-40"><a href="#cb201-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-41"><a href="#cb201-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-42"><a href="#cb201-42" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-43"><a href="#cb201-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb201-44"><a href="#cb201-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb201-45"><a href="#cb201-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-46"><a href="#cb201-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-47"><a href="#cb201-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-48"><a href="#cb201-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-49"><a href="#cb201-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb201-50"><a href="#cb201-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-51"><a href="#cb201-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-52"><a href="#cb201-52" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-53"><a href="#cb201-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb201-54"><a href="#cb201-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-55"><a href="#cb201-55" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-56"><a href="#cb201-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-57"><a href="#cb201-57" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-58"><a href="#cb201-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_implicit_lifetime<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-59"><a href="#cb201-59" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-60"><a href="#cb201-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-61"><a href="#cb201-61" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-62"><a href="#cb201-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb201-63"><a href="#cb201-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb201-64"><a href="#cb201-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb201-65"><a href="#cb201-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-3"><a href="#cb203-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivial<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-4"><a href="#cb203-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copyable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-5"><a href="#cb203-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_standard_layout<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-6"><a href="#cb203-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_empty<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-7"><a href="#cb203-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_polymorphic<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-8"><a href="#cb203-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_abstract<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-9"><a href="#cb203-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_final<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-10"><a href="#cb203-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_aggregate<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-11"><a href="#cb203-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-12"><a href="#cb203-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-13"><a href="#cb203-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_bounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-14"><a href="#cb203-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unbounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-15"><a href="#cb203-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scoped_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-16"><a href="#cb203-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-17"><a href="#cb203-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb203-18"><a href="#cb203-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb203-19"><a href="#cb203-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-20"><a href="#cb203-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-21"><a href="#cb203-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-22"><a href="#cb203-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-23"><a href="#cb203-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb203-24"><a href="#cb203-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-25"><a href="#cb203-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-26"><a href="#cb203-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-27"><a href="#cb203-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb203-28"><a href="#cb203-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-29"><a href="#cb203-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-30"><a href="#cb203-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-31"><a href="#cb203-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-32"><a href="#cb203-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb203-33"><a href="#cb203-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb203-34"><a href="#cb203-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-35"><a href="#cb203-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-36"><a href="#cb203-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-37"><a href="#cb203-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-38"><a href="#cb203-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb203-39"><a href="#cb203-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-40"><a href="#cb203-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-41"><a href="#cb203-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-42"><a href="#cb203-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-43"><a href="#cb203-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb203-44"><a href="#cb203-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb203-45"><a href="#cb203-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-46"><a href="#cb203-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-47"><a href="#cb203-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-48"><a href="#cb203-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-49"><a href="#cb203-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb203-50"><a href="#cb203-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-51"><a href="#cb203-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-52"><a href="#cb203-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-53"><a href="#cb203-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb203-54"><a href="#cb203-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-55"><a href="#cb203-55" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-56"><a href="#cb203-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-57"><a href="#cb203-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-58"><a href="#cb203-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_implicit_lifetime<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-59"><a href="#cb203-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-60"><a href="#cb203-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-61"><a href="#cb203-61" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-62"><a href="#cb203-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb203-63"><a href="#cb203-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb203-64"><a href="#cb203-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb203-65"><a href="#cb203-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7645,21 +7706,21 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>PROP</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.6 <a href="https://wg21.link/meta.unary.prop.query">[meta.unary.prop.query]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 unsigned integer value <code class="sourceCode cpp">I</code>, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_extent<span class="op">(^</span>T, I<span class="op">)</span></code>
 equals <code class="sourceCode cpp">std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span></code>
 ([meta.unary.prop.query]).</p>
-<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_alignment_of<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_rank<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb202-3"><a href="#cb202-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_alignment_of<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_rank<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb204-3"><a href="#cb204-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7668,17 +7729,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7688,7 +7749,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7698,23 +7759,23 @@ each ternary function template <code class="sourceCode cpp">std<span class="op">
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL-R</em><span class="op">(^</span>R, <span class="op">^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL-R</em>_v<span class="op">&lt;</span>R, T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_same<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb203-3"><a href="#cb203-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb203-4"><a href="#cb203-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb203-5"><a href="#cb203-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_layout_compatible<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb203-6"><a href="#cb203-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer_interconvertible_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb203-7"><a href="#cb203-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb203-8"><a href="#cb203-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb203-9"><a href="#cb203-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb203-10"><a href="#cb203-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb203-11"><a href="#cb203-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb203-12"><a href="#cb203-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb203-13"><a href="#cb203-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb203-14"><a href="#cb203-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb203-15"><a href="#cb203-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb203-16"><a href="#cb203-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">5</a></span>
+<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_same<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb205-3"><a href="#cb205-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb205-4"><a href="#cb205-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb205-5"><a href="#cb205-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_layout_compatible<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb205-6"><a href="#cb205-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer_interconvertible_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb205-7"><a href="#cb205-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb205-8"><a href="#cb205-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb205-9"><a href="#cb205-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb205-10"><a href="#cb205-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb205-11"><a href="#cb205-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb205-12"><a href="#cb205-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb205-13"><a href="#cb205-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb205-14"><a href="#cb205-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb205-15"><a href="#cb205-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb205-16"><a href="#cb205-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -7736,7 +7797,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -7748,18 +7809,18 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
-<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb204-3"><a href="#cb204-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb204-4"><a href="#cb204-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb204-6"><a href="#cb204-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb206-3"><a href="#cb206-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb206-4"><a href="#cb206-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb206-5"><a href="#cb206-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb206-6"><a href="#cb206-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7768,15 +7829,15 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
-<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb205-3"><a href="#cb205-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb207-3"><a href="#cb207-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7785,14 +7846,14 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
-<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7801,14 +7862,14 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
-<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7817,14 +7878,14 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.6 <a href="https://wg21.link/meta.trans.ptr">[meta.trans.ptr]</a></span>.</p>
-<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7843,14 +7904,14 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause with signature <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>to<span class="op">&lt;</span>vector<span class="op">&gt;(</span>r<span class="op">)</span> <span class="op">==</span> vector<span class="op">{^</span>T<span class="op">...}</span></code>
@@ -7859,7 +7920,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7868,29 +7929,29 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_invoke_result<span class="op">(^</span>T, r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span>invoke_result_t<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 (<span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>).</p>
-<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_decay<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb209-3"><a href="#cb209-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb209-4"><a href="#cb209-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb209-5"><a href="#cb209-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb209-6"><a href="#cb209-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb209-7"><a href="#cb209-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb209-8"><a href="#cb209-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb209-9"><a href="#cb209-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb209-10"><a href="#cb209-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb209-11"><a href="#cb209-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">4</a></span></p>
+<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_decay<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb211-3"><a href="#cb211-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb211-4"><a href="#cb211-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb211-5"><a href="#cb211-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb211-6"><a href="#cb211-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb211-7"><a href="#cb211-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb211-8"><a href="#cb211-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb211-9"><a href="#cb211-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb211-10"><a href="#cb211-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb211-11"><a href="#cb211-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
-<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb210-4"><a href="#cb210-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb210-5"><a href="#cb210-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type_add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb210-6"><a href="#cb210-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb210-7"><a href="#cb210-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
-<span id="cb210-8"><a href="#cb210-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb210-9"><a href="#cb210-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
+<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb212-3"><a href="#cb212-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
+<span id="cb212-4"><a href="#cb212-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb212-5"><a href="#cb212-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type_add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb212-6"><a href="#cb212-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb212-7"><a href="#cb212-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
+<span id="cb212-8"><a href="#cb212-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb212-9"><a href="#cb212-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -7908,10 +7969,10 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb211"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
-<span id="cb211-3"><a href="#cb211-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
-<span id="cb211-4"><a href="#cb211-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
+<div class="sourceCode" id="cb213"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
+<span id="cb213-3"><a href="#cb213-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
+<span id="cb213-4"><a href="#cb213-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7919,7 +7980,7 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb212"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb214"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>

--- a/2996_reflection/d2996r5.html
+++ b/2996_reflection/d2996r5.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-07-03" />
+  <meta name="dcterms.date" content="2024-07-04" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-07-03</td>
+    <td>2024-07-04</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -3690,39 +3690,40 @@ be explained below.</p>
 <span id="cb76-116"><a href="#cb76-116" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_variable_template<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
 <span id="cb76-117"><a href="#cb76-117" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_class_template<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
 <span id="cb76-118"><a href="#cb76-118" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_alias_template<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-119"><a href="#cb76-119" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_concept<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-120"><a href="#cb76-120" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_structured_binding<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-121"><a href="#cb76-121" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_value<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-122"><a href="#cb76-122" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_object<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-123"><a href="#cb76-123" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-124"><a href="#cb76-124" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-125"><a href="#cb76-125" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb76-126"><a href="#cb76-126" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_special_member<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-127"><a href="#cb76-127" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-128"><a href="#cb76-128" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-129"><a href="#cb76-129" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-130"><a href="#cb76-130" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-131"><a href="#cb76-131" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_assignment<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-132"><a href="#cb76-132" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-133"><a href="#cb76-133" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-134"><a href="#cb76-134" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_destructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-135"><a href="#cb76-135" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
-<span id="cb76-136"><a href="#cb76-136" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb76-137"><a href="#cb76-137" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#data_member_spec-define_class">define_class</a></span></span>
-<span id="cb76-138"><a href="#cb76-138" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> data_member_options_t;</span>
-<span id="cb76-139"><a href="#cb76-139" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> data_member_spec<span class="op">(</span>info type_class,</span>
-<span id="cb76-140"><a href="#cb76-140" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options <span class="op">=</span> <span class="op">{})</span> <span class="op">-&gt;</span> info;</span>
-<span id="cb76-141"><a href="#cb76-141" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb76-142"><a href="#cb76-142" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_class<span class="op">(</span>info type_class, R<span class="op">&amp;&amp;)</span> <span class="op">-&gt;</span> info;</span>
-<span id="cb76-143"><a href="#cb76-143" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb76-144"><a href="#cb76-144" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#data-layout-reflection">data layout</a></span></span>
-<span id="cb76-145"><a href="#cb76-145" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> offset_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb76-146"><a href="#cb76-146" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> size_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb76-147"><a href="#cb76-147" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> alignment_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb76-148"><a href="#cb76-148" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_offset_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb76-149"><a href="#cb76-149" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_size_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb76-150"><a href="#cb76-150" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb76-151"><a href="#cb76-151" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb76-119"><a href="#cb76-119" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_constructor_template<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-120"><a href="#cb76-120" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_concept<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-121"><a href="#cb76-121" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_structured_binding<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-122"><a href="#cb76-122" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_value<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-123"><a href="#cb76-123" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_object<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-124"><a href="#cb76-124" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-125"><a href="#cb76-125" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-126"><a href="#cb76-126" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb76-127"><a href="#cb76-127" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_special_member<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-128"><a href="#cb76-128" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-129"><a href="#cb76-129" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-130"><a href="#cb76-130" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-131"><a href="#cb76-131" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-132"><a href="#cb76-132" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_assignment<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-133"><a href="#cb76-133" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-134"><a href="#cb76-134" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-135"><a href="#cb76-135" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_destructor<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-136"><a href="#cb76-136" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
+<span id="cb76-137"><a href="#cb76-137" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb76-138"><a href="#cb76-138" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#data_member_spec-define_class">define_class</a></span></span>
+<span id="cb76-139"><a href="#cb76-139" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> data_member_options_t;</span>
+<span id="cb76-140"><a href="#cb76-140" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> data_member_spec<span class="op">(</span>info type_class,</span>
+<span id="cb76-141"><a href="#cb76-141" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options <span class="op">=</span> <span class="op">{})</span> <span class="op">-&gt;</span> info;</span>
+<span id="cb76-142"><a href="#cb76-142" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb76-143"><a href="#cb76-143" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_class<span class="op">(</span>info type_class, R<span class="op">&amp;&amp;)</span> <span class="op">-&gt;</span> info;</span>
+<span id="cb76-144"><a href="#cb76-144" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb76-145"><a href="#cb76-145" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#data-layout-reflection">data layout</a></span></span>
+<span id="cb76-146"><a href="#cb76-146" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> offset_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb76-147"><a href="#cb76-147" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> size_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb76-148"><a href="#cb76-148" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> alignment_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb76-149"><a href="#cb76-149" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_offset_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb76-150"><a href="#cb76-150" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_size_of<span class="op">(</span>info entity<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb76-151"><a href="#cb76-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb76-152"><a href="#cb76-152" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <h3 data-number="4.4.8" id="name-loc"><span class="header-section-number">4.4.8</span>
@@ -4924,12 +4925,12 @@ and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
 <code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
 shall designate a namespace or namespace alias.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">1</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-id</em></code> are […]</p>
 </blockquote>
@@ -4938,7 +4939,7 @@ The component names of a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -5475,7 +5476,7 @@ the same type designated by the
 </div>
 <h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 Initializers (General)<a href="#dcl.init.general-initializers-general" class="self-link"></a></h3>
-<p>Change paragraphs 6-7 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<p>Change paragraphs 6-8 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 <span class="ednote" style="color: #0000ff">[ Editor&#39;s note: No changes
 are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
@@ -5512,6 +5513,23 @@ the object is zero-initialized.</span></li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">8</a></span>
+A class type <code class="sourceCode cpp">T</code> is
+<em>const-default-constructible</em> if default-initialization of
+<code class="sourceCode cpp">T</code> would invoke a user-provided
+constructor of <code class="sourceCode cpp">T</code> (not inherited from
+a base class) or if</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(8.1)</a></span>
+[…]</li>
+</ul>
+<p>If a program calls for the default-initialization of an object of a
+const-qualified type <code class="sourceCode cpp">T</code>,
+<code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
+or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
+thereof.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">9</a></span>
+To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.fct-functions"><span>9.3.4.6 <a href="https://wg21.link/dcl.fct">[dcl.fct]</a></span> Functions<a href="#dcl.fct-functions" class="self-link"></a></h3>
@@ -5519,22 +5537,22 @@ Otherwise, no initialization is performed.</li>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">9</a></span>
 A function type with a <em>cv-qualifier-seq</em> or a
 <em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(9.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(9.5)</a></span>
 the <em>type-id</em> of a <em>template-argument</em> for a
 <em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(9.6)</a></span>
 the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
@@ -5546,7 +5564,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator</span>, is ill-formed.</p>
@@ -5574,7 +5592,7 @@ follows:</p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">1</a></span>
 A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
 <span class="addu">not consisting of a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>
@@ -5612,7 +5630,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">0</a></span>
 If a
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 consists of a
@@ -5634,7 +5652,7 @@ designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link
 in the paragraph that immediately follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -5662,7 +5680,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">0</a></span>
 The
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 shall neither contain a dependent
@@ -5670,7 +5688,7 @@ shall neither contain a dependent
 dependent
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -5734,7 +5752,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -5757,7 +5775,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
@@ -5772,7 +5790,7 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 in template parameter declarations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">4</a></span>
 … The concept designated by a type-constraint shall be a type concept
 ([temp.concept]) <span class="addu">that does not consist of a
 <code class="sourceCode cpp"><em>splice-template-name</em></code></span>.</p>
@@ -5830,7 +5848,7 @@ the entity reflected by the
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">*</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 also interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
@@ -5846,7 +5864,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">3</a></span>
 In a <code class="sourceCode cpp"><em>template-argument</em></code>
 <span class="addu">which does not contain a
 <code class="sourceCode cpp"><em>splice-template-argument</em></code></span>,
@@ -5870,7 +5888,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -5893,7 +5911,7 @@ Template non-type arguments<a href="#temp.arg.nontype-template-non-type-argument
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">2</a></span>
 The value of a non-type
 <code class="sourceCode cpp"><em>template-parameter</em></code>
 <em>P</em> of (possibly deduced) type
@@ -5913,7 +5931,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be the name of a class template or an alias template, expressed as
@@ -5934,23 +5952,23 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and they compare equal, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -6009,7 +6027,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">[:</span> <em>constant-expression</em> <span class="op">:]</span></code>
 or <code class="sourceCode cpp"><span class="kw">template</span><span class="op">[:</span> <em>constant-expression</em> <span class="op">:]</span>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6028,10 +6046,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -6057,7 +6075,7 @@ dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">[:</span> <em>constant-expression</em> <span class="op">:]</span></code>
 or <code class="sourceCode cpp"><span class="kw">template</span><span class="op">[:</span> <em>constant-expression</em> <span class="op">:]</span>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6077,19 +6095,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -6101,7 +6119,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -6109,7 +6127,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">7pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">7pre</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -6119,7 +6137,7 @@ might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -6270,269 +6288,270 @@ synopsis</strong></p>
 <span id="cb131-50"><a href="#cb131-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
 <span id="cb131-51"><a href="#cb131-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
 <span id="cb131-52"><a href="#cb131-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
-<span id="cb131-53"><a href="#cb131-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
-<span id="cb131-54"><a href="#cb131-54" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
-<span id="cb131-55"><a href="#cb131-55" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
-<span id="cb131-56"><a href="#cb131-56" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
-<span id="cb131-57"><a href="#cb131-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
-<span id="cb131-58"><a href="#cb131-58" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info entity);</span>
-<span id="cb131-59"><a href="#cb131-59" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info entity);</span>
-<span id="cb131-60"><a href="#cb131-60" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
-<span id="cb131-61"><a href="#cb131-61" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
-<span id="cb131-62"><a href="#cb131-62" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
-<span id="cb131-63"><a href="#cb131-63" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
-<span id="cb131-64"><a href="#cb131-64" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-65"><a href="#cb131-65" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member(info r);</span>
-<span id="cb131-66"><a href="#cb131-66" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
-<span id="cb131-67"><a href="#cb131-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
-<span id="cb131-68"><a href="#cb131-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
-<span id="cb131-69"><a href="#cb131-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
-<span id="cb131-70"><a href="#cb131-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
-<span id="cb131-71"><a href="#cb131-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
-<span id="cb131-72"><a href="#cb131-72" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
-<span id="cb131-73"><a href="#cb131-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
-<span id="cb131-74"><a href="#cb131-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
-<span id="cb131-75"><a href="#cb131-75" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-76"><a href="#cb131-76" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
-<span id="cb131-77"><a href="#cb131-77" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
-<span id="cb131-78"><a href="#cb131-78" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
-<span id="cb131-79"><a href="#cb131-79" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
-<span id="cb131-80"><a href="#cb131-80" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
-<span id="cb131-81"><a href="#cb131-81" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
-<span id="cb131-82"><a href="#cb131-82" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
-<span id="cb131-83"><a href="#cb131-83" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-84"><a href="#cb131-84" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
-<span id="cb131-85"><a href="#cb131-85" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info type);</span>
-<span id="cb131-86"><a href="#cb131-86" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
-<span id="cb131-87"><a href="#cb131-87" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
-<span id="cb131-88"><a href="#cb131-88" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
-<span id="cb131-89"><a href="#cb131-89" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; subobjects_of(info type);</span>
-<span id="cb131-90"><a href="#cb131-90" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
-<span id="cb131-91"><a href="#cb131-91" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-92"><a href="#cb131-92" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.access], reflection member access queries</span>
-<span id="cb131-93"><a href="#cb131-93" aria-hidden="true" tabindex="-1"></a>  class access_context {</span>
-<span id="cb131-94"><a href="#cb131-94" aria-hidden="true" tabindex="-1"></a>    info <em>context_</em>; // exposition-only</span>
-<span id="cb131-95"><a href="#cb131-95" aria-hidden="true" tabindex="-1"></a>  public:</span>
-<span id="cb131-96"><a href="#cb131-96" aria-hidden="true" tabindex="-1"></a>    consteval access_context();</span>
-<span id="cb131-97"><a href="#cb131-97" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb131-98"><a href="#cb131-98" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-99"><a href="#cb131-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_accessible(info r, access_context from = {});</span>
-<span id="cb131-100"><a href="#cb131-100" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-101"><a href="#cb131-101" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_members_of(info target, access_context from = {});</span>
-<span id="cb131-102"><a href="#cb131-102" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_bases_of(info target, access_context from = {});</span>
-<span id="cb131-103"><a href="#cb131-103" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_nonstatic_data_members_of(info target,</span>
-<span id="cb131-104"><a href="#cb131-104" aria-hidden="true" tabindex="-1"></a>                                                              access_context from = {});</span>
-<span id="cb131-105"><a href="#cb131-105" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_static_data_members_of(info target,</span>
-<span id="cb131-106"><a href="#cb131-106" aria-hidden="true" tabindex="-1"></a>                                                           access_context from = {});</span>
-<span id="cb131-107"><a href="#cb131-107" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_subobjects_of(info target, access_context from = {});</span>
-<span id="cb131-108"><a href="#cb131-108" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-109"><a href="#cb131-109" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
-<span id="cb131-110"><a href="#cb131-110" aria-hidden="true" tabindex="-1"></a>  consteval size_t offset_of(info entity);</span>
-<span id="cb131-111"><a href="#cb131-111" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info entity);</span>
-<span id="cb131-112"><a href="#cb131-112" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info entity);</span>
-<span id="cb131-113"><a href="#cb131-113" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_offset_of(info entity);</span>
-<span id="cb131-114"><a href="#cb131-114" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info entity);</span>
-<span id="cb131-115"><a href="#cb131-115" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-116"><a href="#cb131-116" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
-<span id="cb131-117"><a href="#cb131-117" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb131-118"><a href="#cb131-118" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
-<span id="cb131-119"><a href="#cb131-119" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-120"><a href="#cb131-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
-<span id="cb131-121"><a href="#cb131-121" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-122"><a href="#cb131-122" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb131-123"><a href="#cb131-123" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-124"><a href="#cb131-124" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb131-125"><a href="#cb131-125" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-126"><a href="#cb131-126" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
-<span id="cb131-127"><a href="#cb131-127" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
-<span id="cb131-128"><a href="#cb131-128" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
-<span id="cb131-129"><a href="#cb131-129" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-130"><a href="#cb131-130" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb131-131"><a href="#cb131-131" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
-<span id="cb131-132"><a href="#cb131-132" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb131-133"><a href="#cb131-133" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
-<span id="cb131-134"><a href="#cb131-134" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
-<span id="cb131-135"><a href="#cb131-135" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
-<span id="cb131-136"><a href="#cb131-136" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-137"><a href="#cb131-137" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-138"><a href="#cb131-138" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R&amp;&amp; args);</span>
-<span id="cb131-139"><a href="#cb131-139" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R1 = initializer_list&lt;info&gt;, reflection_range R2 = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-140"><a href="#cb131-140" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R1&amp;&amp; tmpl_args, R2&amp;&amp; args);</span>
-<span id="cb131-141"><a href="#cb131-141" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-142"><a href="#cb131-142" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define_class], class definition generation</span>
-<span id="cb131-143"><a href="#cb131-143" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
-<span id="cb131-144"><a href="#cb131-144" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
-<span id="cb131-145"><a href="#cb131-145" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;u8string, T&gt;</span>
-<span id="cb131-146"><a href="#cb131-146" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb131-147"><a href="#cb131-147" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-148"><a href="#cb131-148" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;string, T&gt;</span>
-<span id="cb131-149"><a href="#cb131-149" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb131-150"><a href="#cb131-150" aria-hidden="true" tabindex="-1"></a>    };</span>
-<span id="cb131-151"><a href="#cb131-151" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-152"><a href="#cb131-152" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
-<span id="cb131-153"><a href="#cb131-153" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
-<span id="cb131-154"><a href="#cb131-154" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; width;</span>
-<span id="cb131-155"><a href="#cb131-155" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
-<span id="cb131-156"><a href="#cb131-156" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb131-157"><a href="#cb131-157" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
-<span id="cb131-158"><a href="#cb131-158" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
-<span id="cb131-159"><a href="#cb131-159" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-160"><a href="#cb131-160" aria-hidden="true" tabindex="-1"></a>  consteval info define_class(info type_class, R&amp;&amp;);</span>
-<span id="cb131-161"><a href="#cb131-161" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-162"><a href="#cb131-162" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
-<span id="cb131-163"><a href="#cb131-163" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type);</span>
-<span id="cb131-164"><a href="#cb131-164" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_null_pointer(info type);</span>
-<span id="cb131-165"><a href="#cb131-165" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_integral(info type);</span>
-<span id="cb131-166"><a href="#cb131-166" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_floating_point(info type);</span>
-<span id="cb131-167"><a href="#cb131-167" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_array(info type);</span>
-<span id="cb131-168"><a href="#cb131-168" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer(info type);</span>
-<span id="cb131-169"><a href="#cb131-169" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_lvalue_reference(info type);</span>
-<span id="cb131-170"><a href="#cb131-170" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_rvalue_reference(info type);</span>
-<span id="cb131-171"><a href="#cb131-171" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_object_pointer(info type);</span>
-<span id="cb131-172"><a href="#cb131-172" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_function_pointer(info type);</span>
-<span id="cb131-173"><a href="#cb131-173" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_enum(info type);</span>
-<span id="cb131-174"><a href="#cb131-174" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_union(info type);</span>
-<span id="cb131-175"><a href="#cb131-175" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_class(info type);</span>
-<span id="cb131-176"><a href="#cb131-176" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_function(info type);</span>
-<span id="cb131-177"><a href="#cb131-177" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reflection(info type);</span>
-<span id="cb131-178"><a href="#cb131-178" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-179"><a href="#cb131-179" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
-<span id="cb131-180"><a href="#cb131-180" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reference(info type);</span>
-<span id="cb131-181"><a href="#cb131-181" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_arithmetic(info type);</span>
-<span id="cb131-182"><a href="#cb131-182" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_fundamental(info type);</span>
-<span id="cb131-183"><a href="#cb131-183" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_object(info type);</span>
-<span id="cb131-184"><a href="#cb131-184" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scalar(info type);</span>
-<span id="cb131-185"><a href="#cb131-185" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_compound(info type);</span>
-<span id="cb131-186"><a href="#cb131-186" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_pointer(info type);</span>
-<span id="cb131-187"><a href="#cb131-187" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-188"><a href="#cb131-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
-<span id="cb131-189"><a href="#cb131-189" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_const(info type);</span>
-<span id="cb131-190"><a href="#cb131-190" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_volatile(info type);</span>
-<span id="cb131-191"><a href="#cb131-191" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivial(info type);</span>
-<span id="cb131-192"><a href="#cb131-192" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copyable(info type);</span>
-<span id="cb131-193"><a href="#cb131-193" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_standard_layout(info type);</span>
-<span id="cb131-194"><a href="#cb131-194" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_empty(info type);</span>
-<span id="cb131-195"><a href="#cb131-195" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_polymorphic(info type);</span>
-<span id="cb131-196"><a href="#cb131-196" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_abstract(info type);</span>
-<span id="cb131-197"><a href="#cb131-197" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_final(info type);</span>
-<span id="cb131-198"><a href="#cb131-198" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_aggregate(info type);</span>
-<span id="cb131-199"><a href="#cb131-199" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_signed(info type);</span>
-<span id="cb131-200"><a href="#cb131-200" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unsigned(info type);</span>
-<span id="cb131-201"><a href="#cb131-201" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_bounded_array(info type);</span>
-<span id="cb131-202"><a href="#cb131-202" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unbounded_array(info type);</span>
-<span id="cb131-203"><a href="#cb131-203" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scoped_enum(info type);</span>
-<span id="cb131-204"><a href="#cb131-204" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-205"><a href="#cb131-205" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-206"><a href="#cb131-206" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb131-207"><a href="#cb131-207" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_default_constructible(info type);</span>
-<span id="cb131-208"><a href="#cb131-208" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_constructible(info type);</span>
-<span id="cb131-209"><a href="#cb131-209" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_constructible(info type);</span>
-<span id="cb131-210"><a href="#cb131-210" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-211"><a href="#cb131-211" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_assignable(info type_dst, info type_src);</span>
-<span id="cb131-212"><a href="#cb131-212" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_assignable(info type);</span>
-<span id="cb131-213"><a href="#cb131-213" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_assignable(info type);</span>
-<span id="cb131-214"><a href="#cb131-214" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-215"><a href="#cb131-215" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable_with(info type_dst, info type_src);</span>
-<span id="cb131-216"><a href="#cb131-216" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable(info type);</span>
-<span id="cb131-217"><a href="#cb131-217" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-218"><a href="#cb131-218" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_destructible(info type);</span>
-<span id="cb131-219"><a href="#cb131-219" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-220"><a href="#cb131-220" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-221"><a href="#cb131-221" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_trivially_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb131-222"><a href="#cb131-222" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_default_constructible(info type);</span>
-<span id="cb131-223"><a href="#cb131-223" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_constructible(info type);</span>
-<span id="cb131-224"><a href="#cb131-224" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_constructible(info type);</span>
-<span id="cb131-225"><a href="#cb131-225" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-226"><a href="#cb131-226" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_assignable(info type_dst, info type_src);</span>
-<span id="cb131-227"><a href="#cb131-227" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_assignable(info type);</span>
-<span id="cb131-228"><a href="#cb131-228" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_assignable(info type);</span>
-<span id="cb131-229"><a href="#cb131-229" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_destructible(info type);</span>
-<span id="cb131-230"><a href="#cb131-230" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-231"><a href="#cb131-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-232"><a href="#cb131-232" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb131-233"><a href="#cb131-233" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_default_constructible(info type);</span>
-<span id="cb131-234"><a href="#cb131-234" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_constructible(info type);</span>
-<span id="cb131-235"><a href="#cb131-235" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_constructible(info type);</span>
-<span id="cb131-236"><a href="#cb131-236" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-237"><a href="#cb131-237" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_assignable(info type_dst, info type_src);</span>
-<span id="cb131-238"><a href="#cb131-238" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_assignable(info type);</span>
-<span id="cb131-239"><a href="#cb131-239" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_assignable(info type);</span>
-<span id="cb131-240"><a href="#cb131-240" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-241"><a href="#cb131-241" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable_with(info type_dst, info type_src);</span>
-<span id="cb131-242"><a href="#cb131-242" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable(info type);</span>
-<span id="cb131-243"><a href="#cb131-243" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-244"><a href="#cb131-244" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_destructible(info type);</span>
-<span id="cb131-245"><a href="#cb131-245" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-246"><a href="#cb131-246" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_implicit_lifetime(info type);</span>
-<span id="cb131-247"><a href="#cb131-247" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-248"><a href="#cb131-248" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_virtual_destructor(info type);</span>
-<span id="cb131-249"><a href="#cb131-249" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-250"><a href="#cb131-250" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_unique_object_representations(info type);</span>
-<span id="cb131-251"><a href="#cb131-251" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-252"><a href="#cb131-252" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_constructs_from_temporary(info type_dst, info type_src);</span>
-<span id="cb131-253"><a href="#cb131-253" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_converts_from_temporary(info type_dst, info type_src);</span>
-<span id="cb131-254"><a href="#cb131-254" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-255"><a href="#cb131-255" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
-<span id="cb131-256"><a href="#cb131-256" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_alignment_of(info type);</span>
-<span id="cb131-257"><a href="#cb131-257" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_rank(info type);</span>
-<span id="cb131-258"><a href="#cb131-258" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_extent(info type, unsigned i = 0);</span>
-<span id="cb131-259"><a href="#cb131-259" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-260"><a href="#cb131-260" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
-<span id="cb131-261"><a href="#cb131-261" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_same(info type1, info type2);</span>
-<span id="cb131-262"><a href="#cb131-262" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_base_of(info type_base, info type_derived);</span>
-<span id="cb131-263"><a href="#cb131-263" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_convertible(info type_src, info type_dst);</span>
-<span id="cb131-264"><a href="#cb131-264" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_convertible(info type_src, info type_dst);</span>
-<span id="cb131-265"><a href="#cb131-265" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_layout_compatible(info type1, info type2);</span>
-<span id="cb131-266"><a href="#cb131-266" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer_interconvertible_base_of(info type_base, info type_derived);</span>
-<span id="cb131-267"><a href="#cb131-267" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-268"><a href="#cb131-268" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-269"><a href="#cb131-269" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable(info type, R&amp;&amp; type_args);</span>
-<span id="cb131-270"><a href="#cb131-270" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-271"><a href="#cb131-271" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb131-272"><a href="#cb131-272" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-273"><a href="#cb131-273" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-274"><a href="#cb131-274" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable(info type, R&amp;&amp; type_args);</span>
-<span id="cb131-275"><a href="#cb131-275" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-276"><a href="#cb131-276" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb131-277"><a href="#cb131-277" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-278"><a href="#cb131-278" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
-<span id="cb131-279"><a href="#cb131-279" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_const(info type);</span>
-<span id="cb131-280"><a href="#cb131-280" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_volatile(info type);</span>
-<span id="cb131-281"><a href="#cb131-281" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cv(info type);</span>
-<span id="cb131-282"><a href="#cb131-282" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_const(info type);</span>
-<span id="cb131-283"><a href="#cb131-283" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_volatile(info type);</span>
-<span id="cb131-284"><a href="#cb131-284" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_cv(info type);</span>
-<span id="cb131-285"><a href="#cb131-285" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-286"><a href="#cb131-286" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
-<span id="cb131-287"><a href="#cb131-287" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_reference(info type);</span>
-<span id="cb131-288"><a href="#cb131-288" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_lvalue_reference(info type);</span>
-<span id="cb131-289"><a href="#cb131-289" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_rvalue_reference(info type);</span>
-<span id="cb131-290"><a href="#cb131-290" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-291"><a href="#cb131-291" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
-<span id="cb131-292"><a href="#cb131-292" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_signed(info type);</span>
-<span id="cb131-293"><a href="#cb131-293" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_unsigned(info type);</span>
-<span id="cb131-294"><a href="#cb131-294" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-295"><a href="#cb131-295" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
-<span id="cb131-296"><a href="#cb131-296" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_extent(info type);</span>
-<span id="cb131-297"><a href="#cb131-297" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_all_extents(info type);</span>
-<span id="cb131-298"><a href="#cb131-298" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-299"><a href="#cb131-299" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
-<span id="cb131-300"><a href="#cb131-300" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_pointer(info type);</span>
-<span id="cb131-301"><a href="#cb131-301" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_pointer(info type);</span>
-<span id="cb131-302"><a href="#cb131-302" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-303"><a href="#cb131-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
-<span id="cb131-304"><a href="#cb131-304" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cvref(info type);</span>
-<span id="cb131-305"><a href="#cb131-305" aria-hidden="true" tabindex="-1"></a>  consteval info type_decay(info type);</span>
-<span id="cb131-306"><a href="#cb131-306" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-307"><a href="#cb131-307" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_type(R&amp;&amp; type_args);</span>
-<span id="cb131-308"><a href="#cb131-308" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-309"><a href="#cb131-309" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_reference(R&amp;&amp; type_args);</span>
-<span id="cb131-310"><a href="#cb131-310" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
-<span id="cb131-311"><a href="#cb131-311" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb131-312"><a href="#cb131-312" aria-hidden="true" tabindex="-1"></a>    `consteval info type_invoke_result(info type, R&amp;&amp; type_args);</span>
-<span id="cb131-313"><a href="#cb131-313" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_reference(info type);</span>
-<span id="cb131-314"><a href="#cb131-314" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_ref_decay(info type);</span>
-<span id="cb131-315"><a href="#cb131-315" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<span id="cb131-53"><a href="#cb131-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
+<span id="cb131-54"><a href="#cb131-54" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
+<span id="cb131-55"><a href="#cb131-55" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
+<span id="cb131-56"><a href="#cb131-56" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
+<span id="cb131-57"><a href="#cb131-57" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
+<span id="cb131-58"><a href="#cb131-58" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
+<span id="cb131-59"><a href="#cb131-59" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info entity);</span>
+<span id="cb131-60"><a href="#cb131-60" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info entity);</span>
+<span id="cb131-61"><a href="#cb131-61" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
+<span id="cb131-62"><a href="#cb131-62" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
+<span id="cb131-63"><a href="#cb131-63" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
+<span id="cb131-64"><a href="#cb131-64" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
+<span id="cb131-65"><a href="#cb131-65" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-66"><a href="#cb131-66" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member(info r);</span>
+<span id="cb131-67"><a href="#cb131-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
+<span id="cb131-68"><a href="#cb131-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
+<span id="cb131-69"><a href="#cb131-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
+<span id="cb131-70"><a href="#cb131-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
+<span id="cb131-71"><a href="#cb131-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
+<span id="cb131-72"><a href="#cb131-72" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
+<span id="cb131-73"><a href="#cb131-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
+<span id="cb131-74"><a href="#cb131-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
+<span id="cb131-75"><a href="#cb131-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
+<span id="cb131-76"><a href="#cb131-76" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-77"><a href="#cb131-77" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
+<span id="cb131-78"><a href="#cb131-78" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
+<span id="cb131-79"><a href="#cb131-79" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
+<span id="cb131-80"><a href="#cb131-80" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
+<span id="cb131-81"><a href="#cb131-81" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
+<span id="cb131-82"><a href="#cb131-82" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
+<span id="cb131-83"><a href="#cb131-83" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
+<span id="cb131-84"><a href="#cb131-84" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-85"><a href="#cb131-85" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
+<span id="cb131-86"><a href="#cb131-86" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info type);</span>
+<span id="cb131-87"><a href="#cb131-87" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
+<span id="cb131-88"><a href="#cb131-88" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
+<span id="cb131-89"><a href="#cb131-89" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
+<span id="cb131-90"><a href="#cb131-90" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; subobjects_of(info type);</span>
+<span id="cb131-91"><a href="#cb131-91" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
+<span id="cb131-92"><a href="#cb131-92" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-93"><a href="#cb131-93" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.access], reflection member access queries</span>
+<span id="cb131-94"><a href="#cb131-94" aria-hidden="true" tabindex="-1"></a>  class access_context {</span>
+<span id="cb131-95"><a href="#cb131-95" aria-hidden="true" tabindex="-1"></a>    info <em>context_</em>; // exposition-only</span>
+<span id="cb131-96"><a href="#cb131-96" aria-hidden="true" tabindex="-1"></a>  public:</span>
+<span id="cb131-97"><a href="#cb131-97" aria-hidden="true" tabindex="-1"></a>    consteval access_context();</span>
+<span id="cb131-98"><a href="#cb131-98" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb131-99"><a href="#cb131-99" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-100"><a href="#cb131-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_accessible(info r, access_context from = {});</span>
+<span id="cb131-101"><a href="#cb131-101" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-102"><a href="#cb131-102" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_members_of(info target, access_context from = {});</span>
+<span id="cb131-103"><a href="#cb131-103" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_bases_of(info target, access_context from = {});</span>
+<span id="cb131-104"><a href="#cb131-104" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_nonstatic_data_members_of(info target,</span>
+<span id="cb131-105"><a href="#cb131-105" aria-hidden="true" tabindex="-1"></a>                                                              access_context from = {});</span>
+<span id="cb131-106"><a href="#cb131-106" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_static_data_members_of(info target,</span>
+<span id="cb131-107"><a href="#cb131-107" aria-hidden="true" tabindex="-1"></a>                                                           access_context from = {});</span>
+<span id="cb131-108"><a href="#cb131-108" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; accessible_subobjects_of(info target, access_context from = {});</span>
+<span id="cb131-109"><a href="#cb131-109" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-110"><a href="#cb131-110" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
+<span id="cb131-111"><a href="#cb131-111" aria-hidden="true" tabindex="-1"></a>  consteval size_t offset_of(info entity);</span>
+<span id="cb131-112"><a href="#cb131-112" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info entity);</span>
+<span id="cb131-113"><a href="#cb131-113" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info entity);</span>
+<span id="cb131-114"><a href="#cb131-114" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_offset_of(info entity);</span>
+<span id="cb131-115"><a href="#cb131-115" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info entity);</span>
+<span id="cb131-116"><a href="#cb131-116" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-117"><a href="#cb131-117" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
+<span id="cb131-118"><a href="#cb131-118" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-119"><a href="#cb131-119" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
+<span id="cb131-120"><a href="#cb131-120" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-121"><a href="#cb131-121" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
+<span id="cb131-122"><a href="#cb131-122" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-123"><a href="#cb131-123" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb131-124"><a href="#cb131-124" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-125"><a href="#cb131-125" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb131-126"><a href="#cb131-126" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-127"><a href="#cb131-127" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
+<span id="cb131-128"><a href="#cb131-128" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
+<span id="cb131-129"><a href="#cb131-129" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
+<span id="cb131-130"><a href="#cb131-130" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-131"><a href="#cb131-131" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-132"><a href="#cb131-132" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
+<span id="cb131-133"><a href="#cb131-133" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-134"><a href="#cb131-134" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
+<span id="cb131-135"><a href="#cb131-135" aria-hidden="true" tabindex="-1"></a>  template &lt;typename T&gt;</span>
+<span id="cb131-136"><a href="#cb131-136" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
+<span id="cb131-137"><a href="#cb131-137" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-138"><a href="#cb131-138" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-139"><a href="#cb131-139" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R&amp;&amp; args);</span>
+<span id="cb131-140"><a href="#cb131-140" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R1 = initializer_list&lt;info&gt;, reflection_range R2 = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-141"><a href="#cb131-141" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R1&amp;&amp; tmpl_args, R2&amp;&amp; args);</span>
+<span id="cb131-142"><a href="#cb131-142" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-143"><a href="#cb131-143" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define_class], class definition generation</span>
+<span id="cb131-144"><a href="#cb131-144" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
+<span id="cb131-145"><a href="#cb131-145" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
+<span id="cb131-146"><a href="#cb131-146" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;u8string, T&gt;</span>
+<span id="cb131-147"><a href="#cb131-147" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb131-148"><a href="#cb131-148" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-149"><a href="#cb131-149" aria-hidden="true" tabindex="-1"></a>      template &lt;typename T&gt; requires constructible_from&lt;string, T&gt;</span>
+<span id="cb131-150"><a href="#cb131-150" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb131-151"><a href="#cb131-151" aria-hidden="true" tabindex="-1"></a>    };</span>
+<span id="cb131-152"><a href="#cb131-152" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-153"><a href="#cb131-153" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
+<span id="cb131-154"><a href="#cb131-154" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
+<span id="cb131-155"><a href="#cb131-155" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; width;</span>
+<span id="cb131-156"><a href="#cb131-156" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
+<span id="cb131-157"><a href="#cb131-157" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb131-158"><a href="#cb131-158" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
+<span id="cb131-159"><a href="#cb131-159" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
+<span id="cb131-160"><a href="#cb131-160" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-161"><a href="#cb131-161" aria-hidden="true" tabindex="-1"></a>  consteval info define_class(info type_class, R&amp;&amp;);</span>
+<span id="cb131-162"><a href="#cb131-162" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-163"><a href="#cb131-163" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
+<span id="cb131-164"><a href="#cb131-164" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type);</span>
+<span id="cb131-165"><a href="#cb131-165" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_null_pointer(info type);</span>
+<span id="cb131-166"><a href="#cb131-166" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_integral(info type);</span>
+<span id="cb131-167"><a href="#cb131-167" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_floating_point(info type);</span>
+<span id="cb131-168"><a href="#cb131-168" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_array(info type);</span>
+<span id="cb131-169"><a href="#cb131-169" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer(info type);</span>
+<span id="cb131-170"><a href="#cb131-170" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_lvalue_reference(info type);</span>
+<span id="cb131-171"><a href="#cb131-171" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_rvalue_reference(info type);</span>
+<span id="cb131-172"><a href="#cb131-172" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_object_pointer(info type);</span>
+<span id="cb131-173"><a href="#cb131-173" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_function_pointer(info type);</span>
+<span id="cb131-174"><a href="#cb131-174" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_enum(info type);</span>
+<span id="cb131-175"><a href="#cb131-175" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_union(info type);</span>
+<span id="cb131-176"><a href="#cb131-176" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_class(info type);</span>
+<span id="cb131-177"><a href="#cb131-177" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_function(info type);</span>
+<span id="cb131-178"><a href="#cb131-178" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reflection(info type);</span>
+<span id="cb131-179"><a href="#cb131-179" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-180"><a href="#cb131-180" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
+<span id="cb131-181"><a href="#cb131-181" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reference(info type);</span>
+<span id="cb131-182"><a href="#cb131-182" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_arithmetic(info type);</span>
+<span id="cb131-183"><a href="#cb131-183" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_fundamental(info type);</span>
+<span id="cb131-184"><a href="#cb131-184" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_object(info type);</span>
+<span id="cb131-185"><a href="#cb131-185" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scalar(info type);</span>
+<span id="cb131-186"><a href="#cb131-186" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_compound(info type);</span>
+<span id="cb131-187"><a href="#cb131-187" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_pointer(info type);</span>
+<span id="cb131-188"><a href="#cb131-188" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-189"><a href="#cb131-189" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
+<span id="cb131-190"><a href="#cb131-190" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_const(info type);</span>
+<span id="cb131-191"><a href="#cb131-191" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_volatile(info type);</span>
+<span id="cb131-192"><a href="#cb131-192" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivial(info type);</span>
+<span id="cb131-193"><a href="#cb131-193" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copyable(info type);</span>
+<span id="cb131-194"><a href="#cb131-194" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_standard_layout(info type);</span>
+<span id="cb131-195"><a href="#cb131-195" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_empty(info type);</span>
+<span id="cb131-196"><a href="#cb131-196" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_polymorphic(info type);</span>
+<span id="cb131-197"><a href="#cb131-197" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_abstract(info type);</span>
+<span id="cb131-198"><a href="#cb131-198" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_final(info type);</span>
+<span id="cb131-199"><a href="#cb131-199" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_aggregate(info type);</span>
+<span id="cb131-200"><a href="#cb131-200" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_signed(info type);</span>
+<span id="cb131-201"><a href="#cb131-201" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unsigned(info type);</span>
+<span id="cb131-202"><a href="#cb131-202" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_bounded_array(info type);</span>
+<span id="cb131-203"><a href="#cb131-203" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unbounded_array(info type);</span>
+<span id="cb131-204"><a href="#cb131-204" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scoped_enum(info type);</span>
+<span id="cb131-205"><a href="#cb131-205" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-206"><a href="#cb131-206" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-207"><a href="#cb131-207" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-208"><a href="#cb131-208" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_default_constructible(info type);</span>
+<span id="cb131-209"><a href="#cb131-209" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_constructible(info type);</span>
+<span id="cb131-210"><a href="#cb131-210" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_constructible(info type);</span>
+<span id="cb131-211"><a href="#cb131-211" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-212"><a href="#cb131-212" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_assignable(info type_dst, info type_src);</span>
+<span id="cb131-213"><a href="#cb131-213" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_assignable(info type);</span>
+<span id="cb131-214"><a href="#cb131-214" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_assignable(info type);</span>
+<span id="cb131-215"><a href="#cb131-215" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-216"><a href="#cb131-216" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable_with(info type_dst, info type_src);</span>
+<span id="cb131-217"><a href="#cb131-217" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable(info type);</span>
+<span id="cb131-218"><a href="#cb131-218" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-219"><a href="#cb131-219" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_destructible(info type);</span>
+<span id="cb131-220"><a href="#cb131-220" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-221"><a href="#cb131-221" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-222"><a href="#cb131-222" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_trivially_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-223"><a href="#cb131-223" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_default_constructible(info type);</span>
+<span id="cb131-224"><a href="#cb131-224" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_constructible(info type);</span>
+<span id="cb131-225"><a href="#cb131-225" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_constructible(info type);</span>
+<span id="cb131-226"><a href="#cb131-226" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-227"><a href="#cb131-227" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_assignable(info type_dst, info type_src);</span>
+<span id="cb131-228"><a href="#cb131-228" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_assignable(info type);</span>
+<span id="cb131-229"><a href="#cb131-229" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_assignable(info type);</span>
+<span id="cb131-230"><a href="#cb131-230" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_destructible(info type);</span>
+<span id="cb131-231"><a href="#cb131-231" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-232"><a href="#cb131-232" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-233"><a href="#cb131-233" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-234"><a href="#cb131-234" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_default_constructible(info type);</span>
+<span id="cb131-235"><a href="#cb131-235" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_constructible(info type);</span>
+<span id="cb131-236"><a href="#cb131-236" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_constructible(info type);</span>
+<span id="cb131-237"><a href="#cb131-237" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-238"><a href="#cb131-238" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_assignable(info type_dst, info type_src);</span>
+<span id="cb131-239"><a href="#cb131-239" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_assignable(info type);</span>
+<span id="cb131-240"><a href="#cb131-240" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_assignable(info type);</span>
+<span id="cb131-241"><a href="#cb131-241" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-242"><a href="#cb131-242" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable_with(info type_dst, info type_src);</span>
+<span id="cb131-243"><a href="#cb131-243" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable(info type);</span>
+<span id="cb131-244"><a href="#cb131-244" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-245"><a href="#cb131-245" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_destructible(info type);</span>
+<span id="cb131-246"><a href="#cb131-246" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-247"><a href="#cb131-247" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_implicit_lifetime(info type);</span>
+<span id="cb131-248"><a href="#cb131-248" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-249"><a href="#cb131-249" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_virtual_destructor(info type);</span>
+<span id="cb131-250"><a href="#cb131-250" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-251"><a href="#cb131-251" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_unique_object_representations(info type);</span>
+<span id="cb131-252"><a href="#cb131-252" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-253"><a href="#cb131-253" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_constructs_from_temporary(info type_dst, info type_src);</span>
+<span id="cb131-254"><a href="#cb131-254" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_converts_from_temporary(info type_dst, info type_src);</span>
+<span id="cb131-255"><a href="#cb131-255" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-256"><a href="#cb131-256" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
+<span id="cb131-257"><a href="#cb131-257" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_alignment_of(info type);</span>
+<span id="cb131-258"><a href="#cb131-258" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_rank(info type);</span>
+<span id="cb131-259"><a href="#cb131-259" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_extent(info type, unsigned i = 0);</span>
+<span id="cb131-260"><a href="#cb131-260" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-261"><a href="#cb131-261" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
+<span id="cb131-262"><a href="#cb131-262" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_same(info type1, info type2);</span>
+<span id="cb131-263"><a href="#cb131-263" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_base_of(info type_base, info type_derived);</span>
+<span id="cb131-264"><a href="#cb131-264" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_convertible(info type_src, info type_dst);</span>
+<span id="cb131-265"><a href="#cb131-265" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_convertible(info type_src, info type_dst);</span>
+<span id="cb131-266"><a href="#cb131-266" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_layout_compatible(info type1, info type2);</span>
+<span id="cb131-267"><a href="#cb131-267" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer_interconvertible_base_of(info type_base, info type_derived);</span>
+<span id="cb131-268"><a href="#cb131-268" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-269"><a href="#cb131-269" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-270"><a href="#cb131-270" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-271"><a href="#cb131-271" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-272"><a href="#cb131-272" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb131-273"><a href="#cb131-273" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-274"><a href="#cb131-274" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-275"><a href="#cb131-275" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-276"><a href="#cb131-276" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-277"><a href="#cb131-277" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb131-278"><a href="#cb131-278" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-279"><a href="#cb131-279" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
+<span id="cb131-280"><a href="#cb131-280" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_const(info type);</span>
+<span id="cb131-281"><a href="#cb131-281" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_volatile(info type);</span>
+<span id="cb131-282"><a href="#cb131-282" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cv(info type);</span>
+<span id="cb131-283"><a href="#cb131-283" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_const(info type);</span>
+<span id="cb131-284"><a href="#cb131-284" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_volatile(info type);</span>
+<span id="cb131-285"><a href="#cb131-285" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_cv(info type);</span>
+<span id="cb131-286"><a href="#cb131-286" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-287"><a href="#cb131-287" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
+<span id="cb131-288"><a href="#cb131-288" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_reference(info type);</span>
+<span id="cb131-289"><a href="#cb131-289" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_lvalue_reference(info type);</span>
+<span id="cb131-290"><a href="#cb131-290" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_rvalue_reference(info type);</span>
+<span id="cb131-291"><a href="#cb131-291" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-292"><a href="#cb131-292" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
+<span id="cb131-293"><a href="#cb131-293" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_signed(info type);</span>
+<span id="cb131-294"><a href="#cb131-294" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_unsigned(info type);</span>
+<span id="cb131-295"><a href="#cb131-295" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-296"><a href="#cb131-296" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
+<span id="cb131-297"><a href="#cb131-297" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_extent(info type);</span>
+<span id="cb131-298"><a href="#cb131-298" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_all_extents(info type);</span>
+<span id="cb131-299"><a href="#cb131-299" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-300"><a href="#cb131-300" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
+<span id="cb131-301"><a href="#cb131-301" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_pointer(info type);</span>
+<span id="cb131-302"><a href="#cb131-302" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_pointer(info type);</span>
+<span id="cb131-303"><a href="#cb131-303" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-304"><a href="#cb131-304" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
+<span id="cb131-305"><a href="#cb131-305" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cvref(info type);</span>
+<span id="cb131-306"><a href="#cb131-306" aria-hidden="true" tabindex="-1"></a>  consteval info type_decay(info type);</span>
+<span id="cb131-307"><a href="#cb131-307" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-308"><a href="#cb131-308" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_type(R&amp;&amp; type_args);</span>
+<span id="cb131-309"><a href="#cb131-309" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-310"><a href="#cb131-310" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_reference(R&amp;&amp; type_args);</span>
+<span id="cb131-311"><a href="#cb131-311" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
+<span id="cb131-312"><a href="#cb131-312" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb131-313"><a href="#cb131-313" aria-hidden="true" tabindex="-1"></a>    `consteval info type_invoke_result(info type, R&amp;&amp; type_args);</span>
+<span id="cb131-314"><a href="#cb131-314" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_reference(info type);</span>
+<span id="cb131-315"><a href="#cb131-315" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_ref_decay(info type);</span>
+<span id="cb131-316"><a href="#cb131-316" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6543,42 +6562,42 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <div class="addu">
 <div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view name_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8name_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">1</a></span>
 <em>Constant When</em>: If returning
 <code class="sourceCode cpp">string_view</code>, the unqualified name is
 representable using the ordinary string literal encoding.
 <code class="sourceCode cpp">r</code> represents a declared entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">2</a></span>
 <em>Returns</em>: The unqualified name of the entity designated by
 <code class="sourceCode cpp">r</code>. If this entity has no name, then
 an empty <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
 <div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view qualified_name_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8qualified_name_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">3</a></span>
 <em>Constant When</em>: If returning
 <code class="sourceCode cpp">string_view</code>, the qualified name is
 representable using the ordinary string literal encoding.
 <code class="sourceCode cpp">r</code> represents a declared entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">4</a></span>
 <em>Returns</em>: The qualified name of the entity designated by
 <code class="sourceCode cpp">r</code>. If this entity has no name, then
 an empty <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
 <div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">5</a></span>
 <em>Constant When</em>: If returning
 <code class="sourceCode cpp">string_view</code>, the
 implementation-defined name is representable using the ordinary string
 literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">6</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively,
 suitable for identifying the reflected construct.</p>
 <div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">7</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">source_location</code> corresponding to the
 reflected construct.</p>
@@ -6593,14 +6612,14 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
 class that is public, protected, or private, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -6608,7 +6627,7 @@ function or a virtual base class. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -6616,28 +6635,28 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 defined as deleted ([dcl.fct.def.delete]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 defined as defaulted ([dcl.fct.def.default]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -6652,7 +6671,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -6670,14 +6689,14 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -6687,7 +6706,7 @@ function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> designates a lvalue- or
@@ -6695,7 +6714,7 @@ rvalue-reference qualified function type (respectively), or a member
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -6705,7 +6724,7 @@ that has static storage duration. Otherwise,
 <span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb148-3"><a href="#cb148-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb148-4"><a href="#cb148-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity that has
@@ -6713,61 +6732,61 @@ internal linkage, module linkage, external linkage, or any linkage,
 respectively ([basic.link]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function or member
 function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a type alias.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias, alias
 template, or namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_incomplete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">19</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">20</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 type designated by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, or alias template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">23</a></span>
 <span class="note"><span>[ <em>Note 3:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -6779,24 +6798,25 @@ is
 <span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-4"><a href="#cb156-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb156-5"><a href="#cb156-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb156-6"><a href="#cb156-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb156-7"><a href="#cb156-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">24</a></span>
+<span id="cb156-5"><a href="#cb156-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-6"><a href="#cb156-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-7"><a href="#cb156-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-8"><a href="#cb156-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
-class template, variable template, alias template, concept, structured
-binding, or value respectively. Otherwise,
+class template, variable template, alias template, constructor template,
+concept, structured binding, or value respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an instantiation of a
@@ -6808,7 +6828,7 @@ template. Otherwise,
 <span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-5"><a href="#cb159-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -6816,7 +6836,7 @@ namespace member, non-static data member, static member, or base class
 member, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">28</a></span>
 <em>Returns</em>
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
@@ -6831,19 +6851,20 @@ member that has a default member initializer. Otherwise,
 <span id="cb161-7"><a href="#cb161-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb161-8"><a href="#cb161-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb161-9"><a href="#cb161-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a special member
-function, constructor, default constructor, copy constructor, move
-constructor, assignment operator, copy assignment operator, move
-assignment operator, or destructor, respectively. Otherwise,
+function, non-template constructor, default constructor, copy
+constructor, move constructor, assignment operator, copy assignment
+operator, move assignment operator, or destructor, respectively.
+Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">30</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a function.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a user-provided
@@ -6851,11 +6872,11 @@ a function.</p>
 function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">32</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a typed entity. <code class="sourceCode cpp">r</code> does not designate
 a constructor, destructor, or structured binding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">33</a></span>
 <em>Returns</em>: A reflection of the type of that entity. If every
 declaration of that entity was declared with the same type alias (but
 not a template parameter substituted by a type alias), the reflection
@@ -6865,20 +6886,20 @@ reflection returned is for that alias or for the type underlying that
 alias. Otherwise, the reflection returned shall not be a type alias
 reflection.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">34</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating either an object or a variable denoting an object
 with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">35</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">36</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating either an object or variable usable in constant
 expressions ([expr.const]), an enumerator, or a value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">37</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of an object <code class="sourceCode cpp">o</code>, or a
 reflection of a variable which designates an object
@@ -6890,18 +6911,18 @@ with the cv-qualifiers removed if this is a scalar type. Otherwise, if
 then a reflection of the value of the enumerator. Otherwise,
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">38</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a member of either a class or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">39</a></span>
 <em>Returns</em>: A reflection of that entity’s immediately enclosing
 class or namespace.</p>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">40</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 type alias or a namespace alias, a reflection designating the underlying
 entity. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">41</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">41</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb168"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -6913,15 +6934,15 @@ entity. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 </div>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">42</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">43</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization designated by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
 <div class="sourceCode" id="cb170"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -6943,14 +6964,14 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating either a complete class type or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">2</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">3</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of all the direct members
 <code class="sourceCode cpp">m</code> of the entity, excluding any
@@ -6961,14 +6982,14 @@ kinds of members is unspecified. <span class="note"><span>[ <em>Note
 1:</em> </span>Base classes are not members.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code> is a
 reflection designating a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">5</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">6</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 designated by <code class="sourceCode cpp">type</code>. A
 <code class="sourceCode cpp">vector</code> containing the reflections of
@@ -6978,47 +6999,47 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code>
 designates a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">8</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">9</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the static data members of the type
 designated by <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code>
 designates a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">11</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">12</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the non-static data members of the type
 designated by <code class="sourceCode cpp">type</code>, in the order in
 which they are declared.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> subobjects_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">13</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code> is a
 reflection designating a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">14</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">15</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing all the reflections in <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 followed by all the reflections in <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">16</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type_enum</code> is
 a reflection designating an enumeration.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">17</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 designated by <code class="sourceCode cpp">type_enum</code>, in the
@@ -7036,22 +7057,22 @@ order in which they are declared.</p>
 <span id="cb177-3"><a href="#cb177-3" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
 <span id="cb177-4"><a href="#cb177-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> access_context<span class="op">()</span>;</span>
 <span id="cb177-5"><a href="#cb177-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">1</a></span>
 The type <code class="sourceCode cpp">access_context</code> is suitable
 for ensuring that only accessible members are reflected on.</p>
 <div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context<span class="op">::</span>access_context<span class="op">()</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp">context_</code> to a reflection of the
 function, class, or namespace scope most nearly enclosing the function
 call.</p>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a member of a class.
 <code class="sourceCode cpp">from</code> represents a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 class member designated by <code class="sourceCode cpp">target</code>
@@ -7059,32 +7080,32 @@ can be named within the scope of <code class="sourceCode cpp">from<span class="o
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_members_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
 <code class="sourceCode cpp">from</code> represents a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">6</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">7</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_bases_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">8</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
 <code class="sourceCode cpp">from</code> represents a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">9</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">10</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
@@ -7092,16 +7113,16 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_nonstatic_data_members_of<span class="op">(</span>info target,</span>
 <span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a>                                                            access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">11</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
 <code class="sourceCode cpp">from</code> designates a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">12</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">13</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
@@ -7109,23 +7130,23 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_static_data_members_of<span class="op">(</span>info target,</span>
 <span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a>                                                         access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">14</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code> is a
 reflection designating a complete class type.
 <code class="sourceCode cpp">from</code> designates a function, class,
 or namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">15</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 designates a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>target<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_accessible<span class="op">(</span>e, from<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> accessible_subobjects_of<span class="op">(</span>info target, access_context from <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">17</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing all the reflections in <code class="sourceCode cpp">accessible_bases_of<span class="op">(</span>target, from<span class="op">)</span></code>
 followed by all the reflections in <code class="sourceCode cpp">accessible_nonstatic_data_members_of<span class="op">(</span>target, from<span class="op">)</span></code>.</p>
@@ -7138,30 +7159,30 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a non-static data member or non-virtual base
 class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">2</a></span>
 <em>Returns</em>: The offset in bytes from the beginning of an object of
 type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity reflected by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, non-static data member, base class, object, value,
 or variable.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">4</a></span>
 <em>Returns</em> If <code class="sourceCode cpp">r</code> represents a
 type <code class="sourceCode cpp">T</code>, then <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span></code>.
 Otherwise, <code class="sourceCode cpp">size_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating an object, variable, type, non-static data
 member, or base class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 type, object, or variable, then the alignment requirement of the entity.
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
@@ -7169,23 +7190,23 @@ class, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>ty
 Otherwise, the alignment requirement of the subobject associated with
 the reflected non-static data member within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a non-static data member or a non-virtual base
 class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">8</a></span>
 Let <code class="sourceCode cpp">V</code> be the offset in bits from the
 beginning of an object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity reflected by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">9</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">V <span class="op">-</span> offset_of<span class="op">(</span>r<span class="op">)</span> <span class="op">*</span> CHAR_BIT</code>.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, non-static data member, base class, object, value,
 or variable.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">11</a></span>
 <em>Returns</em> If <code class="sourceCode cpp">r</code> represents a
 type, then the size in bits of any object having the reflected type.
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
@@ -7201,7 +7222,7 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="addu">
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb190-2"><a href="#cb190-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection designating a value, object, variable, function, enumerator,
 or non-static data member that is not a bit-field. If
@@ -7228,7 +7249,7 @@ then the statement <code class="sourceCode cpp">T v <span class="op">=</span> <s
 where <code class="sourceCode cpp">expr</code> is an lvalue naming the
 entity designated by <code class="sourceCode cpp">r</code>, is
 well-formed.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">2</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value or enumerator, then the entity reflected by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -7259,36 +7280,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb191-5"><a href="#cb191-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb192-2"><a href="#cb192-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template designated by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities or aliases designated by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template designated by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities or aliases designated by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -7300,13 +7321,13 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">T</code> is a
 structural type that is not a reference type. Any subobject of the value
 computed by <code class="sourceCode cpp">expr</code> having reference or
 pointer type designates an entity that is a permitted result of a
 constant expression ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">2</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the reflected
@@ -7314,19 +7335,19 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">T</code> is not a
 function type. <code class="sourceCode cpp">expr</code> designates an
 entity that is a permitted result of a constant expression.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">4</a></span>
 <em>Returns</em>: A reflection of the object referenced by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">T</code> is a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function referenced by
@@ -7335,7 +7356,7 @@ function type.</p>
 <span id="cb197-2"><a href="#cb197-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
 <span id="cb197-3"><a href="#cb197-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb197-4"><a href="#cb197-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">7</a></span>
 Let <code class="sourceCode cpp">F</code> be the entity reflected by
 <code class="sourceCode cpp">target</code>, let
 <code class="sourceCode cpp">Arg0</code> be the entity reflected by the
@@ -7346,7 +7367,7 @@ the sequence of entities reflected by the elements of
 <code class="sourceCode cpp">TArgs<span class="op">...</span></code> be
 the sequence of entities or aliases designated by the elements of
 <code class="sourceCode cpp">tmpl_args</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">8</a></span>
 If <code class="sourceCode cpp">F</code> is a non-member function, a
 value of pointer to function type, a value of pointer to member type, or
 a value of closure type, then let
@@ -7376,7 +7397,7 @@ considered by overload resolution, and
 <code class="sourceCode cpp">TArgs<span class="op">...</span></code> are
 inferred as explicit template arguments for
 <code class="sourceCode cpp">F</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">target</code>
 represents a function, a constructor, a constructor template, a value,
 or a function template. If <code class="sourceCode cpp">target</code>
@@ -7385,7 +7406,7 @@ represents a value of type <code class="sourceCode cpp">T</code>, then
 pointer to member type, or closure type. The expression
 <code class="sourceCode cpp">INVOKE<span class="op">-</span>EXPR</code>
 is a well-formed constant expression of structural type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">10</a></span>
 <em>Returns</em>: A reflection of the result of the expression
 <code class="sourceCode cpp">INVOKE<span class="op">-</span>EXPR</code>.</p>
 </div>
@@ -7398,7 +7419,7 @@ Reflection class definition generation<a href="#meta.reflection.define_class-ref
 <div class="addu">
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">type</code>
 represents a type. If
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
@@ -7407,12 +7428,12 @@ contains a value, the <code class="sourceCode cpp">string</code> or
 initialize
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a valid identifier (<span>5.10 <a href="https://wg21.link/lex.name">[lex.name]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">2</a></span>
 <em>Returns</em>: A reflection of a description of the declaration of
 non-static data member with a type designated by
 <code class="sourceCode cpp">type</code> and optional characteristics
 designated by <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">3</a></span>
 <em>Remarks</em>: The reflection value being returned is only useful for
 consumption by <code class="sourceCode cpp">define_class</code>. No
 other function in
@@ -7420,7 +7441,7 @@ other function in
 recognizes such a value.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span>  mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">4</a></span>
 Let <code class="sourceCode cpp"><em>d</em><sub>1</sub></code>,
 <code class="sourceCode cpp"><em>d</em><sub>2</sub></code>, …,
 <code class="sourceCode cpp"><em>d</em><sub>N</sub></code> denote the
@@ -7436,7 +7457,7 @@ reflection values of the range
 <code class="sourceCode cpp"><em>o</em><sub>2</sub></code>, …
 <code class="sourceCode cpp"><em>o</em><sub>N</sub></code>
 respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">class_type</code>
 represents an incomplete class type.
 <code class="sourceCode cpp">mdescrs</code> is a (possibly empty) range
@@ -7458,43 +7479,43 @@ is a valid
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> for a
 non-static data member of type
 <code class="sourceCode cpp"><em>t</em><sub>K</sub></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">6</a></span>
 <em>Effects</em>: Defines <code class="sourceCode cpp">class_type</code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(6.1)</a></span>
 If <code class="sourceCode cpp">class_type</code> represents a
 specialization of a class template, the specialization is explicitly
 specialized.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(6.2)</a></span>
 Non-static data members are declared in the definition of
 <code class="sourceCode cpp">class_type</code> according to
 <code class="sourceCode cpp"><em>d</em><sub>1</sub></code>,
 <code class="sourceCode cpp"><em>d</em><sub>2</sub></code>, …,
 <code class="sourceCode cpp"><em>d</em><sub>N</sub></code>, in that
 order.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(6.3)</a></span>
 The type of the respective members are the types represented by the
 reflection values
 <code class="sourceCode cpp"><em>t</em><sub>1</sub></code>,
 <code class="sourceCode cpp"><em>t</em><sub>2</sub></code>, …
 <code class="sourceCode cpp"><em>t</em><sub>N</sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(6.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(6.4)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>no_unique_address</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) is
 <code class="sourceCode cpp"><span class="kw">true</span></code>, the
 corresponding member is declared with attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(6.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(6.5)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>width</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) contains a
 value, the corresponding member is declared as a bit field with that
 value as its width.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(6.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(6.6)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>alignment</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) contains a
 value <code class="sourceCode cpp"><em>a</em></code>, the corresponding
 member is aligned as if declared with <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><em>a</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(6.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(6.7)</a></span>
 If <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>name</code>
 (for some <code class="sourceCode cpp"><em>K</em></code>) does not
 contain a value, the corresponding member is declared with an
@@ -7503,7 +7524,7 @@ declared with a name corresponding to the
 <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> value that was used to
 initialize <code class="sourceCode cpp"><em>o</em><sub>K</sub><span class="op">.</span>name</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(6.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(6.8)</a></span>
 If <code class="sourceCode cpp">class_type</code> is a union type and
 any of its members is not trivially default constructible, then it has a
 default constructor that is user-provided and has no effect. If
@@ -7511,7 +7532,7 @@ default constructor that is user-provided and has no effect. If
 of its members is not trivially default destructible, then it has a
 default destructor that is user-provided and has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -7521,10 +7542,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -7543,7 +7564,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
@@ -7564,7 +7585,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb200-13"><a href="#cb200-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb200-14"><a href="#cb200-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb200-15"><a href="#cb200-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb201"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -7590,7 +7611,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
@@ -7611,21 +7632,21 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7708,14 +7729,14 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>PROP</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.6 <a href="https://wg21.link/meta.unary.prop.query">[meta.unary.prop.query]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 unsigned integer value <code class="sourceCode cpp">I</code>, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_extent<span class="op">(^</span>T, I<span class="op">)</span></code>
 equals <code class="sourceCode cpp">std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span></code>
@@ -7731,17 +7752,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em></code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7751,7 +7772,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7777,7 +7798,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb205-14"><a href="#cb205-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb205-15"><a href="#cb205-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb205-16"><a href="#cb205-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -7799,7 +7820,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -7811,7 +7832,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
@@ -7831,7 +7852,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
@@ -7848,7 +7869,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
@@ -7864,7 +7885,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
@@ -7880,7 +7901,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
@@ -7906,14 +7927,14 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause with signature <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>to<span class="op">&lt;</span>vector<span class="op">&gt;(</span>r<span class="op">)</span> <span class="op">==</span> vector<span class="op">{^</span>T<span class="op">...}</span></code>
@@ -7922,7 +7943,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -7942,7 +7963,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb211-9"><a href="#cb211-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb211-10"><a href="#cb211-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb211-11"><a href="#cb211-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>

--- a/2996_reflection/d2996r5.html
+++ b/2996_reflection/d2996r5.html
@@ -4654,8 +4654,9 @@ determined in the following way:</p>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 its associated set of entities is the singleton containing the function
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>is_type</code>.</span>
-If <code class="sourceCode cpp">T</code> is any <span class="addu">other</span> fundamental type, its associated set of
-entities is empty.</li>
+If <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
+other</span> fundamental type, its associated set of entities is
+empty.</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_10" id="pnum_10">(3.2)</a></span>
 If <code class="sourceCode cpp">T</code> is a class type …</li>
 </ul>
@@ -4794,7 +4795,7 @@ A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<s
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
 <ul>
-<li>a value with structural type,</li>
+<li>a value with structural type ([temp.param]),</li>
 <li>an object with static storage duration,</li>
 <li>a variable,</li>
 <li>a structured binding,</li>
@@ -4928,13 +4929,16 @@ The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
 <code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
 shall designate a namespace or namespace alias.</p>
 </div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">2</a></span>
+The component names of a
+<code class="sourceCode cpp"><em>qualified-id</em></code> are […]</p>
 </blockquote>
 </div>
 <p>Clarify that a splice cannot appear in a declarative
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">3</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -4957,11 +4961,11 @@ be a friend declaration or inhabit a scope that contains the entity
 being redeclared or specialized.</p>
 </blockquote>
 </div>
-<p>Extend paragraph 3 to also cover splices, and prefer the verb
+<p>Extend the next paragraph to also cover splices, and prefer the verb
 “designate” over “nominate”:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">4</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <code class="sourceCode cpp">​<span class="op">::</span></code>​ <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
@@ -4998,23 +5002,23 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <div class="sourceCode" id="cb110"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
 <span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
 <span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">1</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 let <code class="sourceCode cpp">E</code> be the value of the converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> of the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(1.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(1.1)</a></span>
 If <code class="sourceCode cpp">E</code> is a reflection for an object,
 a function which is not a constructor or destructor, a non-static data
 member, or a structured binding, the expression is an lvalue denoting
 the reflected entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(1.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">E</code> is a reflection for
 a variable or a structured binding, the expression is an lvalue denoting
 the object designated by the reflected entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(1.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(1.3)</a></span>
 Otherwise, <code class="sourceCode cpp">E</code> shall be a reflection
 of a value or an enumerator, and the expression is a prvalue whose
 evaluation computes the reflected value.</p></li>
@@ -5050,7 +5054,7 @@ access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -5072,7 +5076,7 @@ note</em> ]</span></span></p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">2</a></span>
 For the first option, if the <span class="addu">dot is followed by
 an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or
@@ -5095,7 +5099,7 @@ the remainder of [expr.ref] will address only the first option
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">3</a></span>
 The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -5107,7 +5111,7 @@ determines the result of the entire postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">4</a></span>
 Abbreviating <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>postfix-expression</em></code></span>.<span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span>EXPR</code>,
 where <code class="sourceCode cpp">EXPR</code> is the
@@ -5131,7 +5135,7 @@ General<a href="#expr.unary.general-general" class="self-link"></a></h3>
 paragraph 1 to add productions for the new operator:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb112"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -5160,16 +5164,16 @@ template argument parsing section.</p>
 <span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
 <span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
 <span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a>   ^ <em>id-expression</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">2</a></span>
 A <em>reflect-expression</em> is parsed as the longest possible sequence
 of tokens that could syntactically form a
 <em>reflect-expression</em>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb114"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
@@ -5187,7 +5191,7 @@ of tokens that could syntactically form a
 <span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">4</a></span>
 When applied to
 <code class="sourceCode cpp"><span class="op">::</span></code>, the
 reflection operator produces a reflection for the global namespace. When
@@ -5195,30 +5199,30 @@ applied to a
 <code class="sourceCode cpp"><em>namespace-name</em></code>, the
 reflection operator produces a reflection for the indicated namespace or
 namespace alias.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">5</a></span>
 When applied to a
 <code class="sourceCode cpp"><em>template-name</em></code>, the
 reflection operator produces a reflection for the indicated
 template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">6</a></span>
 When applied to a
 <code class="sourceCode cpp"><em>concept-name</em></code>, the
 reflection operator produces a reflection for the indicated concept.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">7</a></span>
 When applied to a <code class="sourceCode cpp"><em>type-id</em></code>,
 the reflection operator produces a reflection for the indicated type
 alias if the <code class="sourceCode cpp"><em>type-id</em></code> is a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, otherwise a
 reflection of the indicated type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">8</a></span>
 When applied to an
 <code class="sourceCode cpp"><em>id-expression</em></code>, the
 reflection operator produces a reflection as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">(8.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">(8.1)</a></span>
 When applied to an enumerator, the reflection operator produces a
 reflection of the enumerator designated by the operand.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">(8.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">(8.2)</a></span>
 Otherwise, when applied to an overload set
 <code class="sourceCode cpp">S</code>, if the assignment of
 <code class="sourceCode cpp">S</code> to an invented variable of type
@@ -5230,19 +5234,19 @@ would select a unique candidate function
 <code class="sourceCode cpp">F</code>. Otherwise, the expression
 <code class="sourceCode cpp"><span class="op">^</span>S</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">(8.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">(8.3)</a></span>
 Otherwise, when applied to one of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">(8.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">(8.3.1)</a></span>
 a non-type template parameter of non-class and non-reference type
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">(8.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">(8.3.2)</a></span>
 a <code class="sourceCode cpp"><em>pack-index-expression</em></code> of
 non-class and non-reference type</li>
 </ul>
 <p>the reflection operator produces a reflection of the value computed
 by the operand.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">(8.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(8.4)</a></span>
 Otherwise, the reflection operator produces a reflection of the
 variable, function, or non-static member designated by the operand. The
 <code class="sourceCode cpp"><em>id-expression</em></code> is not
@@ -5269,7 +5273,7 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
 pointer-to-member type, or <span class="rm" style="color: #bf0303"><del>type</del></span> <span class="addu">one of
 the types <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -5288,57 +5292,57 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between <span>7.6.10 <a href="https://wg21.link/expr.eq">[expr.eq]</a></span>/5 and /6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">5</a></span>
 Two operands of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">*</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(*.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(*.1)</a></span>
 If both operands are null reflection values, then they compare
 equal.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(*.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(*.2)</a></span>
 Otherwise, if one operand is a null reflection value, then they compare
 unequal.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(*.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(*.3)</a></span>
 Otherwise, if one operand is a reflection of a namespace alias, alias
 template, or type alias and the other operand is not a reflection of the
 same kind of alias, they compare unequal. <span class="note"><span>[ <em>Note 1:</em> </span>A reflection of a type and
 a reflection of an alias to that same type do not compare equal.<span>
 — <em>end note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(*.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(*.4)</a></span>
 Otherwise, if both operands are reflections of a namespace alias, alias
 template, or type alias, then they compare equal if their reflected
 aliases share the same name, are declared within the same enclosing
 scope, and alias the same underlying entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(*.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(*.5)</a></span>
 Otherwise, if both operands are reflections of a base class specifier,
 then they compare equal if they are reflections of the same base class
 specifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(*.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(*.6)</a></span>
 Otherwise, if one operand is a reflection of a base class specifier and
 the other is not, then they compare unequal.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(*.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">(*.7)</a></span>
 Otherwise, if neither operand is a reflection of a value, then they
 compare equal if they are reflections of the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">(*.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">(*.8)</a></span>
 Otherwise, if one operand is a reflection of a value and the other is
 not, then they compare unequal.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">(*.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(*.9)</a></span>
 Otherwise, if both operands are reflections of values, then they compare
 equal if and only if the reflected values are
 <em>template-argument-equivalent</em> (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(*.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">(*.10)</a></span>
 Otherwise the result is unspecified. <span class="note"><span>[ <em>Note
 2:</em> </span>For example, if the operands are results of calls to
 <code class="sourceCode cpp">data_member_spec</code><span> — <em>end
 note</em> ]</span></span></li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -5360,26 +5364,26 @@ constant-evaluated</em> <span>7.7 <a href="https://wg21.link/expr.const">[expr.c
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">21</a></span>
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(21.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(21.4)</a></span>
 an immediate invocation, unless it
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(21.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(21.4.1)</a></span>
 results from the substitution of template parameters
 <ul>
 <li>during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
@@ -5390,7 +5394,7 @@ results from the substitution of template parameters
 (<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>),
 or</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(21.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">(21.4.2)</a></span>
 is a manifestly constant-evaluated initializer of a variable that is
 neither
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
@@ -5408,7 +5412,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 <p>Introduce the term “type alias” to <span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.typedef]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">1</a></span>
 […] A name declared with the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
 specifier becomes a typedef-name. A typedef-name names the type
@@ -5416,7 +5420,7 @@ associated with the identifier ([dcl.decl]) or simple-template-id
 ([temp.pre]); a typedef-name is thus a synonym for another type. A
 typedef-name does not introduce a new type the way a class declaration
 ([class.name]) or enum declaration ([dcl.enum]) does.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">2</a></span>
 A <em>typedef-name</em> can also be introduced by an alias-declaration.
 The identifier following the using keyword is not looked up; it becomes
 a typedef-name and the optional attribute-specifier-seq following the
@@ -5424,7 +5428,7 @@ identifier appertains to that typedef-name. Such a typedef-name has the
 same semantics as if it were introduced by the typedef specifier. In
 particular, it does not define a new type.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">*</a></span>
 A <em>type alias</em> is either a name declared with the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
 specifier or a name introduced by an <em>alias-declaration</em>.</p>
@@ -5457,16 +5461,14 @@ follows:</p>
 <div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
 <span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">1</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
 may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">2</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
-designate a type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">3</a></span>
-The type designated by the
+designate a type. The type designated by the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
-the type designated by the
+the same type designated by the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
 </blockquote>
@@ -5487,10 +5489,9 @@ To <em>zero-initialize</em> an object or reference of type
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(6.1)</a></span>
-if <code class="sourceCode cpp">T</code> is any scalar type
-([basic.types.general]) <span class="addu">other than <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code></span>,
-the object is initialized to the value obtained by converting the
-integer literal
+if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
+other</span> scalar type ([basic.types.general]), the object is
+initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(6.2)</a></span>
@@ -5680,23 +5681,24 @@ scope.</p>
 follow:</p>
 <div class="std">
 <blockquote>
-<p>[<em>Note 2</em>: A
+<p><span class="note2"><span>[ <em>Note 2:</em> </span>A
 <code class="sourceCode cpp"><em>using-directive</em></code> makes the
 names in the <span class="rm" style="color: #bf0303"><del>nominated</del></span> <span class="addu">designated</span> namespace usable in the scope […]. During
 unqualified name lookup, the names appear as if they were declared in
 the nearest enclosing namespace which contains both the
 <code class="sourceCode cpp"><em>using-directive</em></code> and the
 <span class="rm" style="color: #bf0303"><del>nomindated</del></span>
-<span class="addu">designated</span> namespace. — <em>end note</em>]</p>
+<span class="addu">designated</span> namespace.<span> — <em>end
+note</em> ]</span></span></p>
 <p>[…]</p>
-<p>[<em>Note 4</em>: A
+<p><span class="note4"><span>[ <em>Note 4:</em> </span>A
 <code class="sourceCode cpp"><em>using-directive</em></code> is
 transitive: if a scope contains a
 <code class="sourceCode cpp"><em>using-directive</em></code> that <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> a namespace that itself contains
 <code class="sourceCode cpp"><em>using-directives</em></code>, the
 namespaces <span class="rm" style="color: #bf0303"><del>nominated</del></span> <span class="addu">designated</span> by those
 <code class="sourceCode cpp"><em>using-directives</em></code> are also
-eligible to be considered. — <em>end note</em>]</p>
+eligible to be considered.<span> — <em>end note</em> ]</span></span></p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -293,7 +293,7 @@ This example also illustrates that bit fields are not beyond the reach of this p
 On Compiler Explorer: [EDG](https://godbolt.org/z/WEYae451z), [Clang](https://godbolt.org/z/dYGaMKEx5).
 
 Note that a "member access splice" like `s.[:member_number(1):]` is a more direct member access mechanism than the traditional syntax.
-It doesn't involve member name lookup, access checking, or --- if the spliced reflection value denotes a member function --- overload resolution.
+It doesn't involve member name lookup, access checking, or --- if the spliced reflection value represents a member function --- overload resolution.
 
 This proposal includes a number of consteval "metafunctions" that enable the introspection of various language constructs.
 Among those metafunctions is `std::meta::nonstatic_data_members_of` which returns a vector of reflection values that describe the non-static members of a given type.
@@ -319,7 +319,7 @@ On Compiler Explorer: [EDG](https://godbolt.org/z/Wb1vx7jqb), [Clang](https://go
 
 This proposal specifies that namespace `std::meta` is associated with the reflection type (`std::meta::info`); the `std::meta::` qualification can therefore be omitted in the example above.
 
-Another frequently-useful metafunction is `std::meta::name_of`, which returns a `std::string_view` describing the unqualified name of an entity denoted by a given reflection value.
+Another frequently-useful metafunction is `std::meta::name_of`, which returns a `std::string_view` describing the unqualified name of an entity represented by a given reflection value.
 With such a facility, we could conceivably access non-static data members "by string":
 
 ::: std
@@ -1466,7 +1466,7 @@ For most members, this doesn't even require any additional wording since that's 
 
 Now, there are a couple interesting cases to point out when `&[:r:]` isn't just the same as `&X::f`.
 
-When `r` is a reflection of a function or function template that is part of an overload set, overload resolution will not consider the whole overload set, just the specific function or function template that `r` reflects:
+When `r` is a reflection of a function or function template that is part of an overload set, overload resolution will not consider the whole overload set, just the specific function or function template that `r` represents:
 
 ::: std
 ```cpp
@@ -1569,7 +1569,7 @@ template <std::meta::info R> struct Outer {
 };
 ```
 
-What kind of parameter is `S`? If `R` reflects a class template, then it is a non-type template parameter of deduced type, but if `R` reflects a concept, it is a type template parameter. There is no other circumstance in the language for which it is not possible to decide at parse time whether a template parameter is a type or a non-type, and we don't wish to introduce one for this use case.
+What kind of parameter is `S`? If `R` represents a class template, then it is a non-type template parameter of deduced type, but if `R` represents a concept, it is a type template parameter. There is no other circumstance in the language for which it is not possible to decide at parse time whether a template parameter is a type or a non-type, and we don't wish to introduce one for this use case.
 
 The most obvious solution would be to introduce a `concept [:R:]` syntax that requires that `R` reflect a concept, and while this could be added going forward, we weren't convinced of its value at this time - especially since the above can easily be rewritten:
 
@@ -1767,7 +1767,7 @@ static_assert(^:: == parent_of(^::std));
 ```
 :::
 
-When the `^` operator is followed by an _id-expression_, the resulting `std::meta::info` reflects the entity named by the expression. Such reflections are equivalent only if they reflect the same entity.
+When the `^` operator is followed by an _id-expression_, the resulting `std::meta::info` represents the entity named by the expression. Such reflections are equivalent only if they reflect the same entity.
 
 ::: std
 ```c++
@@ -2347,7 +2347,7 @@ namespace std::meta {
 
 If a `string_view` is returned, its contents consist of characters representable by the ordinary string literal encoding only; if any character cannot be represented, it is not a constant expression. If the class of reflected entity cannot possibly have a name, the expression fails to be a constant expression.
 
-Given a reflection `r` that designates a declared entity `X`, `name_of(r)` and `qualified_name_of` return a `string_view` holding the unqualified and qualified name of `X`, respectively. `u8name_of(r)` and `u8qualified_name_of` return the same, respectively, as a `u8string_view`.
+Given a reflection `r` that represents a declared entity `X`, `name_of(r)` and `qualified_name_of` return a `string_view` holding the unqualified and qualified name of `X`, respectively. `u8name_of(r)` and `u8qualified_name_of` return the same, respectively, as a `u8string_view`.
 For all other reflections, an empty string view is produced.
 For template instances, the name does not include the template argument list.
 
@@ -2383,9 +2383,9 @@ consteval auto type_doof(std::meta::info r) -> std::meta::info {
 ```
 :::
 
-If `r` designates a member of a class or namespace, `parent_of(r)` is a reflection designating its immediately enclosing class or (possibly inline or anonymous) namespace.
+If `r` represents a member of a class or namespace, `parent_of(r)` is a reflection designating its immediately enclosing class or (possibly inline or anonymous) namespace.
 
-If `r` designates an alias, `dealias(r)` designates the underlying entity.
+If `r` represents an alias, `dealias(r)` represents the underlying entity.
 Otherwise, `dealias(r)` produces `r`.
 `dealias` is recursive - it strips all aliases:
 
@@ -2934,13 +2934,13 @@ Change the grammar for `$operator-or-punctuator$` in paragraph 1 of [lex.operato
 Modify paragraph 4.1 to cover splicing of functions:
 
 ::: std
-- [4.1]{.pnum} A function is named by an expression or conversion if it is the selected member of an overload set ([basic.lookup], [over.match], [over.over]) in an overload resolution performed as part of forming that expression or conversion, [or if it is denoted by a _splice-expression_ ([expr.prim.splice]),]{.addu} unless it is a pure virtual function and either the expression is not an _id-expression_ naming the function with an explicitly qualified name or the expression forms a pointer to member ([expr.unary.op]).
+- [4.1]{.pnum} A function is named by an expression or conversion if it is the selected member of an overload set ([basic.lookup], [over.match], [over.over]) in an overload resolution performed as part of forming that expression or conversion, [or if it is designated by a _splice-expression_ ([expr.prim.splice]),]{.addu} unless it is a pure virtual function and either the expression is not an _id-expression_ naming the function with an explicitly qualified name or the expression forms a pointer to member ([expr.unary.op]).
 :::
 
 Modify the first sentence of paragraph 5 to cover splicing of variables:
 
 ::: std
-- [5]{.pnum} A variable is named by an expression if the expression is an _id-expression_ [or _splice-expression_ ([expr.prim.splice])]{.addu} that denotes it.
+- [5]{.pnum} A variable is named by an expression if the expression is an _id-expression_ [or _splice-expression_ ([expr.prim.splice])]{.addu} that designates it.
 :::
 
 Modify paragraph 6 to cover splicing of structured bindings:
@@ -2955,7 +2955,7 @@ Prepend before paragraph 15 of [basic.def.odr]{.sref}:
 
 ::: addu
 
-[15pre]{.pnum} If a class `C` is defined in a translation unit with a call to `std::meta::define_class`, every definition of that class shall be the result of a call to `std::meta::define_class` such that its respective members are equal in number and have respectively the same types, alignments, `[[no_unique_address]]` attributes (if any), bit-field widths (if any), and specified names (if any).
+[15pre]{.pnum} If a class `C` is defined in a translation unit with a call to `std::meta::define_class`, every definition of that class shall be the result of a call to `std::meta::define_class` such that its corresponding members are equal in number and have respectively the same types, alignments, `[[no_unique_address]]` attributes (if any), bit-field widths (if any), and specified names (if any).
 
 :::
 
@@ -2965,18 +2965,13 @@ Prepend before paragraph 15 of [basic.def.odr]{.sref}:
 
 ### [basic.lookup.argdep]{.sref} Argument-dependent name lookup {-}
 
-Add a bullet to paragraph 3 of [basic.lookup.argdep]{.sref} as follows [this must precede the fundamental type bullet, because `meta::info` is a fundamental type]{.ednote}:
+Modify the first bullet of paragraph 3 of [basic.lookup.argdep]{.sref} as follows:
 
 ::: std
 
 [3]{.pnum} ... Any `$typedef-name$`s and `$using-declaration$`s used to specify the types do not contribute to this set. The set of entities is determined in the following way:
 
-::: addu
-
-- [3.0]{.pnum} If `T` is `std::meta::info`, its associated set of entities is the singleton containing the function `std::meta::is_type`.
-
-:::
-- [3.1]{.pnum} If `T` is a fundamental type, its associated set of entities is empty.
+- [3.1]{.pnum} [If `T` is `std::meta::info`, its associated set of entities is the singleton containing the function `std::meta::is_type`.]{.addu} If `T` is any [other]{.addu} fundamental type, its associated set of entities is empty.
 - [3.2]{.pnum} If `T` is a class type ...
 
 :::
@@ -3013,7 +3008,7 @@ has its linkage determined as follows:
 
 * [4.7]{.pnum} if the enclosing namespace has internal linkage, the name has internal linkage;
 * [4.8]{.pnum} otherwise, if the declaration of the name is attached to a named module ([module.unit]) and is not exported ([module.interface]), the name has module linkage;
-* [4.9]{.pnum} [otherwise, if the declaration is a variable having _consteval-only type_ ([basic.types.general]), or is of a class template specialization type having a _consteval-only type_ as a non-type template argument, the name has internal linkage.]{.addu}
+* [4.9]{.pnum} [otherwise, if the declaration introduces a variable whose type is a consteval-only type ([basic.types.general]) or a class template specialization where one or more non-type template arguments are of consteval-only type, the name has internal linkage.]{.addu}
 * [4.10]{.pnum} otherwise, the name has external linkage.
 
 :::
@@ -3036,11 +3031,11 @@ Add a new paragraph at the end of [basic.types.general]{.sref} as follows:
   - `std::meta::info`, or
   - a pointer or reference to a consteval-only type, or
   - an (possibly multi-dimensional) array of a consteval-only type, or
-  - a pointer-to-member type to a class `C` of type `M` where either `C` or `M` is a consteval-only type, or
-  - a function type with a consteval-only return type or a consteval-only parameter type, or
-  - a class type with a consteval-only base class type or consteval-only non-static data member type.
+  - a class type with a base class or non-static data member of consteval-only type, or
+  - a function type with a return type or parameter type of consteval-only type, or
+  - a pointer-to-member type to a class `C` of type `M` where either `C` or `M` is a consteval-only type.
 
-An object of consteval-only type shall either end its lifetime during the evaluation of a manifestly constant-evaluated expression or conversion ([expr.const]{.sref}), or be a constexpr variable that is not odr-used ([basic.def.odr]{.sref}).
+An object of consteval-only type shall either end its lifetime during the evaluation of a manifestly constant-evaluated expression or conversion ([expr.const]{.sref}), or be a constexpr variable for which every expression that names the variable is within an immediate function context.
 
 [*]{.pnum} Consteval-only types may not be used to declare a static data member of a class having module or external linkage. Furthermore, specializations of a class template having a non-type template argument of consteval-only type may not be used to declare a static data member of a class having module or external linkage.
 
@@ -3054,29 +3049,24 @@ Add a new paragraph before the last paragraph of [basic.fundamental]{.sref} as f
 ::: std
 ::: addu
 
-[17 - 2]{.pnum} A value of type `std::meta::info` is called a _reflection_ and represents a language element such as a type, a value, an object, a non-static data member, etc. An expression convertible to `std::meta::info` is said to _reflect_ the language element represented by the resulting value; the language element is said to be _reflected by_ the expression.
-`sizeof(std::meta::info)` shall be equal to `sizeof(void*)`.
-[Reflections are only meaningful during translation.
-The notion of consteval-only types (see [basic.types.general]{.sref}) exists to diagnose attempts at using such values outside the translation process.]{.note}
+[17 - 1]{.pnum} A value of type `std::meta::info` is called a _reflection_. There exists a unique _null reflection_; every other reflection is a representation of
 
-[17 - 1]{.pnum} Every value of type `std::meta::info` is either a reflection of:
-
-* a value,
-* an object,
-* a reference,
-* a structured bindings,
+* a value with structural type,
+* an object with static storage duration,
+* a variable,
+* a structured binding,
 * a function,
 * an enumerator,
 * a type,
 * a class member,
 * a bit-field,
-* a template,
-* a template specialization,
+* a class template, function template, variable template, alias template, or concept,
 * a namespace,
-* a pack,
-* an alias or description of any of the above,
+* an alias of a type or namespace,
 * a base specifier, or
-* a *null reflection value*.
+* a description of a non-static data member.
+
+An expression convertible to a reflection is said to _represent_ the corresponding entity, variable, alias, base specifier, or description of a non-static data member.
 
 :::
 :::
@@ -3114,7 +3104,9 @@ $splice-specifier$:
 
 [1]{.pnum} The `$constant-expression$` of a `$splice-specifier$` shall be a converted constant expression ([expr.const]) contextually convertible to `std::meta::info`.
 
-[2]{.pnum} Let `E` be the value of the converted `$constant-expression$`. A `$splice-specifier$` designates what `E` represents.
+[2]{.pnum} Let `E` be the value of the converted `$constant-expression$`. The `$splice-specifier$` designates what `E` represents.
+
+[3]{.pnum} A `$splice-specifier$` is dependent if the converted `$constant-expression$` is value-dependent.
 :::
 :::
 
@@ -3145,28 +3137,41 @@ Add a production to the grammar for `$nested-name-specifier$` as follows:
       ::
       $type-name$ ::
       $namespace-name$ ::
-      $computed-type-specifier$ ::
 +     $splice-namespace-qualifier$ ::
+      $computed-type-specifier$ ::
       $nested-name-specifier$ $identifier$ ::
       $nested-name-specifier$ template@~_opt_~@ $simple-template-id$ ::
 +
 + $splice-namespace-qualifier$:
-+     [: $constant-expression$ :]
++     $splice-specifier$
 ```
 :::
 
-Add a restriction to [expr.prim.id.qual]{.sref} for the constraint on `$constant-expression$`.
+Add a new paragraph restricting `$splice-namespace-qualifier$`, and renumber accordingly:
 
 ::: std
 ::: addu
-[0]{.pnum} For a `$splice-namespace-qualifier$`, the `$constant-expression$` shall be a converted constant expression of type `std::meta::info` that is a reflection of either a namespace or a namespace alias.
+[1]{.pnum} The `$splice-specifier$` of a `$splice-namespace-qualifier$` shall designate a namespace or namespace alias.
 :::
 :::
 
-Extend [expr.prim.id.qual]{.sref}/3 to also cover splices:
+Clarify that a splice cannot appear in a declarative `$nested-name-specifier$`:
 
 ::: std
-[3]{.pnum} The `$nested-name-specifier$` `​::`​ nominates the global namespace. A `$nested-name-specifier$` with a `$computed-type-specifier$` nominates the type denoted by the `$computed-type-specifier$`, which shall be a class or enumeration type. [A `$nested-name-specifier$` with a `$splice-namespace-qualifier$` nominates the entity reflected by the `$constant-expression$` of the `$splice-namespace-qualifier$`.]{.addu} If a nested-name-specifier N is declarative and has a simple-template-id with a template argument list A that involves a template parameter, let T be the template nominated by N without A. T shall be a class template.
+[3]{.pnum} A `$nested-name-specifier$` is _declarative_ if it is part of
+
+* a `$class-head-name$`,
+* an `$enum-head-name$`,
+* a `$qualified-id$` that is the `$id-expression$` of a `$declarator-id$`, or
+* a declarative `$nested-name-specifier$`.
+
+A declarative `$nested-name-specifier$` shall not have a `$decltype-specifier$` [or a `$splice-specifier$`]{.addu}. A declaration that uses a declarative `$nested-name-specifier$` shall be a friend declaration or inhabit a scope that contains the entity being redeclared or specialized.
+:::
+
+Extend paragraph 3 to also cover splices, and prefer the verb "designate" over "nominate":
+
+::: std
+[3]{.pnum} The `$nested-name-specifier$` `​::`​ [nominates]{.rm} [designates]{.addu} the global namespace. A `$nested-name-specifier$` with a `$computed-type-specifier$` [nominates]{.rm} [designates]{.addu} the type denoted by the `$computed-type-specifier$`, which shall be a class or enumeration type. [A `$nested-name-specifier$` with a `$splice-namespace-qualifier$` [nominates]{.rm} [designates]{.addu} the same namespace or namespace alias as the `$splice-namespace-qualifier$`.]{.addu} If a `$nested-name-specifier$` _N_ is declarative and has a `$simple-template-id$` with a template argument list _A_ that involves a template parameter, let _T_ be the template [nominated]{.rm} [designated]{.addu} by _N_ without _A_. _T_ shall be a class template.
 
 ...
 
@@ -3228,13 +3233,13 @@ Modify paragraph 1 to account for splices in member access expressions:
 Modify paragraph 2 to account for splices in member access expressions:
 
 ::: std
-[2]{.pnum} For the first option, if the [dot is followed by an]{.addu} `$id-expression$` [names]{.rm} [ or `$splice-expression$` naming]{.addu} a static member or an enumerator, the first expression is a discarded-value expression ([expr.context]); if the `$id-expression$` [or `$splice-expression$`]{.addu} names a non-static data member, the first expression shall be a glvalue. For the second option (arrow), the first expression shall be a prvalue having pointer type. The expression E1->E2 is converted to the equivalent form (*(E1)).E2; the remainder of [expr.ref] will address only the first option (dot).
+[2]{.pnum} For the first option, if the [dot is followed by an]{.addu} `$id-expression$` [names]{.rm} [ or `$splice-expression$` designating]{.addu} a static member or an enumerator, the first expression is a discarded-value expression ([expr.context]); if the `$id-expression$` [or `$splice-expression$` designates]{.addu} [names]{.rm} a non-static data member, the first expression shall be a glvalue. For the second option (arrow), the first expression shall be a prvalue having pointer type. The expression `E1->E2` is converted to the equivalent form `(*(E1)).E2`; the remainder of [expr.ref] will address only the first option (dot).
 :::
 
 Modify paragraph 3 to account for splices in member access expressions:
 
 ::: std
-[3]{.pnum} The postfix expression before the dot is evaluated the result of that evaluation, together with the `$id-expression$` [or `$splice-expression$`]{.addu}, determines the result of the entire postfix expression.
+[3]{.pnum} The postfix expression before the dot is evaluated; the result of that evaluation, together with the `$id-expression$` [or `$splice-expression$`]{.addu}, determines the result of the entire postfix expression.
 :::
 
 Modify paragraph 4 to account for splices in member access expressions:
@@ -3278,7 +3283,7 @@ $reflect-expression$:
    ^ $id-expression$
 ```
 
-[#]{.pnum} The unary `^` operator, called the _reflection operator_, yields a prvalue of type `std::meta::info`. The result is called a _reflection_ and it represents its operand.
+[#]{.pnum} The unary `^` operator, called the _reflection operator_, yields a prvalue of type `std::meta::info` ([basic.fundamental]{.sref}).
 
 [#]{.pnum} A _reflect-expression_ is parsed as the longest possible sequence of tokens that could syntactically form a _reflect-expression_.
 
@@ -3391,10 +3396,11 @@ Add a new paragraph after the definition of _manifestly constant-evaluated_ [exp
 * [#.#]{.pnum} the condition of a constexpr if statement ([stmt.if]{.sref}),
 * [#.#]{.pnum} the initializer of a `constexpr` ([dcl.constexpr]{.sref}) or `constinit` ([dcl.constinit]{.sref}) variable, or
 * [#.#]{.pnum} an immediate invocation, unless it
-
-  * [#.#.#]{.pnum} results from the substitution of template parameters in a `$concept-id$` ([temp.names]{.sref}), a `$requires-expression$` ([expr.prim.req]{.sref}), or during template argument deduction ([temp.deduct]{.sref}), or
+  * [#.#.#]{.pnum} results from the substitution of template parameters
+    * during template argument deduction ([temp.deduct]{.sref}),
+    * in a `$concept-id$` ([temp.names]{.sref}), or
+    * in a `$requires-expression$` ([expr.prim.req]{.sref}), or
   * [#.#.#]{.pnum} is a manifestly constant-evaluated initializer of a variable that is neither  `constexpr` ([dcl.constexpr]{.sref}) nor `constinit` ([dcl.constinit]{.sref}).
-
 
 :::
 :::
@@ -3423,15 +3429,6 @@ Extend the grammar for `$computed-type-specifier$` as follows:
      $decltype-specifier$
      $pack-index-specifier$
 +    $splice-type-specifier$
-
-
-+ $splice-enum-name$:
-+    [: $constant-expression$ :]
-+
-  $using-enum-declarator$:
-     $nested-name-specifier$@~_opt_~@ $identifier$
-     $nested-name-specifier$@~_opt_~@ $simple-template-id$
-+    $splice-enum-name$
 ```
 :::
 
@@ -3443,27 +3440,26 @@ Add a new subsection of [dcl.type]{.sref} following [dcl.type.class.deduct]{.sre
 ::: addu
 ```diff
 +  $splice-type-specifier$
-+      typename [: $constant-expression$ :]
-+      [: $constant-expression$ :]
++      typename@~_opt_~@ $splice-specifier$
 ```
 
-[#]{.pnum} The `$constant-expression$` shall be a converted constant expression ([expr.const]{.sref}) of type `std::meta::info`.
+[#]{.pnum} The `typename` may be omitted only within a type-only context ([temp.res.general]{.sref}).
 
-[#]{.pnum} The form `[: $constant-expression$ :]` shall only be parsed as a `$splice-type-specifier$` within a _type-only context_ ([temp.res.general]{.sref}).
+[#]{.pnum} The `$splice-specifier$` shall designate a type.
 
-[#]{.pnum} The `$constant-expression$` shall evaluate to a reflection of a type, and the type designated by the `$splice-type-specifier$` is the same as the type reflected by the `$constant-expression$`.
+[#]{.pnum} The type designated by the `$splice-type-specifier$` is the type designated by the `$splice-specifier$`.
 :::
 :::
 
 ### [dcl.init.general]{.sref} Initializers (General) {-}
 
-Change paragraphs 6-9 of [dcl.init.general]{.sref} [No changes are necessary for value-initialization, which already forwards to zero-initialization for scalar types]{.ednote}:
+Change paragraphs 6-7 of [dcl.init.general]{.sref} [No changes are necessary for value-initialization, which already forwards to zero-initialization for scalar types]{.ednote}:
 
 ::: std
 [6]{.pnum} To *zero-initialize* an object or reference of type `T` means:
 
-* [6.0]{.pnum} [if `T` is `std::meta::info`, the object is initialied to a null reflection value;]{.addu}
-* [6.1]{.pnum} if `T` is a scalar type ([basic.types.general]), the object is initialized to the value obtained by converting the integer literal `0` (zero) to `T`;
+* [6.0]{.pnum} [if `T` is `std::meta::info`, the object is initialized to a null reflection value;]{.addu}
+* [6.1]{.pnum} if `T` is any scalar type ([basic.types.general]) [other than `std::meta::info`]{.addu}, the object is initialized to the value obtained by converting the integer literal `0` (zero) to `T`;
 * [6.2]{.pnum} [...]
 
 [7]{.pnum} To *default-initialize* an object of type `T` means:
@@ -3472,12 +3468,6 @@ Change paragraphs 6-9 of [dcl.init.general]{.sref} [No changes are necessary for
 * [7.2]{.pnum} If T is an array type, [...]
 * [7.*]{.pnum} [If `T` is `std::meta::info`, the object is zero-initialized.]{.addu}
 * [7.3]{.pnum} Otherwise, no initialization is performed.
-
-[8]{.pnum} A class type `T` is *const-default-constructible* if [`T` is `std::meta::info`,]{.addu} default-initialization of `T` would invoke a user-provided constructor of T (not inherited from a base class)[,]{.addu} or if
-
-* [8.1]{.pnum} [...]
-
-[9]{.pnum} To value-initialize an object of type T means: [...]
 :::
 
 ### [dcl.fct]{.sref} Functions {-}
@@ -3515,13 +3505,10 @@ Extend the grammar for `$using-enum-declarator$` as follows:
   $using-enum-declaration$:
      using enum $using-enum-declarator$ ;
 
-+ $splice-enum-name$:
-+    [: $constant-expression$ :]
-+
   $using-enum-declarator$:
      $nested-name-specifier$@~_opt_~@ $identifier$
      $nested-name-specifier$@~_opt_~@ $simple-template-id$
-+    $splice-enum-name$
++    $splice-specifier$
 ```
 :::
 
@@ -3529,32 +3516,73 @@ Modify paragraph 1 of [enum.udecl]{.sref} as follows:
 
 ::: std
 
-[1]{.pnum} A `$using-enum-declarator$` [not consisting of a `$splice-enum-name$`]{.addu} names the set of declarations found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}) for the `$using-enum-declarator$`. [A `$using-enum-declarator$` containing a `$splice-enum-name$` names the entity reflected by the `$constant-expression$`. ]{.addu}  The `$using-enum-declarator$` shall designate a non-dependent type with a reachable `$enum-specifier$`.
+[1]{.pnum} A `$using-enum-declarator$` [not consisting of a `$splice-specifier$`]{.addu} names the set of declarations found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}) for the `$using-enum-declarator$`. The `$using-enum-declarator$` shall designate a non-dependent type with a reachable `$enum-specifier$`.
+:::
+
+### [namespace.alias]{.sref} Namespace alias {-}
+
+Add a production to the grammar for `$qualified-namespace-specifier$` as follows:
+
+::: std
+```diff
+  $namespace-alias$:
+      $identifier$
+
+  $namespace-alias-definition$:
+      namespace $identifier$ = $qualified-namespace-specifier$
+
+  $qualified-namespace-specifier$:
+      $nested-name-specifier$@~_opt_~@ $namespace-name$
++     $splice-specifier$
+```
+:::
+
+Add the following prior to paragraph 1, and renumber accordingly:
+
+::: std
+:::addu
+[1]{.pnum} If a `$qualified-namespace-specifier$` consists of a `$splice-specifier$`, the `$splice-specifier$` shall designate a namespace or namespace alias; the `$qualified-namespace-specifier$` designates the same namespace or namespace alias designated by the `$splice-specifier$`. Otherwise, the `$qualified-namespace-specifier$` designates the namespace found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}).
+:::
+:::
+
+Prefer the verb "designate" for `$qualified-namespace-specifiers$` in the paragraph that immediately follows:
+
+::: std
+[2]{.pnum} The `$identifier$` in a `$namespace-alias-definition$` becomes a `$namespace-alias$` and denotes the namespace [denoted]{.rm} [designated]{.addu} by the `$qualified-namespace-specifier$`.
 :::
 
 ### [namespace.udir]{.sref} Using namespace directive {-}
 
-Modify the grammar for `$using-directive$` as follows:
+Use `$qualified-namespace-specifier$` in the grammar for `$using-directive$`:
 
 ::: std
 ```diff
-+ $splice-namespace-name$:
-+    [: $constant-expression$ :]
-+
-+ $namespace-declarator$:
-+    $nested-name-specifier$@~_opt_~@ $namespace-name$
-+    $splice-namespace-name$
-+
   $using-directive$:
 -    $attribute-specifier-seq$@~_opt_~@ using namespace $nested-name-specifier$@~_opt_~@ $namespace-name$
-+    $attribute-specifier-seq$@~_opt_~@ using namespace $namespace-declarator$
++    $attribute-specifier-seq$@~_opt_~@ using namespace $qualified-namespace-specifier$
 ```
 :::
 
-Add the following to paragraph 1 of [namespace.udir]{.sref}, prior to the note:
+Add the following prior to the first paragraph of [namespace.udir]{.sref}, and renumber accordingly:
 
 ::: std
-[1]{.pnum} A `$using-directive$` shall not appear in class scope, but may appear in namespace scope or in block scope. [A `$namespace-declarator$` not consisting of a `$splice-namespace-name$` nominates the namespace found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}) and shall not contain a dependent `$nested-name-specifier$`. A `$namespace-declarator$` consisting of a `$splice-namespace-name$` shall contain a non-dependent `$constant-expression$` that reflects a namespace or namespace alias, and nominates the entity reflected by the `$constant-expression$`.]{.addu}
+::: addu
+[1]{.pnum} The `$qualified-namespace-specifier$` shall neither contain a dependent `$nested-name-specifier$` nor a dependent `$splice-specifier$`.
+:::
+
+[2]{.pnum} A `$using-directive$` shall not appear in class scope, but may appear in namespace scope or in block scope.
+
+[...]
+:::
+
+Prefer the verb "designate" rather than "nominate" in the notes that follow:
+
+::: std
+[*Note 2*: A `$using-directive$` makes the names in the [nominated]{.rm} [designated]{.addu} namespace usable in the scope [...]. During unqualified name lookup, the names appear as if they were declared in the nearest enclosing namespace which contains both the `$using-directive$` and the [nomindated]{.rm} [designated]{.addu} namespace. — *end note*]
+
+[...]
+
+[*Note 4*: A `$using-directive$` is transitive: if a scope contains a `$using-directive$` that [nominates]{.rm} [designates]{.addu} a namespace that itself contains `$using-directives$`, the namespaces [nominated]{.rm} [designated]{.addu} by those `$using-directives$` are also eligible to be considered. — *end note*]
 :::
 
 
@@ -4228,7 +4256,7 @@ consteval string_view name_of(info r);
 consteval u8string_view u8name_of(info r);
 ```
 
-[#]{.pnum} *Constant When*: If returning `string_view`, the unqualified name is representable using the ordinary string literal encoding. `r` designates a declared entity.
+[#]{.pnum} *Constant When*: If returning `string_view`, the unqualified name is representable using the ordinary string literal encoding. `r` represents a declared entity.
 
 [#]{.pnum} *Returns*: The unqualified name of the entity designated by `r`. If this entity has no name, then an empty `string_view` or `u8string_view`, respectively.
 
@@ -4237,10 +4265,11 @@ consteval string_view qualified_name_of(info r);
 consteval u8string_view u8qualified_name_of(info r);
 ```
 
-[#]{.pnum} *Constant When*: If returning `string_view`, the qualified name is representable using the ordinary string literal encoding. `r` designates a declared entity.
+[#]{.pnum} *Constant When*: If returning `string_view`, the qualified name is representable using the ordinary string literal encoding. `r` represents a declared entity.
 
 [#]{.pnum} *Returns*: The qualified name of the entity designated by `r`. If this entity has no name, then an empty `string_view` or `u8string_view`, respectively.
 
+```cpp
 consteval string_view display_string_of(info r);
 consteval u8string_view u8display_string_of(info r);
 ```
@@ -4267,61 +4296,61 @@ consteval bool is_protected(info r);
 consteval bool is_private(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a class member or base class that is public, protected, or private, respectively. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a class member or base class that is public, protected, or private, respectively. Otherwise, `false`.
 
 ```cpp
 consteval bool is_virtual(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates either a virtual member function or a virtual base class. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents either a virtual member function or a virtual base class. Otherwise, `false`.
 
 ```cpp
 consteval bool is_pure_virtual(info r);
 consteval bool is_override(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates a member function that is pure virtual or overrides another member function, respectively. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a member function that is pure virtual or overrides another member function, respectively. Otherwise, `false`.
 
 ```cpp
 consteval bool is_final(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a final class or a final member function. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a final class or a final member function. Otherwise, `false`.
 
 ```cpp
 consteval bool is_deleted(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a function that is defined as deleted ([dcl.fct.def.delete]). Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a function that is defined as deleted ([dcl.fct.def.delete]). Otherwise, `false`.
 
 ```cpp
 consteval bool is_defaulted(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a function that is defined as defaulted ([dcl.fct.def.default]). Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a function that is defined as defaulted ([dcl.fct.def.default]). Otherwise, `false`.
 
 ```cpp
 consteval bool is_explicit(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a member function that is declared explicit. Otherwise, `false`. [If `r` designates a member function template that is declared `explicit`, `is_explicit(r)` is still `false` because in general such queries for templates cannot be answered.]{.note}
+[#]{.pnum} *Returns*: `true` if `r` represents a member function that is declared explicit. Otherwise, `false`. [If `r` represents a member function template that is declared `explicit`, `is_explicit(r)` is still `false` because in general such queries for templates cannot be answered.]{.note}
 
 ```cpp
 consteval bool is_noexcept(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a `noexcept` function type or a function or member function that is declared `noexcept`. Otherwise, `false`. [If `r` designates a function template that is declared `noexcept`, `is_noexcept(r)` is still `false` because in general such queries for templates cannot be answered.]{.note}
+[#]{.pnum} *Returns*: `true` if `r` represents a `noexcept` function type or a function or member function that is declared `noexcept`. Otherwise, `false`. [If `r` represents a function template that is declared `noexcept`, `is_noexcept(r)` is still `false` because in general such queries for templates cannot be answered.]{.note}
 
 ```cpp
 consteval bool is_bit_field(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a bit-field. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a bit-field. Otherwise, `false`.
 
 ```cpp
 consteval bool is_const(info r);
 consteval bool is_volatile(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a const or volatile type (respectively), a const- or volatile-qualified function type (respectively), or an object, variable, non-static data member, or function with such a type. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a const or volatile type (respectively), a const- or volatile-qualified function type (respectively), or an object, variable, non-static data member, or function with such a type. Otherwise, `false`.
 
 ```cpp
 consteval bool is_lvalue_reference_qualified(info r);
@@ -4334,7 +4363,7 @@ consteval bool is_rvalue_reference_qualified(info r);
 consteval bool has_static_storage_duration(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates an object or variable that has static storage duration. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents an object or variable that has static storage duration. Otherwise, `false`.
 
 ```cpp
 consteval bool has_internal_linkage(info r);
@@ -4343,48 +4372,48 @@ consteval bool has_external_linkage(info r);
 consteval bool has_linkage(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates an entity that has internal linkage, module linkage, external linkage, or any linkage, respectively ([basic.link]). Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents an entity that has internal linkage, module linkage, external linkage, or any linkage, respectively ([basic.link]). Otherwise, `false`.
 
 
 ```cpp
 consteval bool is_namespace(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a namespace or namespace alias. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a namespace or namespace alias. Otherwise, `false`.
 
 ```cpp
 consteval bool is_function(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates a function or member function. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a function or member function. Otherwise, `false`.
 
 ```cpp
 consteval bool is_variable(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates a variable. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a variable. Otherwise, `false`.
 
 ```cpp
 consteval bool is_type(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates a type or a type alias. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a type or a type alias. Otherwise, `false`.
 
 ```cpp
 consteval bool is_alias(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates a type alias, alias template, or namespace alias. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a type alias, alias template, or namespace alias. Otherwise, `false`.
 
 ```cpp
 consteval bool is_incomplete_type(info r);
 ```
 [#]{.pnum} *Constant When*: `r` is a reflection designating a type.
 
-[#]{.pnum} *Effects*: If `dealias(r)` designates a class template specialization with a reachable definition, the specialization is instantiated.
+[#]{.pnum} *Effects*: If `dealias(r)` represents a class template specialization with a reachable definition, the specialization is instantiated.
 
 [#]{.pnum} *Returns*: `true` if the type designated by `dealias(r)` is an incomplete type ([basic.types]). Otherwise, `false`.
 
 ```cpp
 consteval bool is_template(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates a function template, class template, variable template, or alias template. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a function template, class template, variable template, or alias template. Otherwise, `false`.
 
 [#]{.pnum} [A template specialization is not a template. `is_template(^std::vector)` is `true` but `is_template(^std::vector<int>)` is `false`.]{.note}
 
@@ -4397,17 +4426,17 @@ consteval bool is_concept(info r);
 consteval bool is_structured_binding(info r);
 consteval bool is_value(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates a function template, class template, variable template, alias template, concept, structured binding, or value respectively. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a function template, class template, variable template, alias template, concept, structured binding, or value respectively. Otherwise, `false`.
 
 ```cpp
 consteval bool is_object(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates an object. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents an object. Otherwise, `false`.
 
 ```cpp
 consteval bool has_template_arguments(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` designates an instantiation of a function template, variable template, class template, or an alias template. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents an instantiation of a function template, variable template, class template, or an alias template. Otherwise, `false`.
 
 
 ```cpp
@@ -4418,13 +4447,13 @@ consteval bool is_static_member(info r);
 consteval bool is_base(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a class member, namespace member, non-static data member, static member, or base class member, respectively. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a class member, namespace member, non-static data member, static member, or base class member, respectively. Otherwise, `false`.
 
 ```cpp
 consteval bool has_default_member_initializer(info r);
 ```
 
-[#]{.pnum} *Returns* `true` if `r` designates a non-static data member that has a default member initializer. Otherwise, `false`.
+[#]{.pnum} *Returns* `true` if `r` represents a non-static data member that has a default member initializer. Otherwise, `false`.
 
 ```cpp
 consteval bool is_special_member(info r);
@@ -4438,21 +4467,21 @@ consteval bool is_move_assignment(info r);
 consteval bool is_destructor(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` designates a special member function, constructor, default constructor, copy constructor, move constructor, assignment operator, copy assignment operator, move assignment operator, or destructor, respectively. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a special member function, constructor, default constructor, copy constructor, move constructor, assignment operator, copy assignment operator, move assignment operator, or destructor, respectively. Otherwise, `false`.
 
 ```cpp
 consteval bool is_user_provided(info r);
 ```
 
-[#]{.pnum} *Constant When*: `r` designates a function.
+[#]{.pnum} *Constant When*: `r` represents a function.
 
-[#]{.pnum} *Returns*: `true` if `r` designates a user-provided ([dcl.fct.def.default]{.sref}) function. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a user-provided ([dcl.fct.def.default]{.sref}) function. Otherwise, `false`.
 
 ```cpp
 consteval info type_of(info r);
 ```
 
-[#]{.pnum} *Constant When*: `r` designates a typed entity. `r` does not designate a constructor, destructor, or structured binding.
+[#]{.pnum} *Constant When*: `r` represents a typed entity. `r` does not designate a constructor, destructor, or structured binding.
 
 [#]{.pnum} *Returns*: A reflection of the type of that entity.  If every declaration of that entity was declared with the same type alias (but not a template parameter substituted by a type alias), the reflection returned is for that alias.  Otherwise, if some declaration of that entity was declared with an alias it is unspecified whether the reflection returned is for that alias or for the type underlying that alias. Otherwise, the reflection returned shall not be a type alias reflection.
 
@@ -4476,7 +4505,7 @@ consteval info value_of(info r);
 consteval info parent_of(info r);
 ```
 
-[#]{.pnum} *Constant When*: `r` designates a member of either a class or a namespace.
+[#]{.pnum} *Constant When*: `r` represents a member of either a class or a namespace.
 
 [#]{.pnum} *Returns*: A reflection of that entity's immediately enclosing class or namespace.
 
@@ -4484,7 +4513,7 @@ consteval info parent_of(info r);
 consteval info dealias(info r);
 ```
 
-[#]{.pnum} *Returns*: If `r` designates a type alias or a namespace alias, a reflection designating the underlying entity. Otherwise, `r`.
+[#]{.pnum} *Returns*: If `r` represents a type alias or a namespace alias, a reflection designating the underlying entity. Otherwise, `r`.
 
 [#]{.pnum}
 
@@ -4533,7 +4562,7 @@ consteval vector<info> members_of(info r);
 
 [#]{.pnum} *Constant When*: `r` is a reflection designating either a complete class type or a namespace.
 
-[#]{.pnum} *Effects*: If `dealias(r)` designates a class template specialization with a reachable definition, the specialization is instantiated.
+[#]{.pnum} *Effects*: If `dealias(r)` represents a class template specialization with a reachable definition, the specialization is instantiated.
 
 [#]{.pnum} *Returns*: A `vector` containing the reflections of all the direct members `m` of the entity, excluding any structured bindings, designated by `r`.
 Non-static data members are indexed in the order in which they are declared, but the order of other kinds of members is unspecified. [Base classes are not members.]{.note}
@@ -4544,7 +4573,7 @@ consteval vector<info> bases_of(info type);
 
 [#]{.pnum} *Constant When*: `type` is a reflection designating a complete class type.
 
-[#]{.pnum} *Effects*: If `dealias(type)` designates a class template specialization with a reachable definition, the specialization is instantiated.
+[#]{.pnum} *Effects*: If `dealias(type)` represents a class template specialization with a reachable definition, the specialization is instantiated.
 
 [#]{.pnum} *Returns*: Let `C` be the type designated by `type`. A `vector` containing the reflections of all the direct base classes `b`, if any, of `C`.
 The base classes are indexed in the order in which they appear in the *base-specifier-list* of `C`.
@@ -4575,7 +4604,7 @@ consteval vector<info> subobjects_of(info type);
 
 [#]{.pnum} *Constant When*: `type` is a reflection designating a complete class type.
 
-[#]{.pnum} *Effects*: If `dealias(type)` designates a class template specialization with a reachable definition, the specialization is instantiated.
+[#]{.pnum} *Effects*: If `dealias(type)` represents a class template specialization with a reachable definition, the specialization is instantiated.
 
 [#]{.pnum} *Returns*: A `vector` containing all the reflections in `bases_of(type)` followed by all the reflections in `nonstatic_data_members_of(type)`.
 
@@ -4613,7 +4642,7 @@ consteval access_context::access_context()
 consteval bool is_accessible(info target, access_context from = {});
 ```
 
-[#]{.pnum} *Constant When*: `target` is a reflection designating a member of a class. `from` designates a function, class, or namespace.
+[#]{.pnum} *Constant When*: `target` is a reflection designating a member of a class. `from` represents a function, class, or namespace.
 
 [#]{.pnum} *Returns*: `true` if the class member designated by `target` can be named within the scope of `from.$context_$`. Otherwise, `false`.
 
@@ -4621,7 +4650,7 @@ consteval bool is_accessible(info target, access_context from = {});
 consteval vector<info> accessible_members_of(info target, access_context from = {});
 ```
 
-[#]{.pnum} *Constant When*: `target` is a reflection designating a complete class type. `from` designates a function, class, or namespace.
+[#]{.pnum} *Constant When*: `target` is a reflection designating a complete class type. `from` represents a function, class, or namespace.
 
 [#]{.pnum} *Effects*: If `dealias(type)` designates a class template specialization with a reachable definition, the specialization is instantiated.
 
@@ -4631,7 +4660,7 @@ consteval vector<info> accessible_members_of(info target, access_context from = 
 consteval vector<info> accessible_bases_of(info target, access_context from = {});
 ```
 
-[#]{.pnum} *Constant When*: `target` is a reflection designating a complete class type. `from` designates a function, class, or namespace.
+[#]{.pnum} *Constant When*: `target` is a reflection designating a complete class type. `from` represents a function, class, or namespace.
 
 [#]{.pnum} *Effects*: If `dealias(type)` designates a class template specialization with a reachable definition, the specialization is instantiated.
 
@@ -4686,7 +4715,7 @@ consteval size_t size_of(info r);
 
 [#]{.pnum} *Constant When*: `r` is a reflection of a type, non-static data member, base class, object, value, or variable.
 
-[#]{.pnum} *Returns* If `r` designates a type `T`, then `sizeof(T)`. Otherwise, `size_of(type_of(r))`.
+[#]{.pnum} *Returns* If `r` represents a type `T`, then `sizeof(T)`. Otherwise, `size_of(type_of(r))`.
 
 ```cpp
 consteval size_t alignment_of(info r);
@@ -4694,7 +4723,7 @@ consteval size_t alignment_of(info r);
 
 [#]{.pnum} *Constant When*: `r` is a reflection designating an object, variable, type, non-static data member, or base class.
 
-[#]{.pnum} *Returns*: If `r` designates a type, object, or variable, then the alignment requirement of the entity. Otherwise, if `r` designates a base class, then `alignment_of(type_of(r))`. Otherwise, the alignment requirement of the subobject associated with the reflected non-static data member within any object of type `parent_of(r)`.
+[#]{.pnum} *Returns*: If `r` represents a type, object, or variable, then the alignment requirement of the entity. Otherwise, if `r` represents a base class, then `alignment_of(type_of(r))`. Otherwise, the alignment requirement of the subobject associated with the reflected non-static data member within any object of type `parent_of(r)`.
 
 ```cpp
 consteval size_t bit_offset_of(info r);
@@ -4712,7 +4741,7 @@ consteval size_t bit_size_of(info r);
 
 [#]{.pnum} *Constant When*: `r` is a reflection of a type, non-static data member, base class, object, value, or variable.
 
-[#]{.pnum} *Returns* If `r` designates a type, then the size in bits of any object having the reflected type. Otherwise, if `r` reflects a non-static data member that is a bit-field, then the width of the reflected bit-field. Otherwise, `bit_size_of(type_of(r))`.
+[#]{.pnum} *Returns* If `r` represents a type, then the size in bits of any object having the reflected type. Otherwise, if `r` represents a non-static data member that is a bit-field, then the width of the reflected bit-field. Otherwise, `bit_size_of(type_of(r))`.
 :::
 :::
 
@@ -4726,9 +4755,9 @@ template <class T>
   consteval T extract(info r);
 ```
 
-[#]{.pnum} *Constant When*: `r` is a reflection designating a value, object, variable, function, enumerator, or non-static data member that is not a bit-field. If `r` reflects a value or enumerator, then `T` is not a reference type. If `r` reflects a value or enumerator of type `U`, or if `r` reflects a variable or object of non-reference type `U`, then the cv-unqualified types of `T` and `U` are the same. If `r` reflects a variable, object, or function with type `U`, and `T` is a reference type, then the cv-unqualified types of `T` and `U` are the same, and `T` is either `U` or more cv-qualified than `U`. If `r` reflects a non-static data member, or if `r` reflects a function and `T` is a reference type, then the statement `T v = &expr`, where `expr` is an lvalue naming the entity designated by `r`, is well-formed.
+[#]{.pnum} *Constant When*: `r` is a reflection designating a value, object, variable, function, enumerator, or non-static data member that is not a bit-field. If `r` represents a value or enumerator, then `T` is not a reference type. If `r` represents a value or enumerator of type `U`, or if `r` represents a variable or object of non-reference type `U`, then the cv-unqualified types of `T` and `U` are the same. If `r` represents a variable, object, or function with type `U`, and `T` is a reference type, then the cv-unqualified types of `T` and `U` are the same, and `T` is either `U` or more cv-qualified than `U`. If `r` represents a non-static data member, or if `r` represents a function and `T` is a reference type, then the statement `T v = &expr`, where `expr` is an lvalue naming the entity designated by `r`, is well-formed.
 
-[#]{.pnum} *Returns*: If `r` designates a value or enumerator, then the entity reflected by `r`. Otherwise, if `r` reflects an object, variable, or enumerator and `T` is not a reference type, then the result of an lvalue-to-rvalue conversion applied to an expression naming the entity reflected by `r`. Otherwise, if `r` reflects an object, variable, or function and `T` is a reference type, then the result of an lvalue naming the entity reflected by `r`. Otherwise, if `r` reflects a function or non-static data member, then a pointer value designating the entity reflected by `r`.
+[#]{.pnum} *Returns*: If `r` represents a value or enumerator, then the entity reflected by `r`. Otherwise, if `r` represents an object, variable, or enumerator and `T` is not a reference type, then the result of an lvalue-to-rvalue conversion applied to an expression naming the entity reflected by `r`. Otherwise, if `r` represents an object, variable, or function and `T` is a reference type, then the result of an lvalue naming the entity reflected by `r`. Otherwise, if `r` represents a function or non-static data member, then a pointer value designating the entity reflected by `r`.
 :::
 :::
 
@@ -4748,7 +4777,7 @@ concept reflection_range =
 template <reflection_range R = initializer_list<info>>
 consteval bool can_substitute(info templ, R&& arguments);
 ```
-[1]{.pnum} *Constant When*: `templ` designates a template.
+[1]{.pnum} *Constant When*: `templ` represents a template.
 
 [#]{.pnum} Let `Z` be the template designated by `templ` and let `Args...` be the sequence of entities or aliases designated by the elements of `arguments`.
 
@@ -4812,7 +4841,7 @@ template <reflection_range R1 = initializer_list<info>, reflection_range R2 = in
 
 [#]{.pnum} If `F` is a non-member function, a value of pointer to function type, a value of pointer to member type, or a value of closure type, then let `INVOKE-EXPR` be the expression `INVOKE(F, Arg0, Args...)`. Otherwise, if `F` is a member function, then let `INVOKE-EXPR` be the expression `Arg0.F(Args...)`. Otherwise, if `F` is a constructor for a class `C`, then let `INVOKE-EXPR` be the expression `C(Arg0, Args...)` for which only the constructor `F` is considered by overload resolution. Otherwise, if `F` is a non-member function template or a member function template, then let `INVOKE-EXPR` be the expression `F<TArgs...>(Arg0, Args...)` or `Arg0.template F<TArgs...>(Args...)` respectively. Otherwise, if `F` is a constructor template, then let `INVOKE-EXPR` be the expression `C(Arg0, Args...)` for which only the constructor `F` is considered by overload resolution, and `TArgs...` are inferred as explicit template arguments for `F`.
 
-[#]{.pnum} *Constant When*: `target` designates a reflection of a function, a constructor, a constructor template, a value, or a function template. If `target` reflects a value of type `T`, then `T` is a pointer to function type, pointer to member type, or closure type. The expression `INVOKE-EXPR` is a well-formed constant expression of structural type.
+[#]{.pnum} *Constant When*: `target` represents a function, a constructor, a constructor template, a value, or a function template. If `target` represents a value of type `T`, then `T` is a pointer to function type, pointer to member type, or closure type. The expression `INVOKE-EXPR` is a well-formed constant expression of structural type.
 
 [#]{.pnum} *Returns*: A reflection of the result of the expression `INVOKE-EXPR`.
 
@@ -4829,7 +4858,7 @@ consteval info data_member_spec(info type,
                                 data_member_options_t options = {});
 ```
 [1]{.pnum} *Constant When*:
-`type` designates a type.
+`type` represents a type.
 If `options.name` contains a value, the `string` or `u8string` value that was used to initialize `options.name` contains a valid identifier ([lex.name]{.sref}).
 
 
@@ -4846,9 +4875,9 @@ If `options.name` contains a value, the `string` or `u8string` value that was us
 [#]{.pnum} Let `@*d*~1~@`, `@*d*~2~@`, ..., `@*d*~N~@` denote the reflection values of the range `mdescrs` obtained by calling `data_member_spec` with `type` values `@*t*~1~@`, `@*t*~2~@`, ... `@*t*~N~@` and `option` values `@*o*~1~@`, `@*o*~2~@`, ... `@*o*~N~@` respectively.
 
 [#]{.pnum} *Constant When*:
-`class_type` designates an incomplete class type.  `mdescrs` is a (possibly empty) range of reflection values obtained by calls to `data_member_spec`.
+`class_type` represents an incomplete class type.  `mdescrs` is a (possibly empty) range of reflection values obtained by calls to `data_member_spec`.
 [For example, `class_type` could be a specialization of a class template that has not been instantiated or explicitly specialized.]{.note}
-Each `@*t*~i~@` designates a type that is valid types for data members.
+Each `@*t*~i~@` represents a type that is valid types for data members.
 If `@*o*~K~@.width` (for some `$K$`) contains a value `$w$`, the corresponding type `@*t*~K~@` is a valid type for bit field of width `$w$`.
 If `@*o*~K~@.alignment` (for some `$K$`) contains a value `$a$`, `alignas($a$)` is a valid `$alignment-specifier$` for a non-static data member of type `@*t*~K~@`.
 
@@ -4856,9 +4885,9 @@ If `@*o*~K~@.alignment` (for some `$K$`) contains a value `$a$`, `alignas($a$)` 
 [#]{.pnum} *Effects*:
 Defines `class_type` with properties as follows:
 
-* [#.1]{.pnum} If `class_type` designates a specialization of a class template, the specialization is explicitly specialized.
+* [#.1]{.pnum} If `class_type` represents a specialization of a class template, the specialization is explicitly specialized.
 * [#.#]{.pnum} Non-static data members are declared in the definition of `class_type` according to `@*d*~1~@`, `@*d*~2~@`, ..., `@*d*~N~@`, in that order.
-* [#.#]{.pnum} The type of the respective members are the types denoted by the reflection values `@*t*~1~@`, `@*t*~2~@`, ... `@*t*~N~@`.
+* [#.#]{.pnum} The type of the respective members are the types represented by the reflection values `@*t*~1~@`, `@*t*~2~@`, ... `@*t*~N~@`.
 * [#.#]{.pnum} If `@*o*~K~@.no_unique_address` (for some `$K$`) is `true`, the corresponding member is declared with attribute `[[no_unique_address]]`.
 * [#.#]{.pnum} If `@*o*~K~@.width` (for some `$K$`) contains a value, the corresponding member is declared as a bit field with that value as its width.
 * [#.#]{.pnum} If `@*o*~K~@.alignment` (for some `$K$`) contains a value `$a$`, the corresponding member is aligned as if declared with `alignas($a$)`.

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3051,7 +3051,7 @@ Add a new paragraph before the last paragraph of [basic.fundamental]{.sref} as f
 
 [17 - 1]{.pnum} A value of type `std::meta::info` is called a _reflection_. There exists a unique _null reflection_; every other reflection is a representation of
 
-* a value with structural type,
+* a value with structural type ([temp.param]),
 * an object with static storage duration,
 * a variable,
 * a structured binding,
@@ -3153,6 +3153,8 @@ Add a new paragraph restricting `$splice-namespace-qualifier$`, and renumber acc
 ::: addu
 [1]{.pnum} The `$splice-specifier$` of a `$splice-namespace-qualifier$` shall designate a namespace or namespace alias.
 :::
+
+[2]{.pnum} The component names of a `$qualified-id$` are [...]
 :::
 
 Clarify that a splice cannot appear in a declarative `$nested-name-specifier$`:
@@ -3168,10 +3170,10 @@ Clarify that a splice cannot appear in a declarative `$nested-name-specifier$`:
 A declarative `$nested-name-specifier$` shall not have a `$decltype-specifier$` [or a `$splice-specifier$`]{.addu}. A declaration that uses a declarative `$nested-name-specifier$` shall be a friend declaration or inhabit a scope that contains the entity being redeclared or specialized.
 :::
 
-Extend paragraph 3 to also cover splices, and prefer the verb "designate" over "nominate":
+Extend the next paragraph to also cover splices, and prefer the verb "designate" over "nominate":
 
 ::: std
-[3]{.pnum} The `$nested-name-specifier$` `​::`​ [nominates]{.rm} [designates]{.addu} the global namespace. A `$nested-name-specifier$` with a `$computed-type-specifier$` [nominates]{.rm} [designates]{.addu} the type denoted by the `$computed-type-specifier$`, which shall be a class or enumeration type. [A `$nested-name-specifier$` with a `$splice-namespace-qualifier$` [nominates]{.rm} [designates]{.addu} the same namespace or namespace alias as the `$splice-namespace-qualifier$`.]{.addu} If a `$nested-name-specifier$` _N_ is declarative and has a `$simple-template-id$` with a template argument list _A_ that involves a template parameter, let _T_ be the template [nominated]{.rm} [designated]{.addu} by _N_ without _A_. _T_ shall be a class template.
+[4]{.pnum} The `$nested-name-specifier$` `​::`​ [nominates]{.rm} [designates]{.addu} the global namespace. A `$nested-name-specifier$` with a `$computed-type-specifier$` [nominates]{.rm} [designates]{.addu} the type denoted by the `$computed-type-specifier$`, which shall be a class or enumeration type. [A `$nested-name-specifier$` with a `$splice-namespace-qualifier$` [nominates]{.rm} [designates]{.addu} the same namespace or namespace alias as the `$splice-namespace-qualifier$`.]{.addu} If a `$nested-name-specifier$` _N_ is declarative and has a `$simple-template-id$` with a template argument list _A_ that involves a template parameter, let _T_ be the template [nominated]{.rm} [designated]{.addu} by _N_ without _A_. _T_ shall be a class template.
 
 ...
 
@@ -3445,9 +3447,7 @@ Add a new subsection of [dcl.type]{.sref} following [dcl.type.class.deduct]{.sre
 
 [#]{.pnum} The `typename` may be omitted only within a type-only context ([temp.res.general]{.sref}).
 
-[#]{.pnum} The `$splice-specifier$` shall designate a type.
-
-[#]{.pnum} The type designated by the `$splice-type-specifier$` is the same type designated by the `$splice-specifier$`.
+[#]{.pnum} The `$splice-specifier$` shall designate a type. The type designated by the `$splice-type-specifier$` is the same type designated by the `$splice-specifier$`.
 :::
 :::
 
@@ -3459,7 +3459,7 @@ Change paragraphs 6-7 of [dcl.init.general]{.sref} [No changes are necessary for
 [6]{.pnum} To *zero-initialize* an object or reference of type `T` means:
 
 * [6.0]{.pnum} [if `T` is `std::meta::info`, the object is initialized to a null reflection value;]{.addu}
-* [6.1]{.pnum} if `T` is any scalar type ([basic.types.general]) [other than `std::meta::info`]{.addu}, the object is initialized to the value obtained by converting the integer literal `0` (zero) to `T`;
+* [6.1]{.pnum} if `T` is [a]{.rm} [any other]{.addu} scalar type ([basic.types.general]), the object is initialized to the value obtained by converting the integer literal `0` (zero) to `T`;
 * [6.2]{.pnum} [...]
 
 [7]{.pnum} To *default-initialize* an object of type `T` means:
@@ -3578,11 +3578,11 @@ Add the following prior to the first paragraph of [namespace.udir]{.sref}, and r
 Prefer the verb "designate" rather than "nominate" in the notes that follow:
 
 ::: std
-[*Note 2*: A `$using-directive$` makes the names in the [nominated]{.rm} [designated]{.addu} namespace usable in the scope [...]. During unqualified name lookup, the names appear as if they were declared in the nearest enclosing namespace which contains both the `$using-directive$` and the [nomindated]{.rm} [designated]{.addu} namespace. — *end note*]
+[A `$using-directive$` makes the names in the [nominated]{.rm} [designated]{.addu} namespace usable in the scope [...]. During unqualified name lookup, the names appear as if they were declared in the nearest enclosing namespace which contains both the `$using-directive$` and the [nomindated]{.rm} [designated]{.addu} namespace.]{.note2}
 
 [...]
 
-[*Note 4*: A `$using-directive$` is transitive: if a scope contains a `$using-directive$` that [nominates]{.rm} [designates]{.addu} a namespace that itself contains `$using-directives$`, the namespaces [nominated]{.rm} [designated]{.addu} by those `$using-directives$` are also eligible to be considered. — *end note*]
+[A `$using-directive$` is transitive: if a scope contains a `$using-directive$` that [nominates]{.rm} [designates]{.addu} a namespace that itself contains `$using-directives$`, the namespaces [nominated]{.rm} [designated]{.addu} by those `$using-directives$` are also eligible to be considered.]{.note4}
 :::
 
 

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3447,7 +3447,7 @@ Add a new subsection of [dcl.type]{.sref} following [dcl.type.class.deduct]{.sre
 
 [#]{.pnum} The `$splice-specifier$` shall designate a type.
 
-[#]{.pnum} The type designated by the `$splice-type-specifier$` is the type designated by the `$splice-specifier$`.
+[#]{.pnum} The type designated by the `$splice-type-specifier$` is the same type designated by the `$splice-specifier$`.
 :::
 :::
 

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -2971,7 +2971,7 @@ Modify the first bullet of paragraph 3 of [basic.lookup.argdep]{.sref} as follow
 
 [3]{.pnum} ... Any `$typedef-name$`s and `$using-declaration$`s used to specify the types do not contribute to this set. The set of entities is determined in the following way:
 
-- [3.1]{.pnum} [If `T` is `std::meta::info`, its associated set of entities is the singleton containing the function `std::meta::is_type`.]{.addu} If `T` is any [other]{.addu} fundamental type, its associated set of entities is empty.
+- [3.1]{.pnum} [If `T` is `std::meta::info`, its associated set of entities is the singleton containing the function `std::meta::is_type`.]{.addu} If `T` is [a]{.rm} [any other]{.addu} fundamental type, its associated set of entities is empty.
 - [3.2]{.pnum} If `T` is a class type ...
 
 :::

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -2293,6 +2293,7 @@ namespace std::meta {
   consteval auto is_variable_template(info entity) -> bool;
   consteval auto is_class_template(info entity) -> bool;
   consteval auto is_alias_template(info entity) -> bool;
+  consteval auto is_constructor_template(info entity) -> bool;
   consteval auto is_concept(info entity) -> bool;
   consteval auto is_structured_binding(info entity) -> bool;
   consteval auto is_value(info entity) -> bool;
@@ -3151,16 +3152,16 @@ Add a new paragraph restricting `$splice-namespace-qualifier$`, and renumber acc
 
 ::: std
 ::: addu
-[1]{.pnum} The `$splice-specifier$` of a `$splice-namespace-qualifier$` shall designate a namespace or namespace alias.
+[0]{.pnum} The `$splice-specifier$` of a `$splice-namespace-qualifier$` shall designate a namespace or namespace alias.
 :::
 
-[2]{.pnum} The component names of a `$qualified-id$` are [...]
+[1]{.pnum} The component names of a `$qualified-id$` are [...]
 :::
 
 Clarify that a splice cannot appear in a declarative `$nested-name-specifier$`:
 
 ::: std
-[3]{.pnum} A `$nested-name-specifier$` is _declarative_ if it is part of
+[2]{.pnum} A `$nested-name-specifier$` is _declarative_ if it is part of
 
 * a `$class-head-name$`,
 * an `$enum-head-name$`,
@@ -3453,7 +3454,7 @@ Add a new subsection of [dcl.type]{.sref} following [dcl.type.class.deduct]{.sre
 
 ### [dcl.init.general]{.sref} Initializers (General) {-}
 
-Change paragraphs 6-7 of [dcl.init.general]{.sref} [No changes are necessary for value-initialization, which already forwards to zero-initialization for scalar types]{.ednote}:
+Change paragraphs 6-8 of [dcl.init.general]{.sref} [No changes are necessary for value-initialization, which already forwards to zero-initialization for scalar types]{.ednote}:
 
 ::: std
 [6]{.pnum} To *zero-initialize* an object or reference of type `T` means:
@@ -3468,6 +3469,14 @@ Change paragraphs 6-7 of [dcl.init.general]{.sref} [No changes are necessary for
 * [7.2]{.pnum} If T is an array type, [...]
 * [7.*]{.pnum} [If `T` is `std::meta::info`, the object is zero-initialized.]{.addu}
 * [7.3]{.pnum} Otherwise, no initialization is performed.
+
+[8]{.pnum} A class type `T` is *const-default-constructible* if default-initialization of `T` would invoke a user-provided constructor of `T` (not inherited from a base class) or if
+
+* [8.1]{.pnum} [...]
+
+If a program calls for the default-initialization of an object of a const-qualified type `T`, `T` shall be [`std::meta::info` or]{.addu} a const-default-constructible [class]{.rm} type, or array thereof.
+
+[9]{.pnum} To value-initialize an object of type T means: [...]
 :::
 
 ### [dcl.fct]{.sref} Functions {-}
@@ -3541,7 +3550,7 @@ Add the following prior to paragraph 1, and renumber accordingly:
 
 ::: std
 :::addu
-[1]{.pnum} If a `$qualified-namespace-specifier$` consists of a `$splice-specifier$`, the `$splice-specifier$` shall designate a namespace or namespace alias; the `$qualified-namespace-specifier$` designates the same namespace or namespace alias designated by the `$splice-specifier$`. Otherwise, the `$qualified-namespace-specifier$` designates the namespace found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}).
+[0]{.pnum} If a `$qualified-namespace-specifier$` consists of a `$splice-specifier$`, the `$splice-specifier$` shall designate a namespace or namespace alias; the `$qualified-namespace-specifier$` designates the same namespace or namespace alias designated by the `$splice-specifier$`. Otherwise, the `$qualified-namespace-specifier$` designates the namespace found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}).
 :::
 :::
 
@@ -3567,10 +3576,10 @@ Add the following prior to the first paragraph of [namespace.udir]{.sref}, and r
 
 ::: std
 ::: addu
-[1]{.pnum} The `$qualified-namespace-specifier$` shall neither contain a dependent `$nested-name-specifier$` nor a dependent `$splice-specifier$`.
+[0]{.pnum} The `$qualified-namespace-specifier$` shall neither contain a dependent `$nested-name-specifier$` nor a dependent `$splice-specifier$`.
 :::
 
-[2]{.pnum} A `$using-directive$` shall not appear in class scope, but may appear in namespace scope or in block scope.
+[1]{.pnum} A `$using-directive$` shall not appear in class scope, but may appear in namespace scope or in block scope.
 
 [...]
 :::
@@ -3980,6 +3989,7 @@ namespace std::meta {
   consteval bool is_variable_template(info r);
   consteval bool is_class_template(info r);
   consteval bool is_alias_template(info r);
+  consteval bool is_constructor_template(info r);
   consteval bool is_concept(info r);
   consteval bool is_value(info r);
   consteval bool is_object(info r);
@@ -4422,11 +4432,12 @@ consteval bool is_function_template(info r);
 consteval bool is_variable_template(info r);
 consteval bool is_class_template(info r);
 consteval bool is_alias_template(info r);
+consteval bool is_constructor_template(info r);
 consteval bool is_concept(info r);
 consteval bool is_structured_binding(info r);
 consteval bool is_value(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` represents a function template, class template, variable template, alias template, concept, structured binding, or value respectively. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a function template, class template, variable template, alias template, constructor template, concept, structured binding, or value respectively. Otherwise, `false`.
 
 ```cpp
 consteval bool is_object(info r);
@@ -4467,7 +4478,7 @@ consteval bool is_move_assignment(info r);
 consteval bool is_destructor(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` represents a special member function, constructor, default constructor, copy constructor, move constructor, assignment operator, copy assignment operator, move assignment operator, or destructor, respectively. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a special member function, non-template constructor, default constructor, copy constructor, move constructor, assignment operator, copy assignment operator, move assignment operator, or destructor, respectively. Otherwise, `false`.
 
 ```cpp
 consteval bool is_user_provided(info r);


### PR DESCRIPTION
- Consistently use "represents" for reflections.
- Sub-bullets for 'plainly constant evaluated' exceptions.
- 'Denote' -> 'Designate' for splicing.
- 'respective' -> 'corresponding' in [basic.def.odr].
- Fix ADL wording.
- Reword 'basic.link' changes.
- consteval-only types: "ODR use" -> "immediate function context"
- Fix formatting typo in 'display_string_of' spec.
- 'names' -> 'designates' in [expr.ref] (also some typo fixes).
- Clean up 'basic.fundamental' as per Jens's feedback.
- Clean up 'dcl.init.general' per Jens's feedback.
- Clean up some enum-splicing wording.
- Re-word namespace splicing. Clean up nested-name-specifiers.
- Add `is_constructor_template` function.