### PR TITLE
Some fixes and removals.

### DIFF
--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -6021,48 +6021,56 @@ Otherwise, the result of each of the operators is unspecified.</p>
 </div>
 <h3 class="unnumbered" id="expr.const-constant-expressions"><span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span> Constant
 Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3>
-<p>Add a new paragraph prior to the definition of <em>manifestly
-constant evaluated</em> (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>/20), and
+<p>Add new paragraphs prior to the definition of <em>manifestly constant
+evaluated</em> (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>/20), and
 renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">20</a></span>
-An expression or conversion is <em>plainly constant-evaluated</em> if it
-is:</p>
+An expression or conversion is <em>potentially plainly
+constant-evaluated</em> if it is:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(20.1)</a></span>
-the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
+a <code class="sourceCode cpp"><em>constant-expression</em></code>,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(20.2)</a></span>
+the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(20.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(20.3)</a></span>
-a <code class="sourceCode cpp"><em>constant-expression</em></code> or an
-immediate invocation, unless it
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(20.4)</a></span>
+an immediate invocation.</li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">21</a></span>
+A potentially plainly constant-evaluated expression or conversion is
+also <em>plainly constant-evaluated</em> unless it</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(20.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(21.1)</a></span>
+is a subexpression of an initializer for a variable that is neither
+<code class="sourceCode cpp"><span class="kw">constexpr</span></code>
+nor
+<code class="sourceCode cpp"><span class="kw">constinit</span></code>,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(21.2)</a></span>
 results from the substitution of template parameters
 <ul>
-<li>during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
-<li>in a <code class="sourceCode cpp"><em>concept-id</em></code>
-(<span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
-<li>in a
-<code class="sourceCode cpp"><em>requires-expression</em></code>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.2.1)</a></span>
+during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.2.2)</a></span>
+in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
+<a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.2.3)</a></span>
+in a <code class="sourceCode cpp"><em>requires-expression</em></code>
 (<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>),
 or</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(20.3.2)</a></span>
-is an initializer, or a subexpression thereof, for a variable that is
-neither
-<code class="sourceCode cpp"><span class="kw">constexpr</span></code>
-(<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) nor
-<code class="sourceCode cpp"><span class="kw">constinit</span></code>
-(<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>).</li>
-</ul></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(21.3)</a></span>
+is an immediate invocation appearing within the body of an
+immediate-escalating function that contains an immediate-escalating
+expression.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Plainly
 constant-evaluated expressions are evaluated exactly once, and that
@@ -6099,22 +6107,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">22</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(22.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(22.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(22.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(22.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(21.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(22.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6137,7 +6145,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">23</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6151,26 +6159,18 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">24</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(23.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(24.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
-constant-evaluated,</li>
-<li>required for the lookup of a name appearing within an unevaluated
-operand,</li>
+constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
 <code class="sourceCode cpp"><em>F</em></code>, unless
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(23.1.1)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a plainly
-constant-evaluated expression or a subexpression thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(23.1.2)</a></span>
-<code class="sourceCode cpp"><em>F</em></code> does not contain an
-immediate-escalating expression.</li>
-</ul></li>
+constant-evaluated expression or a subexpression thereof.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 14:</em> </span>An immediate
 invocation within an immediate-escalating function is similar to a trial
@@ -6210,7 +6210,7 @@ once.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb118-27"><a href="#cb118-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6219,11 +6219,11 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code>.</li>
@@ -6257,10 +6257,10 @@ follows:</p>
 <div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
 <span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">1</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
 may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">2</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 designate a type. The type designated by the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6277,45 +6277,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6323,7 +6323,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6332,22 +6332,22 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">9</a></span>
 A function type with a <em>cv-qualifier-seq</em> or a
 <em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(9.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(9.5)</a></span>
 the <em>type-id</em> of a <em>template-argument</em> for a
 <em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(9.6)</a></span>
 the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
@@ -6359,7 +6359,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator</span>, is ill-formed.</p>
@@ -6387,7 +6387,7 @@ follows:</p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">1</a></span>
 A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>
@@ -6425,7 +6425,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">0</a></span>
 If a
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 is a <code class="sourceCode cpp"><em>splice-specifier</em></code>, the
@@ -6446,7 +6446,7 @@ designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link
 in the paragraph that immediately follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6474,7 +6474,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">0</a></span>
 The
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 shall neither contain a dependent
@@ -6482,7 +6482,7 @@ shall neither contain a dependent
 dependent
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6546,7 +6546,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6569,23 +6569,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6600,7 +6600,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6625,7 +6625,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
@@ -6640,7 +6640,7 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 in template parameter declarations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">4</a></span>
 … The concept designated by a type-constraint shall be a type concept
 ([temp.concept]) <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-template-name</em></code></span>.</p>
@@ -6697,21 +6697,21 @@ designates the entity designated by the
 <p>Extend paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a <em>template-argument-list</em> if it
 follows a name that is not a <em>conversion-function-id</em> and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(3.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(3.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(3.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(3.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -6753,7 +6753,7 @@ it follows a
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">9</a></span>
 A <em>concept-id</em> is a <em>simple-template-id</em> where the
 <em>template-name</em> is <span class="addu">either</span> a
 <em>concept-name</em> <span class="addu">or a
@@ -6768,7 +6768,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -6806,7 +6806,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -6825,7 +6825,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be the name of a class template or an alias template, expressed as
@@ -6840,23 +6840,23 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and they compare equal, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -6867,7 +6867,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -6933,7 +6933,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6952,10 +6952,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -6981,7 +6981,7 @@ or a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -7002,7 +7002,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -7020,19 +7020,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7045,7 +7045,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7053,7 +7053,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">7pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">7pre</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7063,7 +7063,7 @@ might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7515,7 +7515,7 @@ synopsis</strong></p>
 <span id="cb137-351"><a href="#cb137-351" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_variant_size(info type);</span>
 <span id="cb137-352"><a href="#cb137-352" aria-hidden="true" tabindex="-1"></a>  consteval info type_variant_alternative(size_t index, info type);</span>
 <span id="cb137-353"><a href="#cb137-353" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
@@ -7531,7 +7531,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -7784,10 +7784,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -7795,11 +7795,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -7814,33 +7814,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -7849,23 +7849,23 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7874,43 +7874,43 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 namespace alias, then the identifier introduced by the declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7922,21 +7922,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -7954,7 +7954,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -7962,7 +7962,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -7970,7 +7970,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -7978,7 +7978,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -7986,7 +7986,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -7995,7 +7995,7 @@ defined as deleted ([dcl.fct.def.delete])or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8003,7 +8003,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8018,7 +8018,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8036,7 +8036,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8046,7 +8046,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -8054,7 +8054,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8063,7 +8063,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8072,7 +8072,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -8082,7 +8082,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -8093,7 +8093,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8102,13 +8102,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8118,13 +8118,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8133,20 +8133,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8154,7 +8154,7 @@ namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8165,7 +8165,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8173,7 +8173,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8188,7 +8188,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8198,14 +8198,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8222,7 +8222,7 @@ is
 <span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8231,7 +8231,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8240,14 +8240,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8258,7 +8258,7 @@ Otherwise,
 <span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8266,20 +8266,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8288,11 +8288,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8308,33 +8308,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8350,24 +8350,24 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
 alias <em>A</em>, then a reflection representing the entity named by
 <em>A</em>. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8379,15 +8379,15 @@ alias <em>A</em>, then a reflection representing the entity named by
 </div>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8409,11 +8409,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8434,7 +8434,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8445,11 +8445,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8463,14 +8463,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8480,92 +8480,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -8580,32 +8580,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8614,7 +8614,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose associated subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -8627,7 +8627,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -8636,20 +8636,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -8657,7 +8657,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8666,7 +8666,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -8679,32 +8679,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -8712,7 +8712,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -8720,7 +8720,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -8728,52 +8728,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -8791,36 +8791,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -8832,32 +8832,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -8865,37 +8865,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -8904,28 +8904,28 @@ type.</p>
 <span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
 <span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb210-4"><a href="#cb210-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">9</a></span>
 An expression <code class="sourceCode cpp"><em>E</em></code> is said to
 be <em>reciprocal to</em> a reflection
 <code class="sourceCode cpp"><em>r</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(9.1)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents a variable,
 and <code class="sourceCode cpp"><em>E</em></code> is an lvalue
 designating the object named by that variable,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(9.2)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents an object or
 function, and <code class="sourceCode cpp"><em>E</em></code> is an
 lvalue that designates that object or function, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(9.3)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents a value, and
 <code class="sourceCode cpp"><em>E</em></code> is a prvalue that
 computes that value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">10</a></span>
 For exposition only, let</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(10.1)</a></span>
 <code class="sourceCode cpp"><em>F</em></code> be either an entity or an
 expression, such that if <code class="sourceCode cpp">target</code>
 represents a function or function template then
@@ -8934,14 +8934,14 @@ represents a function or function template then
 object, or value, then <code class="sourceCode cpp"><em>F</em></code> is
 an expression reciprocal to
 <code class="sourceCode cpp">target</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(10.2)</a></span>
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 be a sequence of entities and expressions corresponding to the elements
 of <code class="sourceCode cpp">tmpl_args</code> (if any), such that for
 every <code class="sourceCode cpp"><em>targ</em></code> in
 <code class="sourceCode cpp">tmpl_args</code>,
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(10.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(10.2.1)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a type
 or <code class="sourceCode cpp"><em>typedef-name</em></code>, the
 corresponding element of
@@ -8949,19 +8949,19 @@ corresponding element of
 is that type, or the type named by that
 <code class="sourceCode cpp"><em>typedef-name</em></code>,
 respectively,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(10.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(10.2.2)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a
 variable, object, value, or function, the corresponding element of
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 is an expression reciprocal to
 <code class="sourceCode cpp"><em>targ</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(10.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(10.2.3)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a class
 or alias template, then the corresponding element of
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 is that template,</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(10.3)</a></span>
 <code class="sourceCode cpp"><em>Args</em><span class="op">...</span></code>
 be a sequence of expressions
 {<code class="sourceCode cpp"><span class="math inline"><em>E</em></span><sub><span class="math inline"><em>K</em></span></sub></code>} corresponding to the
@@ -8972,11 +8972,11 @@ reflections
 variable, object, value, or function,
 <code class="sourceCode cpp"><span class="math inline"><em>E</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is reciprocal to
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(10.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(10.4)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub></code>
 be the first expression in
 <code class="sourceCode cpp"><em>Args</em></code> (if any), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(10.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(10.5)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...</span></code> be
 the sequence of expressions in
 <code class="sourceCode cpp"><em>Args</em></code> excluding
@@ -8986,17 +8986,17 @@ the sequence of expressions in
 <p>and define an expression
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(10.6)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(10.6)</a></span>
 If <code class="sourceCode cpp">target</code> represents a non-member
 function, variable, object, or value, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is the
 expression <code class="sourceCode cpp"><em>INVOKE</em><span class="op">(</span><em>F</em>, <span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub>, <span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(10.7)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(10.7)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a member
 function that is not a constructor, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is the
 expression <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub><span class="op">.</span><em>F</em><span class="op">(</span><span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(10.8)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(10.8)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a
 function template that is not a constructor template, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is either the
@@ -9004,7 +9004,7 @@ expression <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>
 <code class="sourceCode cpp"><em>F</em></code> is a member function
 template, or <code class="sourceCode cpp"><em>F</em><span class="op">&lt;</span><em>TArgs</em><span class="op">...&gt;(</span><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub>, <span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>
 otherwise.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(10.9)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(10.9)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a
 constructor or constructor template for a class
 <code class="sourceCode cpp"><em>C</em></code>, then
@@ -9018,7 +9018,7 @@ template, then
 are inferred as leading template arguments during template argument
 deduction for <code class="sourceCode cpp"><em>F</em></code>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">11</a></span>
 <em>Constant When</em>:</p>
 <ul>
 <li><code class="sourceCode cpp">target</code> represents either a
@@ -9037,13 +9037,13 @@ represents a variable, object, value, or function, and</li>
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is a
 well-formed constant expression of structural type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">12</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">target</code>
 represents a function template, any specialization of the represented
 template that would be invoked by evaluation of
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is
 instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">13</a></span>
 <em>Returns</em>: A reflection of the same result computed by
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code>.</p>
 </div>
@@ -9054,18 +9054,18 @@ Reflection class definition generation<a href="#meta.reflection.define_class-ref
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9086,64 +9086,64 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.2)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 contains a value <code class="sourceCode cpp"><em>NAME</em></code> then
 either:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.3)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(1.4.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(1.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">(1.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(1.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_class</code>.
 Certain other functions in
@@ -9153,7 +9153,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -9161,7 +9161,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9169,21 +9169,21 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(5.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a valid type for data members, for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
@@ -9194,7 +9194,7 @@ then <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span 
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9206,26 +9206,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a non-static
 data member corresponding to each reflection value
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
@@ -9237,28 +9237,28 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.5)</a></span>
 The non-static data member corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.6)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> are
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.7)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>width</code>
 contains a value are declared as bit-fields whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(7.8)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value are declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(7.9)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> are declared with
 names determined as follows:
@@ -9273,16 +9273,16 @@ the non-static data member is unnamed.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 it has a user-provided default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default destructible, then it
 has a user-provided default destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9292,10 +9292,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9316,7 +9316,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
@@ -9338,7 +9338,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb218-14"><a href="#cb218-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb218-15"><a href="#cb218-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb219"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9364,7 +9364,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
@@ -9386,7 +9386,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9394,7 +9394,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9403,7 +9403,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9488,7 +9488,7 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em></code>
@@ -9496,7 +9496,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>PROP</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.6 <a href="https://wg21.link/meta.unary.prop.query">[meta.unary.prop.query]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and unsigned integer value
@@ -9514,10 +9514,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9526,7 +9526,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9538,7 +9538,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9567,7 +9567,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb223-15"><a href="#cb223-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb223-16"><a href="#cb223-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9589,7 +9589,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9601,7 +9601,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9622,7 +9622,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9640,7 +9640,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9657,7 +9657,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9674,7 +9674,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9701,7 +9701,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9709,7 +9709,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9719,7 +9719,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9741,7 +9741,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -9763,7 +9763,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9771,7 +9771,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -9795,7 +9795,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -9803,27 +9803,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-10-29" />
+  <meta name="dcterms.date" content="2024-10-30" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-10-29</td>
+    <td>2024-10-30</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -734,12 +734,9 @@ implementations<span></span></a></li>
 <li><a href="#data_member_spec-define_class" id="toc-data_member_spec-define_class"><span class="toc-section-number">4.4.19</span>
 <code class="sourceCode cpp">data_member_spec</code>,
 <code class="sourceCode cpp">define_class</code><span></span></a></li>
-<li><a href="#define_static_string-define_static_array" id="toc-define_static_string-define_static_array"><span class="toc-section-number">4.4.20</span>
-<code class="sourceCode cpp">define_static_string</code>,
-<code class="sourceCode cpp">define_static_array</code><span></span></a></li>
-<li><a href="#data-layout-reflection" id="toc-data-layout-reflection"><span class="toc-section-number">4.4.21</span> Data Layout
+<li><a href="#data-layout-reflection" id="toc-data-layout-reflection"><span class="toc-section-number">4.4.20</span> Data Layout
 Reflection<span></span></a></li>
-<li><a href="#other-type-traits" id="toc-other-type-traits"><span class="toc-section-number">4.4.22</span> Other Type
+<li><a href="#other-type-traits" id="toc-other-type-traits"><span class="toc-section-number">4.4.21</span> Other Type
 Traits<span></span></a></li>
 </ul></li>
 <li><a href="#odr-concerns" id="toc-odr-concerns"><span class="toc-section-number">4.5</span> ODR Concerns<span></span></a></li>
@@ -779,9 +776,9 @@ types<span></span></a></li>
 expressions<span></span></a></li>
 <li><a href="#expr.prim.id.splice-splice-specifiers" id="toc-expr.prim.id.splice-splice-specifiers">7.5.4.0*
 [expr.prim.id.splice] Splice specifiers<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
@@ -901,8 +898,6 @@ Reflection substitution<span></span></a></li>
 Expression result reflection<span></span></a></li>
 <li><a href="#meta.reflection.define_class-reflection-class-definition-generation" id="toc-meta.reflection.define_class-reflection-class-definition-generation">[meta.reflection.define_class]
 Reflection class definition generation<span></span></a></li>
-<li><a href="#meta.reflection.define_static-static-array-generation" id="toc-meta.reflection.define_static-static-array-generation">[meta.reflection.define_static]
-Static array generation<span></span></a></li>
 <li><a href="#meta.reflection.unary-unary-type-traits" id="toc-meta.reflection.unary-unary-type-traits">[meta.reflection.unary]
 Unary type traits<span></span></a>
 <ul>
@@ -958,6 +953,10 @@ to <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</s
 <code class="sourceCode cpp">spaceship</code>, and
 <code class="sourceCode cpp">ampersand_and</code> -&gt;
 <code class="sourceCode cpp">ampersand_ampersand</code>)</li>
+<li>removed <code class="sourceCode cpp">define_static_array</code> and
+<code class="sourceCode cpp">define_static_string</code></li>
+<li>clarified that <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span> <span class="op">==</span></code>sizeof(void
+*)`</li>
 <li>clarified that
 <code class="sourceCode cpp">data_member_options_t</code> is a
 non-structural consteval-only type</li>
@@ -1012,7 +1011,7 @@ Aliases”</a> section.</li>
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
 <li>removed <code class="sourceCode cpp">subobjects_of</code> and
 <code class="sourceCode cpp">accessible_subobjects_of</code> (will be
-reintroduced by <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>).</li>
+reintroduced by <span class="citation" data-cites="P3293R1">[<a href="#ref-P3293R1" role="doc-biblioref"><strong>P3293R1?</strong></a>]</span>).</li>
 <li>specified constraints for
 <code class="sourceCode cpp">enumerators_of</code> in terms of
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
@@ -1931,7 +1930,7 @@ initialize members of a defined union using a splicer, as in:</p>
 </blockquote>
 </div>
 <p>Arguably, the answer should be yes - this would be consistent with
-how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>.</p>
+how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="#ref-P3293R1" role="doc-biblioref"><strong>P3293R1?</strong></a>]</span>.</p>
 <p>On Compiler Explorer: <a href="https://godbolt.org/z/Efz5vsjaa">EDG</a>, <a href="https://godbolt.org/z/3bvo97fqf">Clang</a>.</p>
 <h2 data-number="3.10" id="struct-to-struct-of-arrays"><span class="header-section-number">3.10</span> Struct to Struct of Arrays<a href="#struct-to-struct-of-arrays" class="self-link"></a></h2>
 <div class="std">
@@ -4165,29 +4164,20 @@ be explained below.</p>
 <span id="cb79-140"><a href="#cb79-140" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb79-141"><a href="#cb79-141" aria-hidden="true" tabindex="-1"></a>    <span class="kw">consteval</span> <span class="kw">auto</span> define_class<span class="op">(</span>info type_class, R<span class="op">&amp;&amp;)</span> <span class="op">-&gt;</span> info;</span>
 <span id="cb79-142"><a href="#cb79-142" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb79-143"><a href="#cb79-143" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#define_static_string-define_static_array">define_static_string
-and define_static_array</a></span></span>
-<span id="cb79-144"><a href="#cb79-144" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_static_string<span class="op">(</span>string_view str<span class="op">)</span> <span class="op">-&gt;</span> <span class="kw">const</span> <span class="dt">char</span> <span class="op">*</span>;</span>
-<span id="cb79-145"><a href="#cb79-145" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_static_string<span class="op">(</span>u8string_view str<span class="op">)</span> <span class="op">-&gt;</span> <span class="kw">const</span> <span class="dt">char8_t</span> <span class="op">*</span>;</span>
-<span id="cb79-146"><a href="#cb79-146" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb79-147"><a href="#cb79-147" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>ranges<span class="op">::</span>input_range R<span class="op">&gt;</span></span>
-<span id="cb79-148"><a href="#cb79-148" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_static_array<span class="op">(</span>R<span class="op">&amp;&amp;</span> r<span class="op">)</span> <span class="op">-&gt;</span> span<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="kw">const</span><span class="op">&gt;</span>;</span>
-<span id="cb79-149"><a href="#cb79-149" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb79-143"><a href="#cb79-143" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#data-layout-reflection">data layout</a></span></span>
+<span id="cb79-144"><a href="#cb79-144" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> member_offset <span class="op">{</span></span>
+<span id="cb79-145"><a href="#cb79-145" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bytes;</span>
+<span id="cb79-146"><a href="#cb79-146" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bits;</span>
+<span id="cb79-147"><a href="#cb79-147" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> total_bits<span class="op">()</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="dt">ptrdiff_t</span>;</span>
+<span id="cb79-148"><a href="#cb79-148" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> <span class="kw">operator</span><span class="op">&lt;=&gt;(</span>member_offset <span class="kw">const</span><span class="op">&amp;)</span> <span class="kw">const</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb79-149"><a href="#cb79-149" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
 <span id="cb79-150"><a href="#cb79-150" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb79-151"><a href="#cb79-151" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#data-layout-reflection">data layout</a></span></span>
-<span id="cb79-152"><a href="#cb79-152" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> member_offset <span class="op">{</span></span>
-<span id="cb79-153"><a href="#cb79-153" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bytes;</span>
-<span id="cb79-154"><a href="#cb79-154" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bits;</span>
-<span id="cb79-155"><a href="#cb79-155" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> total_bits<span class="op">()</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="dt">ptrdiff_t</span>;</span>
-<span id="cb79-156"><a href="#cb79-156" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> <span class="kw">operator</span><span class="op">&lt;=&gt;(</span>member_offset <span class="kw">const</span><span class="op">&amp;)</span> <span class="kw">const</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb79-157"><a href="#cb79-157" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
-<span id="cb79-158"><a href="#cb79-158" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb79-159"><a href="#cb79-159" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> offset_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> member_offset;</span>
-<span id="cb79-160"><a href="#cb79-160" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb79-161"><a href="#cb79-161" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> alignment_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb79-162"><a href="#cb79-162" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb79-163"><a href="#cb79-163" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb79-164"><a href="#cb79-164" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb79-151"><a href="#cb79-151" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> offset_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> member_offset;</span>
+<span id="cb79-152"><a href="#cb79-152" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb79-153"><a href="#cb79-153" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> alignment_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb79-154"><a href="#cb79-154" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb79-155"><a href="#cb79-155" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb79-156"><a href="#cb79-156" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <h3 data-number="4.4.10" id="name-loc"><span class="header-section-number">4.4.10</span>
@@ -4667,108 +4657,27 @@ a type that already has a definition, or which is in the process of
 being defined, the call to
 <code class="sourceCode cpp">define_class</code> is not a constant
 expression.</p>
-<h3 data-number="4.4.20" id="define_static_string-define_static_array"><span class="header-section-number">4.4.20</span>
-<code class="sourceCode cpp">define_static_string</code>,
-<code class="sourceCode cpp">define_static_array</code><a href="#define_static_string-define_static_array" class="self-link"></a></h3>
+<h3 data-number="4.4.20" id="data-layout-reflection"><span class="header-section-number">4.4.20</span> Data Layout Reflection<a href="#data-layout-reflection" class="self-link"></a></h3>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb100"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb100-1"><a href="#cb100-1" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> std<span class="op">::</span>meta <span class="op">{</span></span>
-<span id="cb100-2"><a href="#cb100-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_static_string<span class="op">(</span>string_view str<span class="op">)</span> <span class="op">-&gt;</span> <span class="kw">const</span> <span class="dt">char</span> <span class="op">*</span>;</span>
-<span id="cb100-3"><a href="#cb100-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_static_string<span class="op">(</span>u8string_view str<span class="op">)</span> <span class="op">-&gt;</span> <span class="kw">const</span> <span class="dt">char8_t</span> <span class="op">*</span>;</span>
-<span id="cb100-4"><a href="#cb100-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb100-5"><a href="#cb100-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>ranges<span class="op">::</span>input_range R<span class="op">&gt;</span></span>
-<span id="cb100-6"><a href="#cb100-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_static_array<span class="op">(</span>R<span class="op">&amp;&amp;</span> r<span class="op">)</span> <span class="op">-&gt;</span> span<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="kw">const</span><span class="op">&gt;</span>;</span>
-<span id="cb100-7"><a href="#cb100-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-</blockquote>
-</div>
-<p>Given a <code class="sourceCode cpp">string_view</code> or
-<code class="sourceCode cpp">u8string_view</code>,
-<code class="sourceCode cpp">define_static_string</code> returns a
-pointer to an array of characters containing the contents of
-<code class="sourceCode cpp">str</code> followed by a null terminator.
-The array object has static storage duration, is not a subobject of a
-string literal object, and is usable in constant expressions; a pointer
-to such an object meets the requirements for use as a non-type template
-argument.</p>
-<div class="std">
-<blockquote>
-<div class="sourceCode" id="cb101"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb101-1"><a href="#cb101-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">const</span> <span class="dt">char</span> <span class="op">*</span>P<span class="op">&gt;</span> <span class="kw">struct</span> C <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb101-2"><a href="#cb101-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb101-3"><a href="#cb101-3" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">char</span> msg<span class="op">[]</span> <span class="op">=</span> <span class="st">&quot;strongly in favor&quot;</span>;  <span class="co">// just an idea..</span></span>
-<span id="cb101-4"><a href="#cb101-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb101-5"><a href="#cb101-5" aria-hidden="true" tabindex="-1"></a>C<span class="op">&lt;</span>msg<span class="op">&gt;</span> c1;                          <span class="co">// ok</span></span>
-<span id="cb101-6"><a href="#cb101-6" aria-hidden="true" tabindex="-1"></a>C<span class="op">&lt;</span><span class="st">&quot;nope&quot;</span><span class="op">&gt;</span> c2;                       <span class="co">// ill-formed</span></span>
-<span id="cb101-7"><a href="#cb101-7" aria-hidden="true" tabindex="-1"></a>C<span class="op">&lt;</span>define_static_string<span class="op">(</span><span class="st">&quot;yay&quot;</span><span class="op">)&gt;</span> c3;  <span class="co">// ok</span></span></code></pre></div>
-</blockquote>
-</div>
-<p>In the absence of general support for non-transient constexpr
-allocation, such a facility is essential to building utilities like
-pretty printers.</p>
-<p>An example of such an interface might be built as follow:</p>
-<div class="std">
-<blockquote>
-<div class="sourceCode" id="cb102"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb102-1"><a href="#cb102-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info R<span class="op">&gt;</span> <span class="kw">requires</span> is_value<span class="op">(</span>R<span class="op">)</span></span>
-<span id="cb102-2"><a href="#cb102-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> render<span class="op">()</span> <span class="op">-&gt;</span> std<span class="op">::</span>string;</span>
-<span id="cb102-3"><a href="#cb102-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb102-4"><a href="#cb102-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info R<span class="op">&gt;</span> <span class="kw">requires</span> is_type<span class="op">(</span>R<span class="op">)</span></span>
-<span id="cb102-5"><a href="#cb102-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> render<span class="op">()</span> <span class="op">-&gt;</span> std<span class="op">::</span>string;</span>
-<span id="cb102-6"><a href="#cb102-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb102-7"><a href="#cb102-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info R<span class="op">&gt;</span> <span class="kw">requires</span> is_variable<span class="op">(</span>R<span class="op">)</span></span>
-<span id="cb102-8"><a href="#cb102-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> render<span class="op">()</span> <span class="op">-&gt;</span> std<span class="op">::</span>string;</span>
-<span id="cb102-9"><a href="#cb102-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb102-10"><a href="#cb102-10" aria-hidden="true" tabindex="-1"></a><span class="co">// ...</span></span>
-<span id="cb102-11"><a href="#cb102-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb102-12"><a href="#cb102-12" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info R<span class="op">&gt;</span></span>
-<span id="cb102-13"><a href="#cb102-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> pretty_print<span class="op">()</span> <span class="op">-&gt;</span> std<span class="op">::</span>string_view <span class="op">{</span></span>
-<span id="cb102-14"><a href="#cb102-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> define_static_string<span class="op">(</span>render<span class="op">&lt;</span>R<span class="op">&gt;())</span>;</span>
-<span id="cb102-15"><a href="#cb102-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-</blockquote>
-</div>
-<p>This strategy <a href="https://github.com/bloomberg/clang-p2996/blob/149cca52811b59b22608f6f6e303f6589969c999/libcxx/include/experimental/meta#L2317-L2321">lies
-at the core</a> of how the Clang/P2996 fork builds its example
-implementation of the
-<code class="sourceCode cpp">display_string_of</code> metafunction.</p>
-<p><code class="sourceCode cpp">define_static_array</code> is a more
-general version of
-<code class="sourceCode cpp">define_static_string</code> that works for
-all types. The difference between the two is that
-<code class="sourceCode cpp">define_static_string</code> produces a
-null-terminated array, and thus returns just a pointer, while
-<code class="sourceCode cpp">define_static_array</code> produces an
-array that is the same size as the input range.</p>
-<p>Technically, <code class="sourceCode cpp">define_static_array</code>
-can be used to implement
-<code class="sourceCode cpp">define_static_string</code>:</p>
-<div class="std">
-<blockquote>
-<div class="sourceCode" id="cb103"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb103-1"><a href="#cb103-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> define_static_string<span class="op">(</span>string_view str<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">char</span> <span class="kw">const</span><span class="op">*</span> <span class="op">{</span></span>
-<span id="cb103-2"><a href="#cb103-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> define_static_array<span class="op">(</span>views<span class="op">::</span>concat<span class="op">(</span>str, views<span class="op">::</span>single<span class="op">(</span><span class="ch">&#39;</span><span class="sc">\0</span><span class="ch">&#39;</span><span class="op">))).</span>data<span class="op">()</span>;</span>
-<span id="cb103-3"><a href="#cb103-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
-</blockquote>
-</div>
-<p>But that’s a fairly awkward implementation, and the string use-case
-is sufficiently common as to merit a more ergonomic solution.</p>
-<h3 data-number="4.4.21" id="data-layout-reflection"><span class="header-section-number">4.4.21</span> Data Layout Reflection<a href="#data-layout-reflection" class="self-link"></a></h3>
-<div class="std">
-<blockquote>
-<div class="sourceCode" id="cb104"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb104-1"><a href="#cb104-1" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> std<span class="op">::</span>meta <span class="op">{</span></span>
-<span id="cb104-2"><a href="#cb104-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> member_offset <span class="op">{</span></span>
-<span id="cb104-3"><a href="#cb104-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bytes;</span>
-<span id="cb104-4"><a href="#cb104-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bits;</span>
-<span id="cb104-5"><a href="#cb104-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb104-6"><a href="#cb104-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> total_bits<span class="op">()</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="dt">ptrdiff_t</span> <span class="op">{</span></span>
-<span id="cb104-7"><a href="#cb104-7" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> CHAR_BIT <span class="op">*</span> bytes <span class="op">+</span> bits;</span>
-<span id="cb104-8"><a href="#cb104-8" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb104-9"><a href="#cb104-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb104-10"><a href="#cb104-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> <span class="kw">operator</span><span class="op">&lt;=&gt;(</span>member_offset <span class="kw">const</span><span class="op">&amp;)</span> <span class="kw">const</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb104-11"><a href="#cb104-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
-<span id="cb104-12"><a href="#cb104-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb104-13"><a href="#cb104-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> offset_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> member_offset;</span>
-<span id="cb104-14"><a href="#cb104-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb104-15"><a href="#cb104-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> alignment_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb104-16"><a href="#cb104-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
-<span id="cb104-17"><a href="#cb104-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb104-18"><a href="#cb104-18" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb100-2"><a href="#cb100-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> member_offset <span class="op">{</span></span>
+<span id="cb100-3"><a href="#cb100-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bytes;</span>
+<span id="cb100-4"><a href="#cb100-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">ptrdiff_t</span> bits;</span>
+<span id="cb100-5"><a href="#cb100-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb100-6"><a href="#cb100-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> total_bits<span class="op">()</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="dt">ptrdiff_t</span> <span class="op">{</span></span>
+<span id="cb100-7"><a href="#cb100-7" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> CHAR_BIT <span class="op">*</span> bytes <span class="op">+</span> bits;</span>
+<span id="cb100-8"><a href="#cb100-8" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb100-9"><a href="#cb100-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb100-10"><a href="#cb100-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> <span class="kw">operator</span><span class="op">&lt;=&gt;(</span>member_offset <span class="kw">const</span><span class="op">&amp;)</span> <span class="kw">const</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb100-11"><a href="#cb100-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
+<span id="cb100-12"><a href="#cb100-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb100-13"><a href="#cb100-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> offset_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> member_offset;</span>
+<span id="cb100-14"><a href="#cb100-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb100-15"><a href="#cb100-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> alignment_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb100-16"><a href="#cb100-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">size_t</span>;</span>
+<span id="cb100-17"><a href="#cb100-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb100-18"><a href="#cb100-18" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <p>These are generalized versions of some facilities we already have in
@@ -4791,30 +4700,30 @@ base class subobject or non-static data member, except in bits.</li>
 </ul>
 <div class="std">
 <blockquote>
-<div class="sourceCode" id="cb105"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Msg <span class="op">{</span></span>
-<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> a <span class="op">:</span> <span class="dv">10</span>;</span>
-<span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> b <span class="op">:</span>  <span class="dv">8</span>;</span>
-<span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> c <span class="op">:</span> <span class="dv">25</span>;</span>
-<span id="cb105-5"><a href="#cb105-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> d <span class="op">:</span> <span class="dv">21</span>;</span>
-<span id="cb105-6"><a href="#cb105-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb105-7"><a href="#cb105-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb105-8"><a href="#cb105-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>a<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">})</span>;</span>
-<span id="cb105-9"><a href="#cb105-9" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>b<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">1</span>, <span class="dv">2</span><span class="op">})</span>;</span>
-<span id="cb105-10"><a href="#cb105-10" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>c<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">2</span>, <span class="dv">2</span><span class="op">})</span>;</span>
-<span id="cb105-11"><a href="#cb105-11" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>d<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">5</span>, <span class="dv">3</span><span class="op">})</span>;</span>
-<span id="cb105-12"><a href="#cb105-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb105-13"><a href="#cb105-13" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>a<span class="op">)</span> <span class="op">==</span> <span class="dv">10</span><span class="op">)</span>;</span>
-<span id="cb105-14"><a href="#cb105-14" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>b<span class="op">)</span> <span class="op">==</span> <span class="dv">8</span><span class="op">)</span>;</span>
-<span id="cb105-15"><a href="#cb105-15" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>c<span class="op">)</span> <span class="op">==</span> <span class="dv">25</span><span class="op">)</span>;</span>
-<span id="cb105-16"><a href="#cb105-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>d<span class="op">)</span> <span class="op">==</span> <span class="dv">21</span><span class="op">)</span>;</span>
-<span id="cb105-17"><a href="#cb105-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb105-18"><a href="#cb105-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>a<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb105-19"><a href="#cb105-19" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>b<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">10</span><span class="op">)</span>;</span>
-<span id="cb105-20"><a href="#cb105-20" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>c<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">18</span><span class="op">)</span>;</span>
-<span id="cb105-21"><a href="#cb105-21" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>d<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">43</span><span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb101"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb101-1"><a href="#cb101-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Msg <span class="op">{</span></span>
+<span id="cb101-2"><a href="#cb101-2" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> a <span class="op">:</span> <span class="dv">10</span>;</span>
+<span id="cb101-3"><a href="#cb101-3" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> b <span class="op">:</span>  <span class="dv">8</span>;</span>
+<span id="cb101-4"><a href="#cb101-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> c <span class="op">:</span> <span class="dv">25</span>;</span>
+<span id="cb101-5"><a href="#cb101-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">uint64_t</span> d <span class="op">:</span> <span class="dv">21</span>;</span>
+<span id="cb101-6"><a href="#cb101-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb101-7"><a href="#cb101-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb101-8"><a href="#cb101-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>a<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">})</span>;</span>
+<span id="cb101-9"><a href="#cb101-9" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>b<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">1</span>, <span class="dv">2</span><span class="op">})</span>;</span>
+<span id="cb101-10"><a href="#cb101-10" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>c<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">2</span>, <span class="dv">2</span><span class="op">})</span>;</span>
+<span id="cb101-11"><a href="#cb101-11" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>d<span class="op">)</span> <span class="op">==</span> member_offset<span class="op">{</span><span class="dv">5</span>, <span class="dv">3</span><span class="op">})</span>;</span>
+<span id="cb101-12"><a href="#cb101-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb101-13"><a href="#cb101-13" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>a<span class="op">)</span> <span class="op">==</span> <span class="dv">10</span><span class="op">)</span>;</span>
+<span id="cb101-14"><a href="#cb101-14" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>b<span class="op">)</span> <span class="op">==</span> <span class="dv">8</span><span class="op">)</span>;</span>
+<span id="cb101-15"><a href="#cb101-15" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>c<span class="op">)</span> <span class="op">==</span> <span class="dv">25</span><span class="op">)</span>;</span>
+<span id="cb101-16"><a href="#cb101-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>bit_size_of<span class="op">(^</span>Msg<span class="op">::</span>d<span class="op">)</span> <span class="op">==</span> <span class="dv">21</span><span class="op">)</span>;</span>
+<span id="cb101-17"><a href="#cb101-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb101-18"><a href="#cb101-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>a<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb101-19"><a href="#cb101-19" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>b<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">10</span><span class="op">)</span>;</span>
+<span id="cb101-20"><a href="#cb101-20" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>c<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">18</span><span class="op">)</span>;</span>
+<span id="cb101-21"><a href="#cb101-21" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>offset_of<span class="op">(^</span>Msg<span class="op">::</span>d<span class="op">).</span>total_bits<span class="op">()</span> <span class="op">==</span> <span class="dv">43</span><span class="op">)</span>;</span></code></pre></div>
 </blockquote>
 </div>
-<h3 data-number="4.4.22" id="other-type-traits"><span class="header-section-number">4.4.22</span> Other Type Traits<a href="#other-type-traits" class="self-link"></a></h3>
+<h3 data-number="4.4.21" id="other-type-traits"><span class="header-section-number">4.4.21</span> Other Type Traits<a href="#other-type-traits" class="self-link"></a></h3>
 <p>There is a question of whether all the type traits should be provided
 in
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>.
@@ -4836,24 +4745,24 @@ necessary - since it can be provided indirectly:</p>
 <tr class="odd">
 <td><div>
 
-<div class="sourceCode" id="cb106"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>type_remove_cvref<span class="op">(</span>type<span class="op">)</span></span></code></pre></div>
+<div class="sourceCode" id="cb102"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb102-1"><a href="#cb102-1" aria-hidden="true" tabindex="-1"></a>type_remove_cvref<span class="op">(</span>type<span class="op">)</span></span></code></pre></div>
 
 </div></td>
 <td><div>
 
-<div class="sourceCode" id="cb107"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a>dealias<span class="op">(</span>substitute<span class="op">(^</span>std<span class="op">::</span>remove_cvref_t, <span class="op">{</span>type<span class="op">}))</span></span></code></pre></div>
+<div class="sourceCode" id="cb103"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb103-1"><a href="#cb103-1" aria-hidden="true" tabindex="-1"></a>dealias<span class="op">(</span>substitute<span class="op">(^</span>std<span class="op">::</span>remove_cvref_t, <span class="op">{</span>type<span class="op">}))</span></span></code></pre></div>
 
 </div></td>
 </tr>
 <tr class="even">
 <td><div>
 
-<div class="sourceCode" id="cb108"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a>type_is_const<span class="op">(</span>type<span class="op">)</span></span></code></pre></div>
+<div class="sourceCode" id="cb104"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb104-1"><a href="#cb104-1" aria-hidden="true" tabindex="-1"></a>type_is_const<span class="op">(</span>type<span class="op">)</span></span></code></pre></div>
 
 </div></td>
 <td><div>
 
-<div class="sourceCode" id="cb109"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a>extract<span class="op">&lt;</span><span class="dt">bool</span><span class="op">&gt;(</span>substitute<span class="op">(^</span>std<span class="op">::</span>is_const_v, <span class="op">{</span>type<span class="op">}))</span></span></code></pre></div>
+<div class="sourceCode" id="cb105"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a>extract<span class="op">&lt;</span><span class="dt">bool</span><span class="op">&gt;(</span>substitute<span class="op">(^</span>std<span class="op">::</span>is_const_v, <span class="op">{</span>type<span class="op">}))</span></span></code></pre></div>
 
 </div></td>
 </tr>
@@ -5004,15 +4913,15 @@ and the variant traits
 (<code class="sourceCode cpp">variant_size</code>/<code class="sourceCode cpp">variant_alternative</code>).</p>
 <h2 data-number="4.5" id="odr-concerns"><span class="header-section-number">4.5</span> ODR Concerns<a href="#odr-concerns" class="self-link"></a></h2>
 <p>Static reflection invariably brings new ways to violate ODR.</p>
-<div class="sourceCode" id="cb110"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><span class="co">// File &#39;cls.h&#39;</span></span>
-<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Cls <span class="op">{</span></span>
-<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> odr_violator<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>members_of<span class="op">(</span>parent_of<span class="op">(^</span>std<span class="op">::</span><span class="dt">size_t</span><span class="op">)).</span>size<span class="op">()</span> <span class="op">%</span> <span class="dv">2</span> <span class="op">==</span> <span class="dv">0</span><span class="op">)</span></span>
-<span id="cb110-5"><a href="#cb110-5" aria-hidden="true" tabindex="-1"></a>      branch_1<span class="op">()</span>;</span>
-<span id="cb110-6"><a href="#cb110-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span></span>
-<span id="cb110-7"><a href="#cb110-7" aria-hidden="true" tabindex="-1"></a>      branch_2<span class="op">()</span>;</span>
-<span id="cb110-8"><a href="#cb110-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb110-9"><a href="#cb110-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb106"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a><span class="co">// File &#39;cls.h&#39;</span></span>
+<span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Cls <span class="op">{</span></span>
+<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> odr_violator<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>members_of<span class="op">(</span>parent_of<span class="op">(^</span>std<span class="op">::</span><span class="dt">size_t</span><span class="op">)).</span>size<span class="op">()</span> <span class="op">%</span> <span class="dv">2</span> <span class="op">==</span> <span class="dv">0</span><span class="op">)</span></span>
+<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a>      branch_1<span class="op">()</span>;</span>
+<span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span></span>
+<span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a>      branch_2<span class="op">()</span>;</span>
+<span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <p>Two translation units including
 <code class="sourceCode cpp">cls<span class="op">.</span>h</code> can
 generate different definitions of <code class="sourceCode cpp">Cls<span class="op">::</span>odr_violator<span class="op">()</span></code>
@@ -5138,16 +5047,16 @@ paragraph 1 of <span>5.12 <a href="https://wg21.link/lex.operators">[lex.operato
 include splicer delimiters:</p>
 <div class="std">
 <blockquote>
-<div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a>  <em>operator-or-punctuator</em>: <em>one of</em></span>
-<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>         {        }        [        ]        (        )        <span class="addu"><code class="sourceCode cpp"><span class="op">[:</span>        <span class="op">:]</span></code></span></span>
-<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>         &lt;:       :&gt;       &lt;%       %&gt;       ;        :        ...</span>
-<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a>         ?        ::       .       .*        -&gt;       -&gt;*      ~</span>
-<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a>         !        +        -        *        /        %        ^        &amp;        |</span>
-<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>         =        +=       -=       *=       /=       %=       ^=       &amp;=       |=</span>
-<span id="cb111-7"><a href="#cb111-7" aria-hidden="true" tabindex="-1"></a>         ==       !=       &lt;        &gt;        &lt;=       &gt;=       &lt;=&gt;      &amp;&amp;       ||</span>
-<span id="cb111-8"><a href="#cb111-8" aria-hidden="true" tabindex="-1"></a>         &lt;&lt;       &gt;&gt;       &lt;&lt;=      &gt;&gt;=      ++       --       ,</span>
-<span id="cb111-9"><a href="#cb111-9" aria-hidden="true" tabindex="-1"></a>         and      or       xor      not      bitand   bitor    compl</span>
-<span id="cb111-10"><a href="#cb111-10" aria-hidden="true" tabindex="-1"></a>         and_eq   or_eq    xor_eq   not_eq</span></code></pre></div>
+<div class="sourceCode" id="cb107"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a>  <em>operator-or-punctuator</em>: <em>one of</em></span>
+<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>         {        }        [        ]        (        )        <span class="addu"><code class="sourceCode cpp"><span class="op">[:</span>        <span class="op">:]</span></code></span></span>
+<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>         &lt;:       :&gt;       &lt;%       %&gt;       ;        :        ...</span>
+<span id="cb107-4"><a href="#cb107-4" aria-hidden="true" tabindex="-1"></a>         ?        ::       .       .*        -&gt;       -&gt;*      ~</span>
+<span id="cb107-5"><a href="#cb107-5" aria-hidden="true" tabindex="-1"></a>         !        +        -        *        /        %        ^        &amp;        |</span>
+<span id="cb107-6"><a href="#cb107-6" aria-hidden="true" tabindex="-1"></a>         =        +=       -=       *=       /=       %=       ^=       &amp;=       |=</span>
+<span id="cb107-7"><a href="#cb107-7" aria-hidden="true" tabindex="-1"></a>         ==       !=       &lt;        &gt;        &lt;=       &gt;=       &lt;=&gt;      &amp;&amp;       ||</span>
+<span id="cb107-8"><a href="#cb107-8" aria-hidden="true" tabindex="-1"></a>         &lt;&lt;       &gt;&gt;       &lt;&lt;=      &gt;&gt;=      ++       --       ,</span>
+<span id="cb107-9"><a href="#cb107-9" aria-hidden="true" tabindex="-1"></a>         and      or       xor      not      bitand   bitor    compl</span>
+<span id="cb107-10"><a href="#cb107-10" aria-hidden="true" tabindex="-1"></a>         and_eq   or_eq    xor_eq   not_eq</span></code></pre></div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="basic.def.odr-one-definition-rule"><span>6.3
@@ -5426,7 +5335,8 @@ template, alias template, or concept,</li>
 <p>An expression convertible to a reflection is said to
 <em>represent</em> the corresponding entity, alias, object, value, base
 class specifier, or description of a declaration of a non-static data
-member.</p>
+member. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
+shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span><span class="dt">void</span><span class="op">*)</span></code>.</p>
 </div>
 </blockquote>
 </div>
@@ -5439,15 +5349,15 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb112"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a>  <em>primary-expression</em>:</span>
-<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
-<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a>     this</span>
-<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a>     ( <em>expression</em> )</span>
-<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a>     <em>id-expression</em></span>
-<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a>     <em>lambda-expression</em></span>
-<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a>     <em>fold-expression</em></span>
-<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
-<span id="cb112-9"><a href="#cb112-9" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb108"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a>  <em>primary-expression</em>:</span>
+<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
+<span id="cb108-3"><a href="#cb108-3" aria-hidden="true" tabindex="-1"></a>     this</span>
+<span id="cb108-4"><a href="#cb108-4" aria-hidden="true" tabindex="-1"></a>     ( <em>expression</em> )</span>
+<span id="cb108-5"><a href="#cb108-5" aria-hidden="true" tabindex="-1"></a>     <em>id-expression</em></span>
+<span id="cb108-6"><a href="#cb108-6" aria-hidden="true" tabindex="-1"></a>     <em>lambda-expression</em></span>
+<span id="cb108-7"><a href="#cb108-7" aria-hidden="true" tabindex="-1"></a>     <em>fold-expression</em></span>
+<span id="cb108-8"><a href="#cb108-8" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
+<span id="cb108-9"><a href="#cb108-9" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5458,8 +5368,8 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb113"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><em>splice-specifier</em>:</span>
-<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span></code></pre></div>
+<div class="sourceCode" id="cb109"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a><em>splice-specifier</em>:</span>
+<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">1</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> shall be
@@ -5478,10 +5388,10 @@ value-dependent.</p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
-<p>Add a carve-out for reflection in <span>7.5.5.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
+<p>Add a carve-out for reflection in <span>7.5.4.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">4</a></span>
@@ -5509,7 +5419,7 @@ an unevaluated operand.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Add a production to the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -5517,17 +5427,17 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb114"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a>  <em>nested-name-specifier</em>:</span>
-<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
-<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
-<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
-<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-qualifier</em> ::</span></span>
-<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
-<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
-<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span>
-<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-qualifier</em>:</span></span>
-<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb110"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a>  <em>nested-name-specifier</em>:</span>
+<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
+<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
+<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
+<span id="cb110-5"><a href="#cb110-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-qualifier</em> ::</span></span>
+<span id="cb110-6"><a href="#cb110-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
+<span id="cb110-7"><a href="#cb110-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
+<span id="cb110-8"><a href="#cb110-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span>
+<span id="cb110-9"><a href="#cb110-9" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb110-10"><a href="#cb110-10" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-qualifier</em>:</span></span>
+<span id="cb110-11"><a href="#cb110-11" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5606,15 +5516,15 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
 <p><strong>Expression Splicing [expr.prim.splice]</strong></p>
 <p>FIXME: text for the template version.</p>
-<div class="sourceCode" id="cb115"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
-<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
-<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></code></pre></div>
+<div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
+<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
+<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">1</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 not designate an unnamed bit-field, a constructor or destructor, or a
@@ -5662,13 +5572,13 @@ splices in member access expressions:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>[1]{.pnum} Postfix expressions group left-to-right.</span>
-<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>  <em>postfix-expression</em>:</span>
-<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a>    ...</span>
-<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
-<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span>
-<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
-<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb112"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a>[1]{.pnum} Postfix expressions group left-to-right.</span>
+<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a>  <em>postfix-expression</em>:</span>
+<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
+<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span>
+<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
+<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5836,10 +5746,10 @@ paragraph 1 to add productions for the new operator:</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
-<div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
-<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a>     ...</span>
-<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a>     <em>delete-expression</em></span>
-<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb113"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
+<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a>     ...</span>
+<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a>     <em>delete-expression</em></span>
+<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5898,13 +5808,13 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <code class="sourceCode cpp"><em>id-expression</em></code> can both
 refer to template names, have to handle this better. See wording in the
 template argument parsing section.</p>
-<div class="sourceCode" id="cb118"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a><em>reflect-expression</em>:</span>
-<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>   ^ ::</span>
-<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
-<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></span>
-<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
-<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a>   ^ <em>id-expression</em></span></code></pre></div>
+<div class="sourceCode" id="cb114"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><em>reflect-expression</em>:</span>
+<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a>   ^ ::</span>
+<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></span>
+<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
+<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
+<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>   ^ <em>id-expression</em></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
@@ -5917,19 +5827,19 @@ of tokens that could syntactically form a
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb119"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a>template&lt;bool&gt; struct X {};</span>
-<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a>bool operator&lt;(std::meta::info, X&lt;false&gt;);</span>
-<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a>consteval void g(std::meta::info r, X&lt;false&gt; xv) {</span>
-<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp; true;    // error: ^ applies to the type-id &quot;int&amp;&amp;&quot;</span>
-<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp; true;     // error: ^ applies to the type-id &quot;int&amp;&quot;</span>
-<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a>  r == (^int) &amp;&amp; true;  // OK</span>
-<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp;&amp;&amp; true;  // OK</span>
-<span id="cb119-10"><a href="#cb119-10" aria-hidden="true" tabindex="-1"></a>  ^X &lt; xv;              // error: &lt; starts template argument list</span>
-<span id="cb119-11"><a href="#cb119-11" aria-hidden="true" tabindex="-1"></a>  (^X) &lt; xv;            // OK</span>
-<span id="cb119-12"><a href="#cb119-12" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb119-13"><a href="#cb119-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
+<div class="sourceCode" id="cb115"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>template&lt;bool&gt; struct X {};</span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>bool operator&lt;(std::meta::info, X&lt;false&gt;);</span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a>consteval void g(std::meta::info r, X&lt;false&gt; xv) {</span>
+<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp; true;    // error: ^ applies to the type-id &quot;int&amp;&amp;&quot;</span>
+<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp; true;     // error: ^ applies to the type-id &quot;int&amp;&quot;</span>
+<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a>  r == (^int) &amp;&amp; true;  // OK</span>
+<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp;&amp;&amp; true;  // OK</span>
+<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>  ^X &lt; xv;              // error: &lt; starts template argument list</span>
+<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>  (^X) &lt; xv;            // OK</span>
+<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">4</a></span>
@@ -5996,14 +5906,14 @@ evaluated.</p></li>
 </ul>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb120"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">!=</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">==</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span><span class="dt">int</span><span class="op">))</span>;</span>
-<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb120-5"><a href="#cb120-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> R <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
-<span id="cb120-6"><a href="#cb120-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> S <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: cannot reflect an overload set</span></span>
-<span id="cb120-7"><a href="#cb120-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb120-8"><a href="#cb120-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span></code></pre></div>
+<div class="sourceCode" id="cb116"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">!=</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">==</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span><span class="dt">int</span><span class="op">))</span>;</span>
+<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> R <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
+<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> S <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: cannot reflect an overload set</span></span>
+<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6144,7 +6054,7 @@ results from the substitution of template parameters
 (<span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
 <li>in a
 <code class="sourceCode cpp"><em>requires-expression</em></code>
-(<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>),
+(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>),
 or</li>
 </ul></li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(20.4.2)</a></span>
@@ -6163,19 +6073,19 @@ detailed below, evaluations of such expressions are allowed to produce
 injected declarations.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb121"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
-<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
-<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb121-8"><a href="#cb121-8" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
-<span id="cb121-9"><a href="#cb121-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb121-10"><a href="#cb121-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb121-11"><a href="#cb121-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb121-12"><a href="#cb121-12" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
-<span id="cb121-13"><a href="#cb121-13" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
+<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
+<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
+<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
+<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb117-8"><a href="#cb117-8" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
+<span id="cb117-9"><a href="#cb117-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb117-10"><a href="#cb117-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb117-11"><a href="#cb117-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb117-12"><a href="#cb117-12" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
+<span id="cb117-13"><a href="#cb117-13" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6273,33 +6183,33 @@ declarations when such evaluations can be guaranteed to only happen
 once.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb122"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
-<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
-<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
-<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
-<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
-<span id="cb122-8"><a href="#cb122-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb122-9"><a href="#cb122-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
-<span id="cb122-10"><a href="#cb122-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
-<span id="cb122-11"><a href="#cb122-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
-<span id="cb122-12"><a href="#cb122-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb122-13"><a href="#cb122-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
-<span id="cb122-14"><a href="#cb122-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
-<span id="cb122-15"><a href="#cb122-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
-<span id="cb122-16"><a href="#cb122-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb122-17"><a href="#cb122-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb122-18"><a href="#cb122-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
-<span id="cb122-19"><a href="#cb122-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
-<span id="cb122-20"><a href="#cb122-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb122-21"><a href="#cb122-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
-<span id="cb122-22"><a href="#cb122-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
-<span id="cb122-23"><a href="#cb122-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
-<span id="cb122-24"><a href="#cb122-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evalauted.</span></span>
-<span id="cb122-25"><a href="#cb122-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
-<span id="cb122-26"><a href="#cb122-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
-<span id="cb122-27"><a href="#cb122-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb118"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
+<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
+<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
+<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
+<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
+<span id="cb118-8"><a href="#cb118-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-9"><a href="#cb118-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
+<span id="cb118-10"><a href="#cb118-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
+<span id="cb118-11"><a href="#cb118-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
+<span id="cb118-12"><a href="#cb118-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-13"><a href="#cb118-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
+<span id="cb118-14"><a href="#cb118-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
+<span id="cb118-15"><a href="#cb118-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
+<span id="cb118-16"><a href="#cb118-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-17"><a href="#cb118-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb118-18"><a href="#cb118-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
+<span id="cb118-19"><a href="#cb118-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
+<span id="cb118-20"><a href="#cb118-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb118-21"><a href="#cb118-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
+<span id="cb118-22"><a href="#cb118-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
+<span id="cb118-23"><a href="#cb118-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
+<span id="cb118-24"><a href="#cb118-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evalauted.</span></span>
+<span id="cb118-25"><a href="#cb118-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
+<span id="cb118-26"><a href="#cb118-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
+<span id="cb118-27"><a href="#cb118-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">24</a></span>
@@ -6331,10 +6241,10 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb123"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
-<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
-<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
-<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
+<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6346,8 +6256,8 @@ follows:</p>
 <blockquote>
 <div class="addu">
 <div>
-<div class="sourceCode" id="cb124"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
-<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">1</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
@@ -6465,13 +6375,13 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
-<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
-<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
-<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
+<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
+<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
+<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6501,15 +6411,15 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias</em>:</span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>      <em>identifier</em></span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
-<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
-<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>  <em>qualified-namespace-specifier</em>:</span>
-<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
-<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb122"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias</em>:</span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>      <em>identifier</em></span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
+<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
+<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a>  <em>qualified-namespace-specifier</em>:</span>
+<span id="cb122-8"><a href="#cb122-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb122-9"><a href="#cb122-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6555,9 +6465,9 @@ in the grammar for
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>qualified-namespace-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb123"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
+<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
+<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>qualified-namespace-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6613,10 +6523,10 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
-<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
-<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
+<div class="sourceCode" id="cb124"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
+<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
+<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6624,13 +6534,13 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
-<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
-<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
-<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
-<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
-<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
-<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
+<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
+<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
+<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
+<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6722,8 +6632,8 @@ For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 there exist candidate operator functions of the form</p>
-<div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
-<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb126"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.param-template-parameters"><span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span> Template
@@ -6747,22 +6657,22 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb131"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-name</em>:</span></span>
-<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a><span class="va">+     template <em>splice-specifier</em></span></span>
-<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
-<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span>
-<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
-<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>      identifier</span>
-<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-name</em></span></span>
-<span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
-<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
-<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
-<span id="cb131-14"><a href="#cb131-14" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
-<span id="cb131-15"><a href="#cb131-15" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
-<span id="cb131-16"><a href="#cb131-16" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-name</em>:</span></span>
+<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a><span class="va">+     template <em>splice-specifier</em></span></span>
+<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
+<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span>
+<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
+<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>      identifier</span>
+<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-name</em></span></span>
+<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
+<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
+<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
+<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
+<span id="cb127-15"><a href="#cb127-15" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
+<span id="cb127-16"><a href="#cb127-16" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6823,20 +6733,20 @@ it follows a
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div>
-<div class="sourceCode" id="cb132"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
-<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
-<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>};</span>
-<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
-<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
-<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
-<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
-<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
-<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
-<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
-<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
-<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
+<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>};</span>
+<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
+<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
+<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
+<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
+<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
+<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb128-11"><a href="#cb128-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
+<span id="cb128-12"><a href="#cb128-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
+<span id="cb128-13"><a href="#cb128-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
+<span id="cb128-14"><a href="#cb128-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -6877,16 +6787,16 @@ regardless of the form of the corresponding
 <div class="example2">
 <span>[ <em>Example 2:</em> </span>
 <div>
-<div class="sourceCode" id="cb133"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
-<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
-<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
-<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
-<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
-<span id="cb133-8"><a href="#cb133-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-template-argument: calls the first f()</span></span>
-<span id="cb133-9"><a href="#cb133-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-template-argument: calls the second f()</span></span>
-<span id="cb133-10"><a href="#cb133-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
+<div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
+<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
+<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
+<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
+<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-template-argument: calls the first f()</span></span>
+<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-template-argument: calls the second f()</span></span>
+<span id="cb129-10"><a href="#cb129-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -6979,9 +6889,9 @@ splicing reflections of concepts:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb134"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
-<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
-<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-name</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb130"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
+<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
+<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-name</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7005,19 +6915,19 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb135"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
-<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
-<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
-<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
-<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
-<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
-<span id="cb135-7"><a href="#cb135-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
-<span id="cb135-8"><a href="#cb135-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
-<span id="cb135-9"><a href="#cb135-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
-<span id="cb135-10"><a href="#cb135-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
-<span id="cb135-11"><a href="#cb135-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
-<span id="cb135-12"><a href="#cb135-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
-<span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb131"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
+<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
+<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
+<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
+<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
+<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
+<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
+<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
+<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
+<span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
+<span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
+<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
+<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7053,12 +6963,12 @@ An <em>id-expression</em> is value-dependent if:</p>
 <p>Expressions of the following form are value-dependent if the
 <em>unary-expression</em> or <em>expression</em> is type-dependent or
 the <em>type-id</em> is dependent:</p>
-<div class="sourceCode" id="cb136"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
-<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
-<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
-<span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
-<span id="cb136-5"><a href="#cb136-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
-<span id="cb136-6"><a href="#cb136-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
+<div class="sourceCode" id="cb132"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
 <p><span class="addu">A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 value-dependent if the operand of the reflection operator is a
@@ -7096,8 +7006,8 @@ to disallow lambdas in the same context.</p>
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">9</a></span>
 Preprocessing directives of the forms</p>
-<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
-<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
+<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
 <p>check whether the controlling constant expression evaluates to
 nonzero. <span class="addu">The program is ill-formed if a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> or
@@ -7170,20 +7080,20 @@ synopsis<a href="#meta.type.synop-header-type_traits-synopsis" class="self-link"
 synopsis</strong></p>
 <p>…</p>
 <div>
-<div class="sourceCode" id="cb138"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
-<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
-<span id="cb138-5"><a href="#cb138-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
-<span id="cb138-6"><a href="#cb138-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-7"><a href="#cb138-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb138-8"><a href="#cb138-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb138-9"><a href="#cb138-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
-<span id="cb138-10"><a href="#cb138-10" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb138-11"><a href="#cb138-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb138-12"><a href="#cb138-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
-<span id="cb138-13"><a href="#cb138-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
-<span id="cb138-14"><a href="#cb138-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
+<div class="sourceCode" id="cb134"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
+<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
+<span id="cb134-5"><a href="#cb134-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
+<span id="cb134-6"><a href="#cb134-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb134-7"><a href="#cb134-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb134-8"><a href="#cb134-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb134-9"><a href="#cb134-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
+<span id="cb134-10"><a href="#cb134-10" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb134-11"><a href="#cb134-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb134-12"><a href="#cb134-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
+<span id="cb134-13"><a href="#cb134-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
+<span id="cb134-14"><a href="#cb134-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7205,8 +7115,8 @@ Comments
 </tr>
 <tr>
 <td>
-<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
+<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
 </td>
 <td style="text-align:center; vertical-align: middle">
 <code class="sourceCode cpp">T</code> is
@@ -7229,8 +7139,8 @@ Comments
 <tr>
 <td>
 <div class="addu">
-<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
+<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
 </div>
 </td>
 <td style="text-align:center; vertical-align: middle">
@@ -7254,365 +7164,359 @@ synopsis<a href="#meta.synop-header-meta-synopsis" class="self-link"></a></h3>
 <div class="addu">
 <p><strong>Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
 synopsis</strong></p>
-<div class="sourceCode" id="cb141"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
-<span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
-<span id="cb141-3"><a href="#cb141-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
-<span id="cb141-4"><a href="#cb141-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
-<span id="cb141-5"><a href="#cb141-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-6"><a href="#cb141-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb141-7"><a href="#cb141-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
-<span id="cb141-8"><a href="#cb141-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-9"><a href="#cb141-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
-<span id="cb141-10"><a href="#cb141-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
-<span id="cb141-11"><a href="#cb141-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
-<span id="cb141-12"><a href="#cb141-12" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb141-13"><a href="#cb141-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
-<span id="cb141-14"><a href="#cb141-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
-<span id="cb141-15"><a href="#cb141-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
-<span id="cb141-16"><a href="#cb141-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
-<span id="cb141-17"><a href="#cb141-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-18"><a href="#cb141-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
-<span id="cb141-19"><a href="#cb141-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
-<span id="cb141-20"><a href="#cb141-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-21"><a href="#cb141-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
-<span id="cb141-22"><a href="#cb141-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
-<span id="cb141-23"><a href="#cb141-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-24"><a href="#cb141-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
-<span id="cb141-25"><a href="#cb141-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
-<span id="cb141-26"><a href="#cb141-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-27"><a href="#cb141-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
-<span id="cb141-28"><a href="#cb141-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-29"><a href="#cb141-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
-<span id="cb141-30"><a href="#cb141-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
-<span id="cb141-31"><a href="#cb141-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
-<span id="cb141-32"><a href="#cb141-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
-<span id="cb141-33"><a href="#cb141-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-34"><a href="#cb141-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
-<span id="cb141-35"><a href="#cb141-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
-<span id="cb141-36"><a href="#cb141-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
-<span id="cb141-37"><a href="#cb141-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
-<span id="cb141-38"><a href="#cb141-38" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-39"><a href="#cb141-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
-<span id="cb141-40"><a href="#cb141-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
-<span id="cb141-41"><a href="#cb141-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
-<span id="cb141-42"><a href="#cb141-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
-<span id="cb141-43"><a href="#cb141-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
-<span id="cb141-44"><a href="#cb141-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
-<span id="cb141-45"><a href="#cb141-45" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-46"><a href="#cb141-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
-<span id="cb141-47"><a href="#cb141-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
-<span id="cb141-48"><a href="#cb141-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-49"><a href="#cb141-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
-<span id="cb141-50"><a href="#cb141-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
-<span id="cb141-51"><a href="#cb141-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
-<span id="cb141-52"><a href="#cb141-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
-<span id="cb141-53"><a href="#cb141-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
-<span id="cb141-54"><a href="#cb141-54" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-55"><a href="#cb141-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
-<span id="cb141-56"><a href="#cb141-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
-<span id="cb141-57"><a href="#cb141-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
-<span id="cb141-58"><a href="#cb141-58" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-59"><a href="#cb141-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
-<span id="cb141-60"><a href="#cb141-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
-<span id="cb141-61"><a href="#cb141-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
-<span id="cb141-62"><a href="#cb141-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
-<span id="cb141-63"><a href="#cb141-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-64"><a href="#cb141-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
-<span id="cb141-65"><a href="#cb141-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
-<span id="cb141-66"><a href="#cb141-66" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-67"><a href="#cb141-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
-<span id="cb141-68"><a href="#cb141-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
-<span id="cb141-69"><a href="#cb141-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
-<span id="cb141-70"><a href="#cb141-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
-<span id="cb141-71"><a href="#cb141-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
-<span id="cb141-72"><a href="#cb141-72" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-73"><a href="#cb141-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
-<span id="cb141-74"><a href="#cb141-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
-<span id="cb141-75"><a href="#cb141-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
-<span id="cb141-76"><a href="#cb141-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
-<span id="cb141-77"><a href="#cb141-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
-<span id="cb141-78"><a href="#cb141-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
-<span id="cb141-79"><a href="#cb141-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
-<span id="cb141-80"><a href="#cb141-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
-<span id="cb141-81"><a href="#cb141-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
-<span id="cb141-82"><a href="#cb141-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
-<span id="cb141-83"><a href="#cb141-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
-<span id="cb141-84"><a href="#cb141-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
-<span id="cb141-85"><a href="#cb141-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
-<span id="cb141-86"><a href="#cb141-86" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-87"><a href="#cb141-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
-<span id="cb141-88"><a href="#cb141-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
-<span id="cb141-89"><a href="#cb141-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
-<span id="cb141-90"><a href="#cb141-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
-<span id="cb141-91"><a href="#cb141-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
-<span id="cb141-92"><a href="#cb141-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
-<span id="cb141-93"><a href="#cb141-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
-<span id="cb141-94"><a href="#cb141-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
-<span id="cb141-95"><a href="#cb141-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
-<span id="cb141-96"><a href="#cb141-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
-<span id="cb141-97"><a href="#cb141-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
-<span id="cb141-98"><a href="#cb141-98" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-99"><a href="#cb141-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
-<span id="cb141-100"><a href="#cb141-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
-<span id="cb141-101"><a href="#cb141-101" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-102"><a href="#cb141-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
-<span id="cb141-103"><a href="#cb141-103" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-104"><a href="#cb141-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
-<span id="cb141-105"><a href="#cb141-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
-<span id="cb141-106"><a href="#cb141-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
-<span id="cb141-107"><a href="#cb141-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
-<span id="cb141-108"><a href="#cb141-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
-<span id="cb141-109"><a href="#cb141-109" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-110"><a href="#cb141-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
-<span id="cb141-111"><a href="#cb141-111" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-112"><a href="#cb141-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
-<span id="cb141-113"><a href="#cb141-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
-<span id="cb141-114"><a href="#cb141-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
-<span id="cb141-115"><a href="#cb141-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
-<span id="cb141-116"><a href="#cb141-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
-<span id="cb141-117"><a href="#cb141-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
-<span id="cb141-118"><a href="#cb141-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
-<span id="cb141-119"><a href="#cb141-119" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-120"><a href="#cb141-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
-<span id="cb141-121"><a href="#cb141-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
-<span id="cb141-122"><a href="#cb141-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
-<span id="cb141-123"><a href="#cb141-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
-<span id="cb141-124"><a href="#cb141-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
-<span id="cb141-125"><a href="#cb141-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
-<span id="cb141-126"><a href="#cb141-126" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-127"><a href="#cb141-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
-<span id="cb141-128"><a href="#cb141-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
-<span id="cb141-129"><a href="#cb141-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
-<span id="cb141-130"><a href="#cb141-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
-<span id="cb141-131"><a href="#cb141-131" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-132"><a href="#cb141-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
-<span id="cb141-133"><a href="#cb141-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
-<span id="cb141-134"><a href="#cb141-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
-<span id="cb141-135"><a href="#cb141-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
-<span id="cb141-136"><a href="#cb141-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
-<span id="cb141-137"><a href="#cb141-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
-<span id="cb141-138"><a href="#cb141-138" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb141-139"><a href="#cb141-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
-<span id="cb141-140"><a href="#cb141-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
-<span id="cb141-141"><a href="#cb141-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
-<span id="cb141-142"><a href="#cb141-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
-<span id="cb141-143"><a href="#cb141-143" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-144"><a href="#cb141-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
-<span id="cb141-145"><a href="#cb141-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb141-146"><a href="#cb141-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
-<span id="cb141-147"><a href="#cb141-147" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-148"><a href="#cb141-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
-<span id="cb141-149"><a href="#cb141-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
-<span id="cb141-150"><a href="#cb141-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
-<span id="cb141-151"><a href="#cb141-151" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-152"><a href="#cb141-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-153"><a href="#cb141-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb141-154"><a href="#cb141-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-155"><a href="#cb141-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb141-156"><a href="#cb141-156" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-157"><a href="#cb141-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
-<span id="cb141-158"><a href="#cb141-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb141-159"><a href="#cb141-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
-<span id="cb141-160"><a href="#cb141-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb141-161"><a href="#cb141-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
-<span id="cb141-162"><a href="#cb141-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb141-163"><a href="#cb141-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
-<span id="cb141-164"><a href="#cb141-164" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-165"><a href="#cb141-165" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-166"><a href="#cb141-166" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R&amp;&amp; args);</span>
-<span id="cb141-167"><a href="#cb141-167" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R1 = initializer_list&lt;info&gt;, reflection_range R2 = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-168"><a href="#cb141-168" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R1&amp;&amp; tmpl_args, R2&amp;&amp; args);</span>
-<span id="cb141-169"><a href="#cb141-169" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-170"><a href="#cb141-170" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define_class], class definition generation</span>
-<span id="cb141-171"><a href="#cb141-171" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
-<span id="cb141-172"><a href="#cb141-172" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
-<span id="cb141-173"><a href="#cb141-173" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
-<span id="cb141-174"><a href="#cb141-174" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb141-175"><a href="#cb141-175" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-176"><a href="#cb141-176" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
-<span id="cb141-177"><a href="#cb141-177" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb141-178"><a href="#cb141-178" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-179"><a href="#cb141-179" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
-<span id="cb141-180"><a href="#cb141-180" aria-hidden="true" tabindex="-1"></a>    };</span>
-<span id="cb141-181"><a href="#cb141-181" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-182"><a href="#cb141-182" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
-<span id="cb141-183"><a href="#cb141-183" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
-<span id="cb141-184"><a href="#cb141-184" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; width;</span>
-<span id="cb141-185"><a href="#cb141-185" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
-<span id="cb141-186"><a href="#cb141-186" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb141-187"><a href="#cb141-187" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
-<span id="cb141-188"><a href="#cb141-188" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
-<span id="cb141-189"><a href="#cb141-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
-<span id="cb141-190"><a href="#cb141-190" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-191"><a href="#cb141-191" aria-hidden="true" tabindex="-1"></a>  consteval info define_class(info type_class, R&amp;&amp;);</span>
-<span id="cb141-192"><a href="#cb141-192" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-193"><a href="#cb141-193" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define_static], static array generation</span>
-<span id="cb141-194"><a href="#cb141-194" aria-hidden="true" tabindex="-1"></a>  consteval const char* define_static_string(string_view str);</span>
-<span id="cb141-195"><a href="#cb141-195" aria-hidden="true" tabindex="-1"></a>  consteval const char8_t* define_static_string(u8string_view str);</span>
-<span id="cb141-196"><a href="#cb141-196" aria-hidden="true" tabindex="-1"></a>  template&lt;ranges::input_range R&gt;</span>
-<span id="cb141-197"><a href="#cb141-197" aria-hidden="true" tabindex="-1"></a>    consteval span&lt;const ranges::range_value_t&lt;R&gt;&gt; define_static_array(R&amp;&amp; r);</span>
-<span id="cb141-198"><a href="#cb141-198" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-199"><a href="#cb141-199" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
-<span id="cb141-200"><a href="#cb141-200" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type);</span>
-<span id="cb141-201"><a href="#cb141-201" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_null_pointer(info type);</span>
-<span id="cb141-202"><a href="#cb141-202" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_integral(info type);</span>
-<span id="cb141-203"><a href="#cb141-203" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_floating_point(info type);</span>
-<span id="cb141-204"><a href="#cb141-204" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_array(info type);</span>
-<span id="cb141-205"><a href="#cb141-205" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer(info type);</span>
-<span id="cb141-206"><a href="#cb141-206" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_lvalue_reference(info type);</span>
-<span id="cb141-207"><a href="#cb141-207" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_rvalue_reference(info type);</span>
-<span id="cb141-208"><a href="#cb141-208" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_object_pointer(info type);</span>
-<span id="cb141-209"><a href="#cb141-209" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_function_pointer(info type);</span>
-<span id="cb141-210"><a href="#cb141-210" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_enum(info type);</span>
-<span id="cb141-211"><a href="#cb141-211" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_union(info type);</span>
-<span id="cb141-212"><a href="#cb141-212" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_class(info type);</span>
-<span id="cb141-213"><a href="#cb141-213" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_function(info type);</span>
-<span id="cb141-214"><a href="#cb141-214" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reflection(info type);</span>
-<span id="cb141-215"><a href="#cb141-215" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-216"><a href="#cb141-216" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
-<span id="cb141-217"><a href="#cb141-217" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reference(info type);</span>
-<span id="cb141-218"><a href="#cb141-218" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_arithmetic(info type);</span>
-<span id="cb141-219"><a href="#cb141-219" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_fundamental(info type);</span>
-<span id="cb141-220"><a href="#cb141-220" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_object(info type);</span>
-<span id="cb141-221"><a href="#cb141-221" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scalar(info type);</span>
-<span id="cb141-222"><a href="#cb141-222" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_compound(info type);</span>
-<span id="cb141-223"><a href="#cb141-223" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_pointer(info type);</span>
-<span id="cb141-224"><a href="#cb141-224" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-225"><a href="#cb141-225" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
-<span id="cb141-226"><a href="#cb141-226" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_const(info type);</span>
-<span id="cb141-227"><a href="#cb141-227" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_volatile(info type);</span>
-<span id="cb141-228"><a href="#cb141-228" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivial(info type);</span>
-<span id="cb141-229"><a href="#cb141-229" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copyable(info type);</span>
-<span id="cb141-230"><a href="#cb141-230" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_standard_layout(info type);</span>
-<span id="cb141-231"><a href="#cb141-231" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_empty(info type);</span>
-<span id="cb141-232"><a href="#cb141-232" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_polymorphic(info type);</span>
-<span id="cb141-233"><a href="#cb141-233" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_abstract(info type);</span>
-<span id="cb141-234"><a href="#cb141-234" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_final(info type);</span>
-<span id="cb141-235"><a href="#cb141-235" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_aggregate(info type);</span>
-<span id="cb141-236"><a href="#cb141-236" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_signed(info type);</span>
-<span id="cb141-237"><a href="#cb141-237" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unsigned(info type);</span>
-<span id="cb141-238"><a href="#cb141-238" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_bounded_array(info type);</span>
-<span id="cb141-239"><a href="#cb141-239" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unbounded_array(info type);</span>
-<span id="cb141-240"><a href="#cb141-240" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scoped_enum(info type);</span>
-<span id="cb141-241"><a href="#cb141-241" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-242"><a href="#cb141-242" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-243"><a href="#cb141-243" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb141-244"><a href="#cb141-244" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_default_constructible(info type);</span>
-<span id="cb141-245"><a href="#cb141-245" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_constructible(info type);</span>
-<span id="cb141-246"><a href="#cb141-246" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_constructible(info type);</span>
-<span id="cb141-247"><a href="#cb141-247" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-248"><a href="#cb141-248" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_assignable(info type_dst, info type_src);</span>
-<span id="cb141-249"><a href="#cb141-249" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_assignable(info type);</span>
-<span id="cb141-250"><a href="#cb141-250" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_assignable(info type);</span>
-<span id="cb141-251"><a href="#cb141-251" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-252"><a href="#cb141-252" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable_with(info type_dst, info type_src);</span>
-<span id="cb141-253"><a href="#cb141-253" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable(info type);</span>
-<span id="cb141-254"><a href="#cb141-254" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-255"><a href="#cb141-255" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_destructible(info type);</span>
-<span id="cb141-256"><a href="#cb141-256" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-257"><a href="#cb141-257" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-258"><a href="#cb141-258" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_trivially_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb141-259"><a href="#cb141-259" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_default_constructible(info type);</span>
-<span id="cb141-260"><a href="#cb141-260" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_constructible(info type);</span>
-<span id="cb141-261"><a href="#cb141-261" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_constructible(info type);</span>
-<span id="cb141-262"><a href="#cb141-262" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-263"><a href="#cb141-263" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_assignable(info type_dst, info type_src);</span>
-<span id="cb141-264"><a href="#cb141-264" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_assignable(info type);</span>
-<span id="cb141-265"><a href="#cb141-265" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_assignable(info type);</span>
-<span id="cb141-266"><a href="#cb141-266" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_destructible(info type);</span>
-<span id="cb141-267"><a href="#cb141-267" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-268"><a href="#cb141-268" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-269"><a href="#cb141-269" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_constructible(info type, R&amp;&amp; type_args);</span>
-<span id="cb141-270"><a href="#cb141-270" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_default_constructible(info type);</span>
-<span id="cb141-271"><a href="#cb141-271" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_constructible(info type);</span>
-<span id="cb141-272"><a href="#cb141-272" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_constructible(info type);</span>
-<span id="cb141-273"><a href="#cb141-273" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-274"><a href="#cb141-274" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_assignable(info type_dst, info type_src);</span>
-<span id="cb141-275"><a href="#cb141-275" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_assignable(info type);</span>
-<span id="cb141-276"><a href="#cb141-276" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_assignable(info type);</span>
-<span id="cb141-277"><a href="#cb141-277" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-278"><a href="#cb141-278" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable_with(info type_dst, info type_src);</span>
-<span id="cb141-279"><a href="#cb141-279" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable(info type);</span>
-<span id="cb141-280"><a href="#cb141-280" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-281"><a href="#cb141-281" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_destructible(info type);</span>
-<span id="cb141-282"><a href="#cb141-282" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-283"><a href="#cb141-283" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_implicit_lifetime(info type);</span>
-<span id="cb141-284"><a href="#cb141-284" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-285"><a href="#cb141-285" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_virtual_destructor(info type);</span>
-<span id="cb141-286"><a href="#cb141-286" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-287"><a href="#cb141-287" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_unique_object_representations(info type);</span>
-<span id="cb141-288"><a href="#cb141-288" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-289"><a href="#cb141-289" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_constructs_from_temporary(info type_dst, info type_src);</span>
-<span id="cb141-290"><a href="#cb141-290" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_converts_from_temporary(info type_dst, info type_src);</span>
-<span id="cb141-291"><a href="#cb141-291" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-292"><a href="#cb141-292" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
-<span id="cb141-293"><a href="#cb141-293" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_alignment_of(info type);</span>
-<span id="cb141-294"><a href="#cb141-294" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_rank(info type);</span>
-<span id="cb141-295"><a href="#cb141-295" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_extent(info type, unsigned i = 0);</span>
-<span id="cb141-296"><a href="#cb141-296" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-297"><a href="#cb141-297" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
-<span id="cb141-298"><a href="#cb141-298" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_same(info type1, info type2);</span>
-<span id="cb141-299"><a href="#cb141-299" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_base_of(info type_base, info type_derived);</span>
-<span id="cb141-300"><a href="#cb141-300" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_convertible(info type_src, info type_dst);</span>
-<span id="cb141-301"><a href="#cb141-301" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_convertible(info type_src, info type_dst);</span>
-<span id="cb141-302"><a href="#cb141-302" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_layout_compatible(info type1, info type2);</span>
-<span id="cb141-303"><a href="#cb141-303" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer_interconvertible_base_of(info type_base, info type_derived);</span>
-<span id="cb141-304"><a href="#cb141-304" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-305"><a href="#cb141-305" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-306"><a href="#cb141-306" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable(info type, R&amp;&amp; type_args);</span>
-<span id="cb141-307"><a href="#cb141-307" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-308"><a href="#cb141-308" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb141-309"><a href="#cb141-309" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-310"><a href="#cb141-310" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-311"><a href="#cb141-311" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable(info type, R&amp;&amp; type_args);</span>
-<span id="cb141-312"><a href="#cb141-312" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-313"><a href="#cb141-313" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb141-314"><a href="#cb141-314" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-315"><a href="#cb141-315" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
-<span id="cb141-316"><a href="#cb141-316" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_const(info type);</span>
-<span id="cb141-317"><a href="#cb141-317" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_volatile(info type);</span>
-<span id="cb141-318"><a href="#cb141-318" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cv(info type);</span>
-<span id="cb141-319"><a href="#cb141-319" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_const(info type);</span>
-<span id="cb141-320"><a href="#cb141-320" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_volatile(info type);</span>
-<span id="cb141-321"><a href="#cb141-321" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_cv(info type);</span>
-<span id="cb141-322"><a href="#cb141-322" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-323"><a href="#cb141-323" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
-<span id="cb141-324"><a href="#cb141-324" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_reference(info type);</span>
-<span id="cb141-325"><a href="#cb141-325" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_lvalue_reference(info type);</span>
-<span id="cb141-326"><a href="#cb141-326" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_rvalue_reference(info type);</span>
-<span id="cb141-327"><a href="#cb141-327" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-328"><a href="#cb141-328" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
-<span id="cb141-329"><a href="#cb141-329" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_signed(info type);</span>
-<span id="cb141-330"><a href="#cb141-330" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_unsigned(info type);</span>
-<span id="cb141-331"><a href="#cb141-331" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-332"><a href="#cb141-332" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
-<span id="cb141-333"><a href="#cb141-333" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_extent(info type);</span>
-<span id="cb141-334"><a href="#cb141-334" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_all_extents(info type);</span>
-<span id="cb141-335"><a href="#cb141-335" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-336"><a href="#cb141-336" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
-<span id="cb141-337"><a href="#cb141-337" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_pointer(info type);</span>
-<span id="cb141-338"><a href="#cb141-338" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_pointer(info type);</span>
-<span id="cb141-339"><a href="#cb141-339" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-340"><a href="#cb141-340" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
-<span id="cb141-341"><a href="#cb141-341" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cvref(info type);</span>
-<span id="cb141-342"><a href="#cb141-342" aria-hidden="true" tabindex="-1"></a>  consteval info type_decay(info type);</span>
-<span id="cb141-343"><a href="#cb141-343" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-344"><a href="#cb141-344" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_type(R&amp;&amp; type_args);</span>
-<span id="cb141-345"><a href="#cb141-345" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-346"><a href="#cb141-346" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_reference(R&amp;&amp; type_args);</span>
-<span id="cb141-347"><a href="#cb141-347" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
-<span id="cb141-348"><a href="#cb141-348" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb141-349"><a href="#cb141-349" aria-hidden="true" tabindex="-1"></a>    `consteval info type_invoke_result(info type, R&amp;&amp; type_args);</span>
-<span id="cb141-350"><a href="#cb141-350" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_reference(info type);</span>
-<span id="cb141-351"><a href="#cb141-351" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_ref_decay(info type);</span>
-<span id="cb141-352"><a href="#cb141-352" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-353"><a href="#cb141-353" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
-<span id="cb141-354"><a href="#cb141-354" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_tuple_size(info type);</span>
-<span id="cb141-355"><a href="#cb141-355" aria-hidden="true" tabindex="-1"></a>  consteval info type_tuple_element(size_t index, info type);</span>
-<span id="cb141-356"><a href="#cb141-356" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb141-357"><a href="#cb141-357" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_variant_size(info type);</span>
-<span id="cb141-358"><a href="#cb141-358" aria-hidden="true" tabindex="-1"></a>  consteval info type_variant_alternative(size_t index, info type);</span>
-<span id="cb141-359"><a href="#cb141-359" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb137"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
+<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
+<span id="cb137-3"><a href="#cb137-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
+<span id="cb137-4"><a href="#cb137-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
+<span id="cb137-5"><a href="#cb137-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-6"><a href="#cb137-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb137-7"><a href="#cb137-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
+<span id="cb137-8"><a href="#cb137-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-9"><a href="#cb137-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
+<span id="cb137-10"><a href="#cb137-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
+<span id="cb137-11"><a href="#cb137-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
+<span id="cb137-12"><a href="#cb137-12" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb137-13"><a href="#cb137-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
+<span id="cb137-14"><a href="#cb137-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
+<span id="cb137-15"><a href="#cb137-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
+<span id="cb137-16"><a href="#cb137-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
+<span id="cb137-17"><a href="#cb137-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-18"><a href="#cb137-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
+<span id="cb137-19"><a href="#cb137-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
+<span id="cb137-20"><a href="#cb137-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-21"><a href="#cb137-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
+<span id="cb137-22"><a href="#cb137-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
+<span id="cb137-23"><a href="#cb137-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-24"><a href="#cb137-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
+<span id="cb137-25"><a href="#cb137-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
+<span id="cb137-26"><a href="#cb137-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-27"><a href="#cb137-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
+<span id="cb137-28"><a href="#cb137-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-29"><a href="#cb137-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
+<span id="cb137-30"><a href="#cb137-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
+<span id="cb137-31"><a href="#cb137-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
+<span id="cb137-32"><a href="#cb137-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
+<span id="cb137-33"><a href="#cb137-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-34"><a href="#cb137-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
+<span id="cb137-35"><a href="#cb137-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
+<span id="cb137-36"><a href="#cb137-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
+<span id="cb137-37"><a href="#cb137-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
+<span id="cb137-38"><a href="#cb137-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-39"><a href="#cb137-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
+<span id="cb137-40"><a href="#cb137-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
+<span id="cb137-41"><a href="#cb137-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
+<span id="cb137-42"><a href="#cb137-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
+<span id="cb137-43"><a href="#cb137-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
+<span id="cb137-44"><a href="#cb137-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
+<span id="cb137-45"><a href="#cb137-45" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-46"><a href="#cb137-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
+<span id="cb137-47"><a href="#cb137-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
+<span id="cb137-48"><a href="#cb137-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-49"><a href="#cb137-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
+<span id="cb137-50"><a href="#cb137-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
+<span id="cb137-51"><a href="#cb137-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
+<span id="cb137-52"><a href="#cb137-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
+<span id="cb137-53"><a href="#cb137-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
+<span id="cb137-54"><a href="#cb137-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-55"><a href="#cb137-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
+<span id="cb137-56"><a href="#cb137-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
+<span id="cb137-57"><a href="#cb137-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
+<span id="cb137-58"><a href="#cb137-58" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-59"><a href="#cb137-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
+<span id="cb137-60"><a href="#cb137-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
+<span id="cb137-61"><a href="#cb137-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
+<span id="cb137-62"><a href="#cb137-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
+<span id="cb137-63"><a href="#cb137-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-64"><a href="#cb137-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
+<span id="cb137-65"><a href="#cb137-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
+<span id="cb137-66"><a href="#cb137-66" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-67"><a href="#cb137-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
+<span id="cb137-68"><a href="#cb137-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
+<span id="cb137-69"><a href="#cb137-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
+<span id="cb137-70"><a href="#cb137-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
+<span id="cb137-71"><a href="#cb137-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
+<span id="cb137-72"><a href="#cb137-72" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-73"><a href="#cb137-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
+<span id="cb137-74"><a href="#cb137-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
+<span id="cb137-75"><a href="#cb137-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
+<span id="cb137-76"><a href="#cb137-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
+<span id="cb137-77"><a href="#cb137-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
+<span id="cb137-78"><a href="#cb137-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
+<span id="cb137-79"><a href="#cb137-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
+<span id="cb137-80"><a href="#cb137-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
+<span id="cb137-81"><a href="#cb137-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
+<span id="cb137-82"><a href="#cb137-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
+<span id="cb137-83"><a href="#cb137-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
+<span id="cb137-84"><a href="#cb137-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
+<span id="cb137-85"><a href="#cb137-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
+<span id="cb137-86"><a href="#cb137-86" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-87"><a href="#cb137-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
+<span id="cb137-88"><a href="#cb137-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
+<span id="cb137-89"><a href="#cb137-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
+<span id="cb137-90"><a href="#cb137-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
+<span id="cb137-91"><a href="#cb137-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
+<span id="cb137-92"><a href="#cb137-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
+<span id="cb137-93"><a href="#cb137-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
+<span id="cb137-94"><a href="#cb137-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
+<span id="cb137-95"><a href="#cb137-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
+<span id="cb137-96"><a href="#cb137-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
+<span id="cb137-97"><a href="#cb137-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
+<span id="cb137-98"><a href="#cb137-98" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-99"><a href="#cb137-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
+<span id="cb137-100"><a href="#cb137-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
+<span id="cb137-101"><a href="#cb137-101" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-102"><a href="#cb137-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
+<span id="cb137-103"><a href="#cb137-103" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-104"><a href="#cb137-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
+<span id="cb137-105"><a href="#cb137-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
+<span id="cb137-106"><a href="#cb137-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
+<span id="cb137-107"><a href="#cb137-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
+<span id="cb137-108"><a href="#cb137-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
+<span id="cb137-109"><a href="#cb137-109" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-110"><a href="#cb137-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
+<span id="cb137-111"><a href="#cb137-111" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-112"><a href="#cb137-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
+<span id="cb137-113"><a href="#cb137-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
+<span id="cb137-114"><a href="#cb137-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
+<span id="cb137-115"><a href="#cb137-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
+<span id="cb137-116"><a href="#cb137-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
+<span id="cb137-117"><a href="#cb137-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
+<span id="cb137-118"><a href="#cb137-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
+<span id="cb137-119"><a href="#cb137-119" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-120"><a href="#cb137-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
+<span id="cb137-121"><a href="#cb137-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
+<span id="cb137-122"><a href="#cb137-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
+<span id="cb137-123"><a href="#cb137-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
+<span id="cb137-124"><a href="#cb137-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
+<span id="cb137-125"><a href="#cb137-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
+<span id="cb137-126"><a href="#cb137-126" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-127"><a href="#cb137-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
+<span id="cb137-128"><a href="#cb137-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
+<span id="cb137-129"><a href="#cb137-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
+<span id="cb137-130"><a href="#cb137-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
+<span id="cb137-131"><a href="#cb137-131" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-132"><a href="#cb137-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
+<span id="cb137-133"><a href="#cb137-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
+<span id="cb137-134"><a href="#cb137-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
+<span id="cb137-135"><a href="#cb137-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
+<span id="cb137-136"><a href="#cb137-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
+<span id="cb137-137"><a href="#cb137-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
+<span id="cb137-138"><a href="#cb137-138" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb137-139"><a href="#cb137-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
+<span id="cb137-140"><a href="#cb137-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
+<span id="cb137-141"><a href="#cb137-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
+<span id="cb137-142"><a href="#cb137-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
+<span id="cb137-143"><a href="#cb137-143" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-144"><a href="#cb137-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
+<span id="cb137-145"><a href="#cb137-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb137-146"><a href="#cb137-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
+<span id="cb137-147"><a href="#cb137-147" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-148"><a href="#cb137-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
+<span id="cb137-149"><a href="#cb137-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
+<span id="cb137-150"><a href="#cb137-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
+<span id="cb137-151"><a href="#cb137-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-152"><a href="#cb137-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-153"><a href="#cb137-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb137-154"><a href="#cb137-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-155"><a href="#cb137-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb137-156"><a href="#cb137-156" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-157"><a href="#cb137-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
+<span id="cb137-158"><a href="#cb137-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb137-159"><a href="#cb137-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
+<span id="cb137-160"><a href="#cb137-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb137-161"><a href="#cb137-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
+<span id="cb137-162"><a href="#cb137-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb137-163"><a href="#cb137-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
+<span id="cb137-164"><a href="#cb137-164" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-165"><a href="#cb137-165" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-166"><a href="#cb137-166" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R&amp;&amp; args);</span>
+<span id="cb137-167"><a href="#cb137-167" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R1 = initializer_list&lt;info&gt;, reflection_range R2 = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-168"><a href="#cb137-168" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_invoke(info target, R1&amp;&amp; tmpl_args, R2&amp;&amp; args);</span>
+<span id="cb137-169"><a href="#cb137-169" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-170"><a href="#cb137-170" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define_class], class definition generation</span>
+<span id="cb137-171"><a href="#cb137-171" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
+<span id="cb137-172"><a href="#cb137-172" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
+<span id="cb137-173"><a href="#cb137-173" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
+<span id="cb137-174"><a href="#cb137-174" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb137-175"><a href="#cb137-175" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-176"><a href="#cb137-176" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
+<span id="cb137-177"><a href="#cb137-177" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb137-178"><a href="#cb137-178" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-179"><a href="#cb137-179" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
+<span id="cb137-180"><a href="#cb137-180" aria-hidden="true" tabindex="-1"></a>    };</span>
+<span id="cb137-181"><a href="#cb137-181" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-182"><a href="#cb137-182" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
+<span id="cb137-183"><a href="#cb137-183" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
+<span id="cb137-184"><a href="#cb137-184" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; width;</span>
+<span id="cb137-185"><a href="#cb137-185" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
+<span id="cb137-186"><a href="#cb137-186" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb137-187"><a href="#cb137-187" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
+<span id="cb137-188"><a href="#cb137-188" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
+<span id="cb137-189"><a href="#cb137-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
+<span id="cb137-190"><a href="#cb137-190" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-191"><a href="#cb137-191" aria-hidden="true" tabindex="-1"></a>  consteval info define_class(info type_class, R&amp;&amp;);</span>
+<span id="cb137-192"><a href="#cb137-192" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-193"><a href="#cb137-193" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
+<span id="cb137-194"><a href="#cb137-194" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type);</span>
+<span id="cb137-195"><a href="#cb137-195" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_null_pointer(info type);</span>
+<span id="cb137-196"><a href="#cb137-196" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_integral(info type);</span>
+<span id="cb137-197"><a href="#cb137-197" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_floating_point(info type);</span>
+<span id="cb137-198"><a href="#cb137-198" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_array(info type);</span>
+<span id="cb137-199"><a href="#cb137-199" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer(info type);</span>
+<span id="cb137-200"><a href="#cb137-200" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_lvalue_reference(info type);</span>
+<span id="cb137-201"><a href="#cb137-201" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_rvalue_reference(info type);</span>
+<span id="cb137-202"><a href="#cb137-202" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_object_pointer(info type);</span>
+<span id="cb137-203"><a href="#cb137-203" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_function_pointer(info type);</span>
+<span id="cb137-204"><a href="#cb137-204" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_enum(info type);</span>
+<span id="cb137-205"><a href="#cb137-205" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_union(info type);</span>
+<span id="cb137-206"><a href="#cb137-206" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_class(info type);</span>
+<span id="cb137-207"><a href="#cb137-207" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_function(info type);</span>
+<span id="cb137-208"><a href="#cb137-208" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reflection(info type);</span>
+<span id="cb137-209"><a href="#cb137-209" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-210"><a href="#cb137-210" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
+<span id="cb137-211"><a href="#cb137-211" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_reference(info type);</span>
+<span id="cb137-212"><a href="#cb137-212" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_arithmetic(info type);</span>
+<span id="cb137-213"><a href="#cb137-213" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_fundamental(info type);</span>
+<span id="cb137-214"><a href="#cb137-214" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_object(info type);</span>
+<span id="cb137-215"><a href="#cb137-215" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scalar(info type);</span>
+<span id="cb137-216"><a href="#cb137-216" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_compound(info type);</span>
+<span id="cb137-217"><a href="#cb137-217" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_member_pointer(info type);</span>
+<span id="cb137-218"><a href="#cb137-218" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-219"><a href="#cb137-219" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
+<span id="cb137-220"><a href="#cb137-220" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_const(info type);</span>
+<span id="cb137-221"><a href="#cb137-221" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_volatile(info type);</span>
+<span id="cb137-222"><a href="#cb137-222" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivial(info type);</span>
+<span id="cb137-223"><a href="#cb137-223" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copyable(info type);</span>
+<span id="cb137-224"><a href="#cb137-224" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_standard_layout(info type);</span>
+<span id="cb137-225"><a href="#cb137-225" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_empty(info type);</span>
+<span id="cb137-226"><a href="#cb137-226" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_polymorphic(info type);</span>
+<span id="cb137-227"><a href="#cb137-227" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_abstract(info type);</span>
+<span id="cb137-228"><a href="#cb137-228" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_final(info type);</span>
+<span id="cb137-229"><a href="#cb137-229" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_aggregate(info type);</span>
+<span id="cb137-230"><a href="#cb137-230" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_signed(info type);</span>
+<span id="cb137-231"><a href="#cb137-231" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unsigned(info type);</span>
+<span id="cb137-232"><a href="#cb137-232" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_bounded_array(info type);</span>
+<span id="cb137-233"><a href="#cb137-233" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_unbounded_array(info type);</span>
+<span id="cb137-234"><a href="#cb137-234" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_scoped_enum(info type);</span>
+<span id="cb137-235"><a href="#cb137-235" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-236"><a href="#cb137-236" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-237"><a href="#cb137-237" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb137-238"><a href="#cb137-238" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_default_constructible(info type);</span>
+<span id="cb137-239"><a href="#cb137-239" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_constructible(info type);</span>
+<span id="cb137-240"><a href="#cb137-240" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_constructible(info type);</span>
+<span id="cb137-241"><a href="#cb137-241" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-242"><a href="#cb137-242" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_assignable(info type_dst, info type_src);</span>
+<span id="cb137-243"><a href="#cb137-243" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_copy_assignable(info type);</span>
+<span id="cb137-244"><a href="#cb137-244" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_move_assignable(info type);</span>
+<span id="cb137-245"><a href="#cb137-245" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-246"><a href="#cb137-246" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable_with(info type_dst, info type_src);</span>
+<span id="cb137-247"><a href="#cb137-247" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_swappable(info type);</span>
+<span id="cb137-248"><a href="#cb137-248" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-249"><a href="#cb137-249" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_destructible(info type);</span>
+<span id="cb137-250"><a href="#cb137-250" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-251"><a href="#cb137-251" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-252"><a href="#cb137-252" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_trivially_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb137-253"><a href="#cb137-253" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_default_constructible(info type);</span>
+<span id="cb137-254"><a href="#cb137-254" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_constructible(info type);</span>
+<span id="cb137-255"><a href="#cb137-255" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_constructible(info type);</span>
+<span id="cb137-256"><a href="#cb137-256" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-257"><a href="#cb137-257" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_assignable(info type_dst, info type_src);</span>
+<span id="cb137-258"><a href="#cb137-258" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_copy_assignable(info type);</span>
+<span id="cb137-259"><a href="#cb137-259" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_move_assignable(info type);</span>
+<span id="cb137-260"><a href="#cb137-260" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_trivially_destructible(info type);</span>
+<span id="cb137-261"><a href="#cb137-261" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-262"><a href="#cb137-262" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-263"><a href="#cb137-263" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_constructible(info type, R&amp;&amp; type_args);</span>
+<span id="cb137-264"><a href="#cb137-264" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_default_constructible(info type);</span>
+<span id="cb137-265"><a href="#cb137-265" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_constructible(info type);</span>
+<span id="cb137-266"><a href="#cb137-266" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_constructible(info type);</span>
+<span id="cb137-267"><a href="#cb137-267" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-268"><a href="#cb137-268" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_assignable(info type_dst, info type_src);</span>
+<span id="cb137-269"><a href="#cb137-269" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_copy_assignable(info type);</span>
+<span id="cb137-270"><a href="#cb137-270" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_move_assignable(info type);</span>
+<span id="cb137-271"><a href="#cb137-271" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-272"><a href="#cb137-272" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable_with(info type_dst, info type_src);</span>
+<span id="cb137-273"><a href="#cb137-273" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_swappable(info type);</span>
+<span id="cb137-274"><a href="#cb137-274" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-275"><a href="#cb137-275" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_destructible(info type);</span>
+<span id="cb137-276"><a href="#cb137-276" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-277"><a href="#cb137-277" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_implicit_lifetime(info type);</span>
+<span id="cb137-278"><a href="#cb137-278" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-279"><a href="#cb137-279" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_virtual_destructor(info type);</span>
+<span id="cb137-280"><a href="#cb137-280" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-281"><a href="#cb137-281" aria-hidden="true" tabindex="-1"></a>  consteval bool type_has_unique_object_representations(info type);</span>
+<span id="cb137-282"><a href="#cb137-282" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-283"><a href="#cb137-283" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_constructs_from_temporary(info type_dst, info type_src);</span>
+<span id="cb137-284"><a href="#cb137-284" aria-hidden="true" tabindex="-1"></a>  consteval bool type_reference_converts_from_temporary(info type_dst, info type_src);</span>
+<span id="cb137-285"><a href="#cb137-285" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-286"><a href="#cb137-286" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
+<span id="cb137-287"><a href="#cb137-287" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_alignment_of(info type);</span>
+<span id="cb137-288"><a href="#cb137-288" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_rank(info type);</span>
+<span id="cb137-289"><a href="#cb137-289" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_extent(info type, unsigned i = 0);</span>
+<span id="cb137-290"><a href="#cb137-290" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-291"><a href="#cb137-291" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
+<span id="cb137-292"><a href="#cb137-292" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_same(info type1, info type2);</span>
+<span id="cb137-293"><a href="#cb137-293" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_base_of(info type_base, info type_derived);</span>
+<span id="cb137-294"><a href="#cb137-294" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_convertible(info type_src, info type_dst);</span>
+<span id="cb137-295"><a href="#cb137-295" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_nothrow_convertible(info type_src, info type_dst);</span>
+<span id="cb137-296"><a href="#cb137-296" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_layout_compatible(info type1, info type2);</span>
+<span id="cb137-297"><a href="#cb137-297" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_pointer_interconvertible_base_of(info type_base, info type_derived);</span>
+<span id="cb137-298"><a href="#cb137-298" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-299"><a href="#cb137-299" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-300"><a href="#cb137-300" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable(info type, R&amp;&amp; type_args);</span>
+<span id="cb137-301"><a href="#cb137-301" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-302"><a href="#cb137-302" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb137-303"><a href="#cb137-303" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-304"><a href="#cb137-304" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-305"><a href="#cb137-305" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable(info type, R&amp;&amp; type_args);</span>
+<span id="cb137-306"><a href="#cb137-306" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-307"><a href="#cb137-307" aria-hidden="true" tabindex="-1"></a>    consteval bool type_is_nothrow_invocable_r(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb137-308"><a href="#cb137-308" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-309"><a href="#cb137-309" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
+<span id="cb137-310"><a href="#cb137-310" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_const(info type);</span>
+<span id="cb137-311"><a href="#cb137-311" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_volatile(info type);</span>
+<span id="cb137-312"><a href="#cb137-312" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cv(info type);</span>
+<span id="cb137-313"><a href="#cb137-313" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_const(info type);</span>
+<span id="cb137-314"><a href="#cb137-314" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_volatile(info type);</span>
+<span id="cb137-315"><a href="#cb137-315" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_cv(info type);</span>
+<span id="cb137-316"><a href="#cb137-316" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-317"><a href="#cb137-317" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
+<span id="cb137-318"><a href="#cb137-318" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_reference(info type);</span>
+<span id="cb137-319"><a href="#cb137-319" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_lvalue_reference(info type);</span>
+<span id="cb137-320"><a href="#cb137-320" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_rvalue_reference(info type);</span>
+<span id="cb137-321"><a href="#cb137-321" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-322"><a href="#cb137-322" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
+<span id="cb137-323"><a href="#cb137-323" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_signed(info type);</span>
+<span id="cb137-324"><a href="#cb137-324" aria-hidden="true" tabindex="-1"></a>  consteval info type_make_unsigned(info type);</span>
+<span id="cb137-325"><a href="#cb137-325" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-326"><a href="#cb137-326" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
+<span id="cb137-327"><a href="#cb137-327" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_extent(info type);</span>
+<span id="cb137-328"><a href="#cb137-328" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_all_extents(info type);</span>
+<span id="cb137-329"><a href="#cb137-329" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-330"><a href="#cb137-330" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
+<span id="cb137-331"><a href="#cb137-331" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_pointer(info type);</span>
+<span id="cb137-332"><a href="#cb137-332" aria-hidden="true" tabindex="-1"></a>  consteval info type_add_pointer(info type);</span>
+<span id="cb137-333"><a href="#cb137-333" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-334"><a href="#cb137-334" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
+<span id="cb137-335"><a href="#cb137-335" aria-hidden="true" tabindex="-1"></a>  consteval info type_remove_cvref(info type);</span>
+<span id="cb137-336"><a href="#cb137-336" aria-hidden="true" tabindex="-1"></a>  consteval info type_decay(info type);</span>
+<span id="cb137-337"><a href="#cb137-337" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-338"><a href="#cb137-338" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_type(R&amp;&amp; type_args);</span>
+<span id="cb137-339"><a href="#cb137-339" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-340"><a href="#cb137-340" aria-hidden="true" tabindex="-1"></a>    consteval info type_common_reference(R&amp;&amp; type_args);</span>
+<span id="cb137-341"><a href="#cb137-341" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
+<span id="cb137-342"><a href="#cb137-342" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb137-343"><a href="#cb137-343" aria-hidden="true" tabindex="-1"></a>    `consteval info type_invoke_result(info type, R&amp;&amp; type_args);</span>
+<span id="cb137-344"><a href="#cb137-344" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_reference(info type);</span>
+<span id="cb137-345"><a href="#cb137-345" aria-hidden="true" tabindex="-1"></a>  consteval info type_unwrap_ref_decay(info type);</span>
+<span id="cb137-346"><a href="#cb137-346" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-347"><a href="#cb137-347" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
+<span id="cb137-348"><a href="#cb137-348" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_tuple_size(info type);</span>
+<span id="cb137-349"><a href="#cb137-349" aria-hidden="true" tabindex="-1"></a>  consteval info type_tuple_element(size_t index, info type);</span>
+<span id="cb137-350"><a href="#cb137-350" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb137-351"><a href="#cb137-351" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_variant_size(info type);</span>
+<span id="cb137-352"><a href="#cb137-352" aria-hidden="true" tabindex="-1"></a>  consteval info type_variant_alternative(size_t index, info type);</span>
+<span id="cb137-353"><a href="#cb137-353" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
@@ -7625,10 +7529,10 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
-<span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
-<span id="cb142-3"><a href="#cb142-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb142-4"><a href="#cb142-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
+<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
+<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
@@ -7881,7 +7785,7 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tr>
 </tbody>
 </table>
-<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
@@ -7891,8 +7795,8 @@ an operator function or operator function template.</p>
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
 unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
-<span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
+<span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
@@ -7911,7 +7815,7 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
 <em>Returns</em>:</p>
 <ul>
@@ -7976,8 +7880,8 @@ contains a value.</li>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
-<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
@@ -8018,8 +7922,8 @@ then the <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> contents of <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
-<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
@@ -8027,7 +7931,7 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
-<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
@@ -8038,9 +7942,9 @@ Otherwise, an implementation-defined
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
-declaration of the represented construct. If multiple such declarations
-exist and one is a definition, a value corresponding to the definition
-is preferred.</p>
+declaration of the represented construct that is reachable from the
+evaluation construct. If there are multiple such declarations and one is
+a definition, a value corresponding to the definition is preferred.</p>
 </div>
 </blockquote>
 </div>
@@ -8049,9 +7953,9 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb149-3"><a href="#cb149-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8059,15 +7963,15 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
 function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8075,15 +7979,15 @@ function or a virtual base class specifier. Otherwise,
 is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8091,8 +7995,8 @@ final member function. Otherwise,
 defined as deleted ([dcl.fct.def.delete])or defined as defaulted
 ([dcl.fct.def.default]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8100,7 +8004,7 @@ defined as deleted ([dcl.fct.def.delete])or defined as defaulted
 user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.def.default">[dcl.fct.def.default]</a></span>),
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8115,7 +8019,7 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8133,7 +8037,7 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8143,15 +8047,15 @@ declaration of a non-static data member for which any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8160,7 +8064,7 @@ type (respectively), a const- or volatile-qualified function type
 (respectively), or an object, variable, non-static data member, or
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8168,8 +8072,8 @@ function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">mutable</span></code>
 non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8177,9 +8081,9 @@ non-static data member. Otherwise,
 rvalue-reference qualified function type (respectively), or a member
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb162-2"><a href="#cb162-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb162-3"><a href="#cb162-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8187,10 +8091,10 @@ function with such a type. Otherwise,
 that has static, thread, or automatic storage duration, respectively
 ([basic.stc]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb163-3"><a href="#cb163-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb163-4"><a href="#cb163-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8199,7 +8103,7 @@ type, template, or namespace whose name has internal linkage, module
 linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
@@ -8215,7 +8119,7 @@ there is some point in the evaluation context from which the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
@@ -8230,28 +8134,28 @@ or enumeration type <code class="sourceCode cpp"><em>E</em></code>, such
 that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8262,30 +8166,30 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 <code class="sourceCode cpp"><em>typedef-name</em></code><span>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-2"><a href="#cb171-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-3"><a href="#cb171-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
 operator function, or literal operator, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-3"><a href="#cb172-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-4"><a href="#cb172-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-5"><a href="#cb172-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-6"><a href="#cb172-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-7"><a href="#cb172-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-8"><a href="#cb172-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-9"><a href="#cb172-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-4"><a href="#cb168-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-5"><a href="#cb168-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-6"><a href="#cb168-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8295,7 +8199,7 @@ constructor, a move constructor, an assignment operator, a copy
 assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8311,15 +8215,15 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code> but
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-2"><a href="#cb174-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-6"><a href="#cb174-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-7"><a href="#cb174-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-8"><a href="#cb174-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-9"><a href="#cb174-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-5"><a href="#cb170-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-6"><a href="#cb170-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8328,7 +8232,7 @@ variable template, class template, alias template, conversion function
 template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8336,26 +8240,26 @@ constructor template, or concept respectively. Otherwise,
 function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb176-2"><a href="#cb176-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb178-4"><a href="#cb178-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb178-5"><a href="#cb178-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb174-2"><a href="#cb174-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -8363,14 +8267,14 @@ Otherwise,
 namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
@@ -8385,7 +8289,7 @@ entity, object, or value, then the type of what is represented by
 then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
@@ -8396,16 +8300,16 @@ reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
-<span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
-<span id="cb182-3"><a href="#cb182-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb182-4"><a href="#cb182-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb182-5"><a href="#cb182-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
-<span id="cb182-6"><a href="#cb182-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
-<span id="cb182-7"><a href="#cb182-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
+<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
+<span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
+<span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-4"><a href="#cb178-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb178-5"><a href="#cb178-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
+<span id="cb178-6"><a href="#cb178-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
+<span id="cb178-7"><a href="#cb178-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
@@ -8437,17 +8341,17 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb184-3"><a href="#cb184-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb184-4"><a href="#cb184-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb184-5"><a href="#cb184-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
-<span id="cb184-6"><a href="#cb184-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
-<span id="cb184-7"><a href="#cb184-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
-<span id="cb184-8"><a href="#cb184-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
+<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb180-3"><a href="#cb180-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb180-4"><a href="#cb180-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb180-5"><a href="#cb180-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
+<span id="cb180-6"><a href="#cb180-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
+<span id="cb180-7"><a href="#cb180-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
+<span id="cb180-8"><a href="#cb180-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
@@ -8459,7 +8363,7 @@ specifier.</p>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
@@ -8468,15 +8372,15 @@ alias <em>A</em>, then a reflection representing the entity named by
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
-<div class="sourceCode" id="cb187"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
-<span id="cb187-2"><a href="#cb187-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
-<span id="cb187-3"><a href="#cb187-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
-<span id="cb187-4"><a href="#cb187-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
-<span id="cb187-5"><a href="#cb187-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
+<div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
+<span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
+<span id="cb183-3"><a href="#cb183-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
+<span id="cb183-4"><a href="#cb183-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
+<span id="cb183-5"><a href="#cb183-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb188-2"><a href="#cb188-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
@@ -8488,14 +8392,14 @@ template arguments of the specialization represented by
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
-<div class="sourceCode" id="cb189"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
-<span id="cb189-2"><a href="#cb189-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
-<span id="cb189-3"><a href="#cb189-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb189-4"><a href="#cb189-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
-<span id="cb189-5"><a href="#cb189-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
-<span id="cb189-6"><a href="#cb189-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb189-7"><a href="#cb189-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
-<span id="cb189-8"><a href="#cb189-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
+<div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
+<span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
+<span id="cb185-3"><a href="#cb185-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb185-4"><a href="#cb185-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
+<span id="cb185-5"><a href="#cb185-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
+<span id="cb185-6"><a href="#cb185-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb185-7"><a href="#cb185-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
+<span id="cb185-8"><a href="#cb185-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -8506,7 +8410,7 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
@@ -8560,7 +8464,7 @@ declared within the member-specification of
 unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
@@ -8577,7 +8481,7 @@ of all the direct base class specifiers, if any, of
 indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
-<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
@@ -8590,7 +8494,7 @@ the specialization is instantiated.</p>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
@@ -8603,7 +8507,7 @@ the specialization is instantiated.</p>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
@@ -8613,7 +8517,7 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
@@ -8627,7 +8531,7 @@ containing each element, <code class="sourceCode cpp">e</code>, of <code class="
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
@@ -8641,7 +8545,7 @@ containing each element, <code class="sourceCode cpp">e</code>, of <code class="
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
@@ -8655,7 +8559,7 @@ containing each element, <code class="sourceCode cpp">e</code>, of <code class="
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
@@ -8677,10 +8581,10 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
-<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
@@ -8702,7 +8606,7 @@ to the subobject associated with the entity represented by
 </ul>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
-<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
@@ -8724,7 +8628,7 @@ Otherwise, <code class="sourceCode cpp">size_of<span class="op">(</span>type_of<
 corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
@@ -8754,7 +8658,7 @@ description of a declaration of a non-static data member), then the
 data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
@@ -8783,8 +8687,8 @@ used to extract a value out of a reflection when the type is known.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
-<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
@@ -8797,8 +8701,8 @@ and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>rem
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
@@ -8829,8 +8733,8 @@ then when <code class="sourceCode cpp">T</code> is
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
@@ -8859,8 +8763,8 @@ convertible to <code class="sourceCode cpp">T</code>.</li>
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">11</a></span>
 <em>Effects</em>:</p>
 <ul>
@@ -8882,13 +8786,13 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
-<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
-<span id="cb208-3"><a href="#cb208-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb208-4"><a href="#cb208-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb208-5"><a href="#cb208-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
+<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
+<span id="cb204-3"><a href="#cb204-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb204-4"><a href="#cb204-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
@@ -8907,8 +8811,8 @@ is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
-<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
@@ -8928,8 +8832,8 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
@@ -8961,8 +8865,8 @@ lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
 value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
@@ -8988,8 +8892,8 @@ variable ([dcl.fct.def.general]).</li>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
@@ -8998,10 +8902,10 @@ type.</p>
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
-<span id="cb214-3"><a href="#cb214-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb214-4"><a href="#cb214-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
+<span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb210-4"><a href="#cb210-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">9</a></span>
 An expression <code class="sourceCode cpp"><em>E</em></code> is said to
 be <em>reciprocal to</em> a reflection
@@ -9156,13 +9060,13 @@ Reflection class definition generation<a href="#meta.reflection.define_class-ref
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
-<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
@@ -9178,12 +9082,12 @@ ordinary string literal (or
 <code class="sourceCode cpp">string</code>, etc) or a UTF-8 string
 literal (or <code class="sourceCode cpp">u8string_view</code>,
 <code class="sourceCode cpp">u8string</code>, etc) equally well.</p>
-<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
-<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
 <span> — <em>end note</em> ]</span>
 </div>
-<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
+<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
@@ -9250,15 +9154,15 @@ Certain other functions in
 <code class="sourceCode cpp">identifier_of</code>) can also be used to
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
-<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
 declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
@@ -9300,7 +9204,7 @@ be a sequence of reflections and
 be a sequence of
 <code class="sourceCode cpp">data_member_options_t</code> values such
 that</p>
-<div class="sourceCode" id="cb221"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
+<div class="sourceCode" id="cb217"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
@@ -9385,71 +9289,15 @@ has a user-provided default destructor which has no effect.</li>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="meta.reflection.define_static-static-array-generation">[meta.reflection.define_static]
-Static array generation<a href="#meta.reflection.define_static-static-array-generation" class="self-link"></a></h3>
-<div class="std">
-<blockquote>
-<div class="addu">
-<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">const</span> <span class="dt">char</span><span class="op">*</span> define_static_string<span class="op">(</span>string_view str<span class="op">)</span>;</span>
-<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">const</span> <span class="dt">char8_t</span><span class="op">*</span> define_static_string<span class="op">(</span>u8string_view str<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">1</a></span>
-Let <code class="sourceCode cpp"><em>S</em></code> be a constexpr
-variable of array type with static storage duration, whose elements are
-of type <code class="sourceCode cpp"><span class="kw">const</span> <span class="dt">char</span></code>
-or <code class="sourceCode cpp"><span class="kw">const</span> <span class="dt">char8_t</span></code>
-respectively, for which there exists some
-<code class="sourceCode cpp">k</code> ≥
-<code class="sourceCode cpp"><span class="dv">0</span></code> such
-that:</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(1.1)</a></span>
-<code class="sourceCode cpp"><em>S</em><span class="op">[</span>k <span class="op">+</span> i<span class="op">]</span> <span class="op">==</span> str<span class="op">[</span>i<span class="op">]</span></code>
-for all 0 ≤ <code class="sourceCode cpp">i</code> &lt; <code class="sourceCode cpp">str<span class="op">.</span>size<span class="op">()</span></code>,
-and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(1.2)</a></span>
-<code class="sourceCode cpp"><em>S</em><span class="op">[</span>k <span class="op">+</span> str<span class="op">.</span>size<span class="op">()]</span> <span class="op">==</span> <span class="ch">&#39;</span><span class="sc">\0</span><span class="ch">&#39;</span></code>.</li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">2</a></span>
-<em>Returns</em>: <code class="sourceCode cpp"><span class="op">&amp;</span><em>S</em><span class="op">[</span>k<span class="op">]</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">3</a></span>
-<em>Recommended Practice</em>: Implementations are encouraged to return
-the same object whenever the same variant of these functions is called
-with the same argument. <span class="note"><span>[ <em>Note 1:</em>
-</span>The returned object is distinct from any string literal<span>
-— <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span>ranges<span class="op">::</span>input_range R<span class="op">&gt;</span></span>
-<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">consteval</span> span<span class="op">&lt;</span><span class="kw">const</span> ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span> define_static_array<span class="op">(</span>R<span class="op">&amp;&amp;</span> r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">4</a></span>
-<em>Constraints</em>: <code class="sourceCode cpp">is_constructible_v<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span></code>
-is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">5</a></span>
-Let <code class="sourceCode cpp">D</code> be <code class="sourceCode cpp">ranges<span class="op">::</span>distance<span class="op">(</span>r<span class="op">)</span></code>
-and <code class="sourceCode cpp">S</code> be a constexpr variable of
-array type with static storage duration, whose elements are of type
-<code class="sourceCode cpp"><span class="kw">const</span> ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span></code>,
-for which there exists some <code class="sourceCode cpp">k</code> ≥
-<code class="sourceCode cpp"><span class="dv">0</span></code> such that
-<code class="sourceCode cpp"><em>S</em><span class="op">[</span>k <span class="op">+</span> i<span class="op">]</span> <span class="op">==</span> r<span class="op">[</span>i<span class="op">]</span></code>
-for all 0 ≤ <code class="sourceCode cpp">i</code> &lt;
-<code class="sourceCode cpp"><em>D</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">6</a></span>
-<em>Returns</em>: <code class="sourceCode cpp">span<span class="op">(</span>addressof<span class="op">(</span><em>S</em><span class="op">[</span><em>k</em><span class="op">])</span>, <em>D</em><span class="op">)</span></code></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">7</a></span>
-<em>Recommended Practice</em>: Implementations are encouraged to return
-the same object whenever the same the function is called with the same
-argument.</p>
-</div>
-</blockquote>
-</div>
 <h3 class="unnumbered" id="meta.reflection.unary-unary-type-traits">[meta.reflection.unary]
 Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-link"></a></h3>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9470,44 +9318,44 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.unary.cat]</a></span>.</p>
-<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_void<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_null_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-3"><a href="#cb224-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_integral<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-4"><a href="#cb224-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_floating_point<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-5"><a href="#cb224-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_array<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-6"><a href="#cb224-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-7"><a href="#cb224-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-8"><a href="#cb224-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-9"><a href="#cb224-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_object_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-10"><a href="#cb224-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_function_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-11"><a href="#cb224-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-12"><a href="#cb224-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_union<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-13"><a href="#cb224-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-14"><a href="#cb224-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-15"><a href="#cb224-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">2</a></span></p>
+<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_void<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_null_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_integral<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-4"><a href="#cb218-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_floating_point<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-5"><a href="#cb218-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_array<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-6"><a href="#cb218-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-9"><a href="#cb218-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_object_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-10"><a href="#cb218-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_function_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-11"><a href="#cb218-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-12"><a href="#cb218-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_union<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-14"><a href="#cb218-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-15"><a href="#cb218-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb225"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type) {</span>
-<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
-<span id="cb225-4"><a href="#cb225-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
-<span id="cb225-5"><a href="#cb225-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb225-6"><a href="#cb225-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
-<span id="cb225-7"><a href="#cb225-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
-<span id="cb225-8"><a href="#cb225-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
-<span id="cb225-9"><a href="#cb225-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
-<span id="cb225-10"><a href="#cb225-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
-<span id="cb225-11"><a href="#cb225-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
-<span id="cb225-12"><a href="#cb225-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb225-13"><a href="#cb225-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb219"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a>  consteval bool type_is_void(info type) {</span>
+<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
+<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
+<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
+<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
+<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
+<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
+<span id="cb219-10"><a href="#cb219-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
+<span id="cb219-11"><a href="#cb219-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
+<span id="cb219-12"><a href="#cb219-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb219-13"><a href="#cb219-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -9518,20 +9366,20 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.3 <a href="https://wg21.link/meta.unary.comp">[meta.unary.comp]</a></span>.</p>
-<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_arithmetic<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-3"><a href="#cb226-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_fundamental<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-4"><a href="#cb226-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_object<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-5"><a href="#cb226-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scalar<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-6"><a href="#cb226-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_compound<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-7"><a href="#cb226-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_arithmetic<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_fundamental<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_object<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scalar<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_compound<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_member_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9540,7 +9388,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9548,7 +9396,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9557,7 +9405,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9569,71 +9417,71 @@ each function template <code class="sourceCode cpp">std<span class="op">::</span
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-TRAIT</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-3"><a href="#cb227-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivial<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-4"><a href="#cb227-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copyable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-5"><a href="#cb227-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_standard_layout<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-6"><a href="#cb227-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_empty<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-7"><a href="#cb227-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_polymorphic<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-8"><a href="#cb227-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_abstract<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-9"><a href="#cb227-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_final<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-10"><a href="#cb227-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_aggregate<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-11"><a href="#cb227-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-12"><a href="#cb227-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-13"><a href="#cb227-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_bounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-14"><a href="#cb227-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unbounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-15"><a href="#cb227-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scoped_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-16"><a href="#cb227-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-17"><a href="#cb227-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb227-18"><a href="#cb227-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb227-19"><a href="#cb227-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-20"><a href="#cb227-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-21"><a href="#cb227-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-22"><a href="#cb227-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-23"><a href="#cb227-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb227-24"><a href="#cb227-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-25"><a href="#cb227-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-26"><a href="#cb227-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-27"><a href="#cb227-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb227-28"><a href="#cb227-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-29"><a href="#cb227-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-30"><a href="#cb227-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-31"><a href="#cb227-31" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-32"><a href="#cb227-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb227-33"><a href="#cb227-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb227-34"><a href="#cb227-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-35"><a href="#cb227-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-36"><a href="#cb227-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-37"><a href="#cb227-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-38"><a href="#cb227-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb227-39"><a href="#cb227-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-40"><a href="#cb227-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-41"><a href="#cb227-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-42"><a href="#cb227-42" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-43"><a href="#cb227-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb227-44"><a href="#cb227-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb227-45"><a href="#cb227-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-46"><a href="#cb227-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-47"><a href="#cb227-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-48"><a href="#cb227-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-49"><a href="#cb227-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb227-50"><a href="#cb227-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-51"><a href="#cb227-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-52"><a href="#cb227-52" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-53"><a href="#cb227-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb227-54"><a href="#cb227-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-55"><a href="#cb227-55" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-56"><a href="#cb227-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-57"><a href="#cb227-57" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-58"><a href="#cb227-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_implicit_lifetime<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-59"><a href="#cb227-59" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-60"><a href="#cb227-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-61"><a href="#cb227-61" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-62"><a href="#cb227-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-63"><a href="#cb227-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-64"><a href="#cb227-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb227-65"><a href="#cb227-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivial<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-4"><a href="#cb221-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copyable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-5"><a href="#cb221-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_standard_layout<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-6"><a href="#cb221-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_empty<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_polymorphic<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-8"><a href="#cb221-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_abstract<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-9"><a href="#cb221-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_final<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-10"><a href="#cb221-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_aggregate<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-11"><a href="#cb221-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-12"><a href="#cb221-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-13"><a href="#cb221-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_bounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-14"><a href="#cb221-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_unbounded_array<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-15"><a href="#cb221-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_scoped_enum<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-17"><a href="#cb221-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-18"><a href="#cb221-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-19"><a href="#cb221-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-20"><a href="#cb221-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-21"><a href="#cb221-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-22"><a href="#cb221-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-23"><a href="#cb221-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-24"><a href="#cb221-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-25"><a href="#cb221-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-26"><a href="#cb221-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-27"><a href="#cb221-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-28"><a href="#cb221-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-29"><a href="#cb221-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-30"><a href="#cb221-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-31"><a href="#cb221-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-32"><a href="#cb221-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-33"><a href="#cb221-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-34"><a href="#cb221-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-35"><a href="#cb221-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-36"><a href="#cb221-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-37"><a href="#cb221-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-38"><a href="#cb221-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-39"><a href="#cb221-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-40"><a href="#cb221-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-41"><a href="#cb221-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_trivially_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-42"><a href="#cb221-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-43"><a href="#cb221-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-44"><a href="#cb221-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_constructible<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-45"><a href="#cb221-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_default_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-46"><a href="#cb221-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-47"><a href="#cb221-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_constructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-48"><a href="#cb221-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-49"><a href="#cb221-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_assignable<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-50"><a href="#cb221-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_copy_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-51"><a href="#cb221-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_move_assignable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-52"><a href="#cb221-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-53"><a href="#cb221-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable_with<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-54"><a href="#cb221-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_swappable<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-55"><a href="#cb221-55" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-56"><a href="#cb221-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_destructible<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-57"><a href="#cb221-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-58"><a href="#cb221-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_implicit_lifetime<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-59"><a href="#cb221-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-60"><a href="#cb221-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-61"><a href="#cb221-61" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-62"><a href="#cb221-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-63"><a href="#cb221-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-64"><a href="#cb221-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-65"><a href="#cb221-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9642,7 +9490,7 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em></code>
@@ -9650,16 +9498,16 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>PROP</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.6 <a href="https://wg21.link/meta.unary.prop.query">[meta.unary.prop.query]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and unsigned integer value
 <code class="sourceCode cpp">I</code>, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_extent<span class="op">(^</span>T, I<span class="op">)</span></code>
 equals <code class="sourceCode cpp">std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span></code>
 ([meta.unary.prop.query]).</p>
-<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_alignment_of<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_rank<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb228-3"><a href="#cb228-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_alignment_of<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_rank<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-3"><a href="#cb222-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9668,10 +9516,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9680,7 +9528,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9692,7 +9540,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9705,23 +9553,23 @@ each ternary function template <code class="sourceCode cpp">std<span class="op">
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL-R</em><span class="op">(^</span>R, <span class="op">^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL-R</em>_v<span class="op">&lt;</span>R, T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_same<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb229-3"><a href="#cb229-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb229-4"><a href="#cb229-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb229-5"><a href="#cb229-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_layout_compatible<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb229-6"><a href="#cb229-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer_interconvertible_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb229-7"><a href="#cb229-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb229-8"><a href="#cb229-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb229-12"><a href="#cb229-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb229-13"><a href="#cb229-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb229-14"><a href="#cb229-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb229-15"><a href="#cb229-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb229-16"><a href="#cb229-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">5</a></span>
+<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_same<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb223-3"><a href="#cb223-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb223-4"><a href="#cb223-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_convertible<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb223-5"><a href="#cb223-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_layout_compatible<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb223-6"><a href="#cb223-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_pointer_interconvertible_base_of<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb223-7"><a href="#cb223-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb223-8"><a href="#cb223-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb223-9"><a href="#cb223-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb223-10"><a href="#cb223-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb223-11"><a href="#cb223-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb223-12"><a href="#cb223-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb223-13"><a href="#cb223-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb223-15"><a href="#cb223-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb223-16"><a href="#cb223-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9743,7 +9591,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9755,19 +9603,19 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
-<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-3"><a href="#cb230-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-4"><a href="#cb230-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-5"><a href="#cb230-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-6"><a href="#cb230-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb224-3"><a href="#cb224-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb224-4"><a href="#cb224-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb224-5"><a href="#cb224-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb224-6"><a href="#cb224-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9776,16 +9624,16 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
-<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb231-2"><a href="#cb231-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb231-3"><a href="#cb231-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9794,15 +9642,15 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
-<div class="sourceCode" id="cb232"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9811,15 +9659,15 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
-<div class="sourceCode" id="cb233"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb233-2"><a href="#cb233-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9828,15 +9676,15 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.6 <a href="https://wg21.link/meta.trans.ptr">[meta.trans.ptr]</a></span>.</p>
-<div class="sourceCode" id="cb234"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb234-2"><a href="#cb234-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9855,7 +9703,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9863,7 +9711,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9873,7 +9721,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9884,29 +9732,29 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_invoke_result<span class="op">(^</span>T, r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span>invoke_result_t<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 (<span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>).</p>
-<div class="sourceCode" id="cb235"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb235-1"><a href="#cb235-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb235-2"><a href="#cb235-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_decay<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb235-3"><a href="#cb235-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb235-4"><a href="#cb235-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb235-5"><a href="#cb235-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb235-6"><a href="#cb235-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb235-7"><a href="#cb235-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb235-8"><a href="#cb235-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb235-9"><a href="#cb235-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb235-10"><a href="#cb235-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb235-11"><a href="#cb235-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">4</a></span></p>
+<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_decay<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-3"><a href="#cb229-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb229-4"><a href="#cb229-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb229-5"><a href="#cb229-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb229-6"><a href="#cb229-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb229-7"><a href="#cb229-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-8"><a href="#cb229-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb236"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb236-1"><a href="#cb236-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
-<span id="cb236-2"><a href="#cb236-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb236-3"><a href="#cb236-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb236-4"><a href="#cb236-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb236-5"><a href="#cb236-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type_add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb236-6"><a href="#cb236-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb236-7"><a href="#cb236-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
-<span id="cb236-8"><a href="#cb236-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb236-9"><a href="#cb236-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
+<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb230-3"><a href="#cb230-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
+<span id="cb230-4"><a href="#cb230-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb230-5"><a href="#cb230-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type_add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb230-6"><a href="#cb230-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb230-7"><a href="#cb230-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
+<span id="cb230-8"><a href="#cb230-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb230-9"><a href="#cb230-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -9917,7 +9765,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9925,7 +9773,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -9934,11 +9782,11 @@ defined in this clause with the signature <code class="sourceCode cpp">info<span
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^</span>T<span class="op">)</span></code>
 returns a reflection representing the type <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<div class="sourceCode" id="cb237"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb237-1"><a href="#cb237-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb237-2"><a href="#cb237-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb237-3"><a href="#cb237-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb237-4"><a href="#cb237-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb237-5"><a href="#cb237-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb231-2"><a href="#cb231-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb231-3"><a href="#cb231-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb231-4"><a href="#cb231-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> type_variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb231-5"><a href="#cb231-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9949,7 +9797,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -9957,27 +9805,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -9995,10 +9843,10 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb238"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb238-1"><a href="#cb238-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
-<span id="cb238-2"><a href="#cb238-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
-<span id="cb238-3"><a href="#cb238-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
-<span id="cb238-4"><a href="#cb238-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
+<div class="sourceCode" id="cb232"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
+<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
+<span id="cb232-3"><a href="#cb232-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
+<span id="cb232-4"><a href="#cb232-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10006,7 +9854,7 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb239"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb239-1"><a href="#cb239-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb233"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10101,10 +9949,6 @@ constant-evaluation. <a href="https://wg21.link/p3068r1"><div class="csl-block">
 <div id="ref-P3096R1" class="csl-entry" role="doc-biblioentry">
 [P3096R1] Adam Lach, Walter Genovese. 2024-05-15. Function Parameter
 Reflection in Reflection for C++26. <a href="https://wg21.link/p3096r1"><div class="csl-block">https://wg21.link/p3096r1</div></a>
-</div>
-<div id="ref-P3293R1" class="csl-entry" role="doc-biblioentry">
-[P3293R1] Barry Revzin, Peter Dimov, Dan Katz, Daveed Vandevoorde.
-2024-10-13. Splicing a base class subobject. <a href="https://wg21.link/p3293r1"><div class="csl-block">https://wg21.link/p3293r1</div></a>
 </div>
 <div id="ref-P3295R0" class="csl-entry" role="doc-biblioentry">
 [P3295R0] Ben Craig. 2024-05-21. Freestanding constexpr containers and

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -6028,55 +6028,51 @@ renumber accordingly:</p>
 <blockquote>
 <div class="addu">
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">20</a></span>
-An expression or conversion is <em>potentially plainly
-constant-evaluated</em> if it is:</p>
+An expression or conversion is <em>in substitution context</em> if it
+results from the substitution of template parameters</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(20.1)</a></span>
-a <code class="sourceCode cpp"><em>constant-expression</em></code>,</li>
+during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(20.2)</a></span>
-the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
+in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
+<a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(20.3)</a></span>
+in a <code class="sourceCode cpp"><em>requires-expression</em></code>
+(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">21</a></span>
+An expression or conversion is <em>plainly constant-evaluated</em> if it
+is</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(21.1)</a></span>
+a <code class="sourceCode cpp"><em>constant-expression</em></code> that
+is not in substitution context,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(21.2)</a></span>
+the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(21.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(20.4)</a></span>
-an immediate invocation.</li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">21</a></span>
-A potentially plainly constant-evaluated expression or conversion is
-also <em>plainly constant-evaluated</em> unless it</p>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.4)</a></span>
+an immediate invocation, unless it is
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(21.1)</a></span>
-is a subexpression of an initializer for a variable that is neither
-<code class="sourceCode cpp"><span class="kw">constexpr</span></code>
-nor
-<code class="sourceCode cpp"><span class="kw">constinit</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(21.2)</a></span>
-results from the substitution of template parameters
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.2.1)</a></span>
-during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.2.2)</a></span>
-in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
-<a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.2.3)</a></span>
-in a <code class="sourceCode cpp"><em>requires-expression</em></code>
-(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>),
-or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.4.1)</a></span>
+in substitution context, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.4.2)</a></span>
+within the body of an immediate-escalating function that contains an
+immediate-escalating expression.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(21.3)</a></span>
-is an immediate invocation appearing within the body of an
-immediate-escalating function that contains an immediate-escalating
-expression.</li>
 </ul>
-<p><span class="note"><span>[ <em>Note 1:</em> </span>Plainly
-constant-evaluated expressions are evaluated exactly once, and that
-evaluation precedes any subsequent parsing (<span>5.2 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span>). As
-detailed below, evaluations of such expressions are allowed to produce
-injected declarations.<span> — <em>end note</em> ]</span></span></p>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>A plainly
+constant-evaluated expression
+<code class="sourceCode cpp"><em>E</em></code> is evaluated exactly
+once, may produce injected declarations (see below), and any such
+declarations are reachable at a point immediatelly following
+<code class="sourceCode cpp"><em>E</em></code>.<span> — <em>end
+note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
@@ -6107,22 +6103,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">22</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(22.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(22.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(22.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(22.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(22.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(22.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(22.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(22.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6145,7 +6141,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">23</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6159,12 +6155,12 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">24</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(24.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
 constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
@@ -6210,7 +6206,7 @@ once.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb118-27"><a href="#cb118-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6219,11 +6215,11 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code>.</li>
@@ -6257,10 +6253,10 @@ follows:</p>
 <div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
 <span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">1</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
 may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">2</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 designate a type. The type designated by the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6277,45 +6273,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6323,7 +6319,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6332,22 +6328,22 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">9</a></span>
 A function type with a <em>cv-qualifier-seq</em> or a
 <em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(9.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(9.5)</a></span>
 the <em>type-id</em> of a <em>template-argument</em> for a
 <em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(9.6)</a></span>
 the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
@@ -6359,7 +6355,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator</span>, is ill-formed.</p>
@@ -6387,7 +6383,7 @@ follows:</p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">1</a></span>
 A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>
@@ -6425,7 +6421,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">0</a></span>
 If a
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 is a <code class="sourceCode cpp"><em>splice-specifier</em></code>, the
@@ -6446,7 +6442,7 @@ designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link
 in the paragraph that immediately follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6474,7 +6470,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">0</a></span>
 The
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 shall neither contain a dependent
@@ -6482,7 +6478,7 @@ shall neither contain a dependent
 dependent
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6546,7 +6542,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6569,23 +6565,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6600,7 +6596,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6625,7 +6621,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
@@ -6640,7 +6636,7 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 in template parameter declarations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">4</a></span>
 … The concept designated by a type-constraint shall be a type concept
 ([temp.concept]) <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-template-name</em></code></span>.</p>
@@ -6697,21 +6693,21 @@ designates the entity designated by the
 <p>Extend paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a <em>template-argument-list</em> if it
 follows a name that is not a <em>conversion-function-id</em> and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(3.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(3.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(3.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(3.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -6753,7 +6749,7 @@ it follows a
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">9</a></span>
 A <em>concept-id</em> is a <em>simple-template-id</em> where the
 <em>template-name</em> is <span class="addu">either</span> a
 <em>concept-name</em> <span class="addu">or a
@@ -6768,7 +6764,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -6806,7 +6802,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -6825,7 +6821,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be the name of a class template or an alias template, expressed as
@@ -6840,23 +6836,23 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and they compare equal, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -6867,7 +6863,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -6933,7 +6929,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6952,10 +6948,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -6981,7 +6977,7 @@ or a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -7002,7 +6998,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -7020,19 +7016,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7045,7 +7041,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7053,7 +7049,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">7pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">7pre</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7063,7 +7059,7 @@ might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7515,7 +7511,7 @@ synopsis</strong></p>
 <span id="cb137-351"><a href="#cb137-351" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_variant_size(info type);</span>
 <span id="cb137-352"><a href="#cb137-352" aria-hidden="true" tabindex="-1"></a>  consteval info type_variant_alternative(size_t index, info type);</span>
 <span id="cb137-353"><a href="#cb137-353" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
@@ -7531,7 +7527,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -7784,10 +7780,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -7795,11 +7791,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -7814,33 +7810,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -7849,23 +7845,23 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7874,43 +7870,43 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 namespace alias, then the identifier introduced by the declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7922,21 +7918,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -7954,7 +7950,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -7962,7 +7958,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -7970,7 +7966,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -7978,7 +7974,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -7986,7 +7982,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -7995,7 +7991,7 @@ defined as deleted ([dcl.fct.def.delete])or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8003,7 +7999,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8018,7 +8014,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8036,7 +8032,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8046,7 +8042,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -8054,7 +8050,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8063,7 +8059,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8072,7 +8068,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -8082,7 +8078,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -8093,7 +8089,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8102,13 +8098,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8118,13 +8114,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8133,20 +8129,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8154,7 +8150,7 @@ namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8165,7 +8161,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8173,7 +8169,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8188,7 +8184,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8198,14 +8194,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8222,7 +8218,7 @@ is
 <span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8231,7 +8227,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8240,14 +8236,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8258,7 +8254,7 @@ Otherwise,
 <span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8266,20 +8262,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8288,11 +8284,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8308,33 +8304,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8350,24 +8346,24 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
 alias <em>A</em>, then a reflection representing the entity named by
 <em>A</em>. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8379,15 +8375,15 @@ alias <em>A</em>, then a reflection representing the entity named by
 </div>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8409,11 +8405,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8434,7 +8430,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8445,11 +8441,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8463,14 +8459,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8480,92 +8476,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -8580,32 +8576,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8614,7 +8610,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose associated subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -8627,7 +8623,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -8636,20 +8632,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -8657,7 +8653,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8666,7 +8662,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -8679,32 +8675,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -8712,7 +8708,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -8720,7 +8716,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -8728,52 +8724,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -8791,36 +8787,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -8832,32 +8828,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -8865,37 +8861,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -8904,28 +8900,28 @@ type.</p>
 <span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
 <span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb210-4"><a href="#cb210-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">9</a></span>
 An expression <code class="sourceCode cpp"><em>E</em></code> is said to
 be <em>reciprocal to</em> a reflection
 <code class="sourceCode cpp"><em>r</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(9.1)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents a variable,
 and <code class="sourceCode cpp"><em>E</em></code> is an lvalue
 designating the object named by that variable,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(9.2)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents an object or
 function, and <code class="sourceCode cpp"><em>E</em></code> is an
 lvalue that designates that object or function, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(9.3)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents a value, and
 <code class="sourceCode cpp"><em>E</em></code> is a prvalue that
 computes that value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">10</a></span>
 For exposition only, let</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(10.1)</a></span>
 <code class="sourceCode cpp"><em>F</em></code> be either an entity or an
 expression, such that if <code class="sourceCode cpp">target</code>
 represents a function or function template then
@@ -8934,14 +8930,14 @@ represents a function or function template then
 object, or value, then <code class="sourceCode cpp"><em>F</em></code> is
 an expression reciprocal to
 <code class="sourceCode cpp">target</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(10.2)</a></span>
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 be a sequence of entities and expressions corresponding to the elements
 of <code class="sourceCode cpp">tmpl_args</code> (if any), such that for
 every <code class="sourceCode cpp"><em>targ</em></code> in
 <code class="sourceCode cpp">tmpl_args</code>,
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(10.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(10.2.1)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a type
 or <code class="sourceCode cpp"><em>typedef-name</em></code>, the
 corresponding element of
@@ -8949,19 +8945,19 @@ corresponding element of
 is that type, or the type named by that
 <code class="sourceCode cpp"><em>typedef-name</em></code>,
 respectively,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(10.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(10.2.2)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a
 variable, object, value, or function, the corresponding element of
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 is an expression reciprocal to
 <code class="sourceCode cpp"><em>targ</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(10.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(10.2.3)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a class
 or alias template, then the corresponding element of
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 is that template,</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(10.3)</a></span>
 <code class="sourceCode cpp"><em>Args</em><span class="op">...</span></code>
 be a sequence of expressions
 {<code class="sourceCode cpp"><span class="math inline"><em>E</em></span><sub><span class="math inline"><em>K</em></span></sub></code>} corresponding to the
@@ -8972,11 +8968,11 @@ reflections
 variable, object, value, or function,
 <code class="sourceCode cpp"><span class="math inline"><em>E</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is reciprocal to
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(10.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(10.4)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub></code>
 be the first expression in
 <code class="sourceCode cpp"><em>Args</em></code> (if any), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(10.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(10.5)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...</span></code> be
 the sequence of expressions in
 <code class="sourceCode cpp"><em>Args</em></code> excluding
@@ -8986,17 +8982,17 @@ the sequence of expressions in
 <p>and define an expression
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(10.6)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(10.6)</a></span>
 If <code class="sourceCode cpp">target</code> represents a non-member
 function, variable, object, or value, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is the
 expression <code class="sourceCode cpp"><em>INVOKE</em><span class="op">(</span><em>F</em>, <span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub>, <span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(10.7)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(10.7)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a member
 function that is not a constructor, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is the
 expression <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub><span class="op">.</span><em>F</em><span class="op">(</span><span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(10.8)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(10.8)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a
 function template that is not a constructor template, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is either the
@@ -9004,7 +9000,7 @@ expression <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>
 <code class="sourceCode cpp"><em>F</em></code> is a member function
 template, or <code class="sourceCode cpp"><em>F</em><span class="op">&lt;</span><em>TArgs</em><span class="op">...&gt;(</span><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub>, <span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>
 otherwise.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(10.9)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(10.9)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a
 constructor or constructor template for a class
 <code class="sourceCode cpp"><em>C</em></code>, then
@@ -9018,7 +9014,7 @@ template, then
 are inferred as leading template arguments during template argument
 deduction for <code class="sourceCode cpp"><em>F</em></code>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">11</a></span>
 <em>Constant When</em>:</p>
 <ul>
 <li><code class="sourceCode cpp">target</code> represents either a
@@ -9037,13 +9033,13 @@ represents a variable, object, value, or function, and</li>
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is a
 well-formed constant expression of structural type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">12</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">target</code>
 represents a function template, any specialization of the represented
 template that would be invoked by evaluation of
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is
 instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">13</a></span>
 <em>Returns</em>: A reflection of the same result computed by
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code>.</p>
 </div>
@@ -9054,18 +9050,18 @@ Reflection class definition generation<a href="#meta.reflection.define_class-ref
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9086,64 +9082,64 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.2)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 contains a value <code class="sourceCode cpp"><em>NAME</em></code> then
 either:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.3)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(1.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.4.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(1.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(1.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">(1.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(1.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(1.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">(1.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_class</code>.
 Certain other functions in
@@ -9153,7 +9149,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -9161,7 +9157,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9169,21 +9165,21 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(5.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a valid type for data members, for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
@@ -9194,7 +9190,7 @@ then <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span 
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9206,26 +9202,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a non-static
 data member corresponding to each reflection value
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
@@ -9237,28 +9233,28 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.5)</a></span>
 The non-static data member corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.6)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> are
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.7)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>width</code>
 contains a value are declared as bit-fields whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.8)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value are declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(7.9)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> are declared with
 names determined as follows:
@@ -9273,16 +9269,16 @@ the non-static data member is unnamed.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 it has a user-provided default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default destructible, then it
 has a user-provided default destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9292,10 +9288,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9316,7 +9312,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
@@ -9338,7 +9334,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb218-14"><a href="#cb218-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb218-15"><a href="#cb218-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb219"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9364,7 +9360,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
@@ -9386,7 +9382,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9394,7 +9390,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9403,7 +9399,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9488,7 +9484,7 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em></code>
@@ -9496,7 +9492,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>PROP</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.6 <a href="https://wg21.link/meta.unary.prop.query">[meta.unary.prop.query]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and unsigned integer value
@@ -9514,10 +9510,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9526,7 +9522,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9538,7 +9534,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9567,7 +9563,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb223-15"><a href="#cb223-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb223-16"><a href="#cb223-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9589,7 +9585,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9601,7 +9597,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9622,7 +9618,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9640,7 +9636,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9657,7 +9653,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9674,7 +9670,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9701,7 +9697,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9709,7 +9705,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9719,7 +9715,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9741,7 +9737,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -9763,7 +9759,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9771,7 +9767,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -9795,7 +9791,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -9803,27 +9799,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-10-30" />
+  <meta name="dcterms.date" content="2024-11-01" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-10-30</td>
+    <td>2024-11-01</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -6032,21 +6032,19 @@ An expression or conversion is <em>plainly constant-evaluated</em> if it
 is:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(20.1)</a></span>
-a <code class="sourceCode cpp"><em>constant-expression</em></code>,
-or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(20.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(20.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(20.2)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
-variable, or a subexpression thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(20.4)</a></span>
-an immediate invocation, unless it
+variable, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(20.3)</a></span>
+a <code class="sourceCode cpp"><em>constant-expression</em></code> or an
+immediate invocation, unless it
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(20.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(20.3.1)</a></span>
 results from the substitution of template parameters
 <ul>
 <li>during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
@@ -6057,13 +6055,13 @@ results from the substitution of template parameters
 (<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>),
 or</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(20.4.2)</a></span>
-is an initializer for a variable that is neither
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(20.3.2)</a></span>
+is an initializer, or a subexpression thereof, for a variable that is
+neither
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) nor
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
-(<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>), or a
-subexpression thereof.</li>
+(<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>).</li>
 </ul></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Plainly
@@ -6073,52 +6071,50 @@ detailed below, evaluations of such expressions are allowed to produce
 injected declarations.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
 <span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
-<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
-<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
-<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb117-8"><a href="#cb117-8" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
-<span id="cb117-9"><a href="#cb117-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb117-10"><a href="#cb117-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb117-11"><a href="#cb117-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb117-12"><a href="#cb117-12" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
-<span id="cb117-13"><a href="#cb117-13" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
+<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
+<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb117-8"><a href="#cb117-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
+<span id="cb117-9"><a href="#cb117-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb117-10"><a href="#cb117-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
+<span id="cb117-11"><a href="#cb117-11" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
+<span id="cb117-12"><a href="#cb117-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb117-13"><a href="#cb117-13" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
+<span id="cb117-14"><a href="#cb117-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb117-15"><a href="#cb117-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb117-16"><a href="#cb117-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb117-17"><a href="#cb117-17" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
+<span id="cb117-18"><a href="#cb117-18" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
 </blockquote>
 </div>
-<p>Modify the definition of <em>manifestly constant-evaluated</em> to
-leverage that of <em>plainly constant-evaluated</em>:</p>
+<p>Add a note following the definition of <em>manifestly
+constant-evaluated</em> to clarify the relationship with <em>plainly
+constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">21</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.1)</a></span>
-a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>constant-expression</em></code></span></del></span>
-<span class="addu">plainly constant-evaluated expression</span>, or</li>
-</ul>
-<div class="rm" style="color: #bf0303">
-
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(21.1)</a></span>
+a <code class="sourceCode cpp"><em>constant-expression</em></code>,
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-</ul>
-
-</div>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(21.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(21.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6141,7 +6137,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">22</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6155,21 +6151,23 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">23</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(23.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(23.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
-constant-evaluated, or</li>
+constant-evaluated,</li>
+<li>required for the lookup of a name appearing within an unevaluated
+operand,</li>
 <li>within the body of an immediate-escalating function
 <code class="sourceCode cpp"><em>F</em></code>, unless
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(23.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(23.1.1)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a plainly
 constant-evaluated expression or a subexpression thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(23.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(23.1.2)</a></span>
 <code class="sourceCode cpp"><em>F</em></code> does not contain an
 immediate-escalating expression.</li>
 </ul></li>
@@ -6212,7 +6210,7 @@ once.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb118-27"><a href="#cb118-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6221,11 +6219,11 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code>.</li>
@@ -6259,10 +6257,10 @@ follows:</p>
 <div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
 <span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">1</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
 may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">2</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 designate a type. The type designated by the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6279,45 +6277,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6325,7 +6323,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6334,22 +6332,22 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">9</a></span>
 A function type with a <em>cv-qualifier-seq</em> or a
 <em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(9.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(9.5)</a></span>
 the <em>type-id</em> of a <em>template-argument</em> for a
 <em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(9.6)</a></span>
 the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
@@ -6361,7 +6359,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator</span>, is ill-formed.</p>
@@ -6389,7 +6387,7 @@ follows:</p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">1</a></span>
 A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>
@@ -6427,7 +6425,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">0</a></span>
 If a
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 is a <code class="sourceCode cpp"><em>splice-specifier</em></code>, the
@@ -6448,7 +6446,7 @@ designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link
 in the paragraph that immediately follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6476,7 +6474,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">0</a></span>
 The
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 shall neither contain a dependent
@@ -6484,7 +6482,7 @@ shall neither contain a dependent
 dependent
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6548,7 +6546,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6571,23 +6569,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6602,7 +6600,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6627,7 +6625,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
@@ -6642,7 +6640,7 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 in template parameter declarations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">4</a></span>
 … The concept designated by a type-constraint shall be a type concept
 ([temp.concept]) <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-template-name</em></code></span>.</p>
@@ -6699,21 +6697,21 @@ designates the entity designated by the
 <p>Extend paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a <em>template-argument-list</em> if it
 follows a name that is not a <em>conversion-function-id</em> and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(3.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(3.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(3.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(3.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -6755,7 +6753,7 @@ it follows a
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">9</a></span>
 A <em>concept-id</em> is a <em>simple-template-id</em> where the
 <em>template-name</em> is <span class="addu">either</span> a
 <em>concept-name</em> <span class="addu">or a
@@ -6770,7 +6768,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -6808,7 +6806,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -6827,7 +6825,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be the name of a class template or an alias template, expressed as
@@ -6842,23 +6840,23 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and they compare equal, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -6869,7 +6867,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -6935,7 +6933,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6954,10 +6952,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -6983,7 +6981,7 @@ or a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -7004,7 +7002,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -7022,19 +7020,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7047,7 +7045,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7055,7 +7053,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">7pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">7pre</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7065,7 +7063,7 @@ might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7517,7 +7515,7 @@ synopsis</strong></p>
 <span id="cb137-351"><a href="#cb137-351" aria-hidden="true" tabindex="-1"></a>  consteval size_t type_variant_size(info type);</span>
 <span id="cb137-352"><a href="#cb137-352" aria-hidden="true" tabindex="-1"></a>  consteval info type_variant_alternative(size_t index, info type);</span>
 <span id="cb137-353"><a href="#cb137-353" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
@@ -7533,7 +7531,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -7786,10 +7784,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -7797,11 +7795,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -7816,33 +7814,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -7851,23 +7849,23 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7876,43 +7874,43 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 namespace alias, then the identifier introduced by the declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7924,21 +7922,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -7956,7 +7954,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -7964,7 +7962,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -7972,7 +7970,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -7980,7 +7978,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -7988,7 +7986,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -7997,7 +7995,7 @@ defined as deleted ([dcl.fct.def.delete])or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8005,7 +8003,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8020,7 +8018,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8038,7 +8036,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8048,7 +8046,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -8056,7 +8054,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8065,7 +8063,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8074,7 +8072,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -8084,7 +8082,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -8095,7 +8093,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8104,13 +8102,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8120,13 +8118,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8135,20 +8133,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8156,7 +8154,7 @@ namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8167,7 +8165,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8175,7 +8173,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8190,7 +8188,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8200,14 +8198,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8224,7 +8222,7 @@ is
 <span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8233,7 +8231,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8242,14 +8240,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8260,7 +8258,7 @@ Otherwise,
 <span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8268,20 +8266,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8290,11 +8288,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8310,33 +8308,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8352,24 +8350,24 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
 alias <em>A</em>, then a reflection representing the entity named by
 <em>A</em>. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8381,15 +8379,15 @@ alias <em>A</em>, then a reflection representing the entity named by
 </div>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8411,11 +8409,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8436,7 +8434,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8447,11 +8445,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8465,14 +8463,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8482,92 +8480,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -8582,32 +8580,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8616,7 +8614,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose associated subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -8629,7 +8627,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -8638,20 +8636,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -8659,7 +8657,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8668,7 +8666,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -8681,32 +8679,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -8714,7 +8712,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -8722,7 +8720,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -8730,52 +8728,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -8793,36 +8791,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -8834,32 +8832,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -8867,37 +8865,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -8906,28 +8904,28 @@ type.</p>
 <span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span>
 <span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R1 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;</span>, reflection_range R2 <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb210-4"><a href="#cb210-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_invoke<span class="op">(</span>info target, R1<span class="op">&amp;&amp;</span> tmpl_args, R2<span class="op">&amp;&amp;</span> args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">9</a></span>
 An expression <code class="sourceCode cpp"><em>E</em></code> is said to
 be <em>reciprocal to</em> a reflection
 <code class="sourceCode cpp"><em>r</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(9.1)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents a variable,
 and <code class="sourceCode cpp"><em>E</em></code> is an lvalue
 designating the object named by that variable,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(9.2)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents an object or
 function, and <code class="sourceCode cpp"><em>E</em></code> is an
 lvalue that designates that object or function, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(9.3)</a></span>
 <code class="sourceCode cpp"><em>r</em></code> represents a value, and
 <code class="sourceCode cpp"><em>E</em></code> is a prvalue that
 computes that value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">10</a></span>
 For exposition only, let</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(10.1)</a></span>
 <code class="sourceCode cpp"><em>F</em></code> be either an entity or an
 expression, such that if <code class="sourceCode cpp">target</code>
 represents a function or function template then
@@ -8936,14 +8934,14 @@ represents a function or function template then
 object, or value, then <code class="sourceCode cpp"><em>F</em></code> is
 an expression reciprocal to
 <code class="sourceCode cpp">target</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(10.2)</a></span>
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 be a sequence of entities and expressions corresponding to the elements
 of <code class="sourceCode cpp">tmpl_args</code> (if any), such that for
 every <code class="sourceCode cpp"><em>targ</em></code> in
 <code class="sourceCode cpp">tmpl_args</code>,
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(10.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(10.2.1)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a type
 or <code class="sourceCode cpp"><em>typedef-name</em></code>, the
 corresponding element of
@@ -8951,19 +8949,19 @@ corresponding element of
 is that type, or the type named by that
 <code class="sourceCode cpp"><em>typedef-name</em></code>,
 respectively,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(10.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(10.2.2)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a
 variable, object, value, or function, the corresponding element of
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 is an expression reciprocal to
 <code class="sourceCode cpp"><em>targ</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(10.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(10.2.3)</a></span>
 if <code class="sourceCode cpp"><em>targ</em></code> represents a class
 or alias template, then the corresponding element of
 <code class="sourceCode cpp"><em>TArgs</em><span class="op">...</span></code>
 is that template,</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(10.3)</a></span>
 <code class="sourceCode cpp"><em>Args</em><span class="op">...</span></code>
 be a sequence of expressions
 {<code class="sourceCode cpp"><span class="math inline"><em>E</em></span><sub><span class="math inline"><em>K</em></span></sub></code>} corresponding to the
@@ -8974,11 +8972,11 @@ reflections
 variable, object, value, or function,
 <code class="sourceCode cpp"><span class="math inline"><em>E</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is reciprocal to
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(10.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(10.4)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub></code>
 be the first expression in
 <code class="sourceCode cpp"><em>Args</em></code> (if any), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(10.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(10.5)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...</span></code> be
 the sequence of expressions in
 <code class="sourceCode cpp"><em>Args</em></code> excluding
@@ -8988,17 +8986,17 @@ the sequence of expressions in
 <p>and define an expression
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(10.6)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(10.6)</a></span>
 If <code class="sourceCode cpp">target</code> represents a non-member
 function, variable, object, or value, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is the
 expression <code class="sourceCode cpp"><em>INVOKE</em><span class="op">(</span><em>F</em>, <span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub>, <span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(10.7)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(10.7)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a member
 function that is not a constructor, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is the
 expression <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub><span class="op">.</span><em>F</em><span class="op">(</span><span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(10.8)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(10.8)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a
 function template that is not a constructor template, then
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is either the
@@ -9006,7 +9004,7 @@ expression <code class="sourceCode cpp"><span class="math inline"><em>A</em><em>
 <code class="sourceCode cpp"><em>F</em></code> is a member function
 template, or <code class="sourceCode cpp"><em>F</em><span class="op">&lt;</span><em>TArgs</em><span class="op">...&gt;(</span><span class="math inline"><em>A</em><em>r</em><em>g</em></span><sub>0</sub>, <span class="math inline"><em>A</em><em>r</em><em>g</em><em>s</em></span><sub><span class="math inline">+</span></sub><span class="op">...)</span></code>
 otherwise.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(10.9)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(10.9)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>F</em></code> is a
 constructor or constructor template for a class
 <code class="sourceCode cpp"><em>C</em></code>, then
@@ -9020,7 +9018,7 @@ template, then
 are inferred as leading template arguments during template argument
 deduction for <code class="sourceCode cpp"><em>F</em></code>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">11</a></span>
 <em>Constant When</em>:</p>
 <ul>
 <li><code class="sourceCode cpp">target</code> represents either a
@@ -9039,13 +9037,13 @@ represents a variable, object, value, or function, and</li>
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is a
 well-formed constant expression of structural type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">12</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">target</code>
 represents a function template, any specialization of the represented
 template that would be invoked by evaluation of
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code> is
 instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">13</a></span>
 <em>Returns</em>: A reflection of the same result computed by
 <code class="sourceCode cpp"><em>INVOKE-EXPR</em></code>.</p>
 </div>
@@ -9056,18 +9054,18 @@ Reflection class definition generation<a href="#meta.reflection.define_class-ref
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9088,64 +9086,64 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(1.2)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 contains a value <code class="sourceCode cpp"><em>NAME</em></code> then
 either:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span><em>NAME</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.3)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.4.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(1.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_class</code>.
 Certain other functions in
@@ -9155,7 +9153,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -9163,7 +9161,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_class<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9171,21 +9169,21 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(5.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a valid type for data members, for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
@@ -9196,7 +9194,7 @@ then <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span 
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9208,26 +9206,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a non-static
 data member corresponding to each reflection value
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
@@ -9239,28 +9237,28 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.5)</a></span>
 The non-static data member corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.6)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> are
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.7)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>width</code>
 contains a value are declared as bit-fields whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.8)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value are declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.9)</a></span>
 Non-static data members corresponding to reflections
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> are declared with
 names determined as follows:
@@ -9275,16 +9273,16 @@ the non-static data member is unnamed.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 it has a user-provided default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default destructible, then it
 has a user-provided default destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9294,10 +9292,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9318,7 +9316,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
@@ -9340,7 +9338,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_class<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb218-14"><a href="#cb218-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_function<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb218-15"><a href="#cb218-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_reflection<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb219"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9366,7 +9364,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>TRAIT</em></code>
@@ -9388,7 +9386,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9396,7 +9394,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9405,7 +9403,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9490,7 +9488,7 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em></code>
@@ -9498,7 +9496,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>PROP</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>PROP</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.6 <a href="https://wg21.link/meta.unary.prop.query">[meta.unary.prop.query]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and unsigned integer value
@@ -9516,10 +9514,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9528,7 +9526,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>REL</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9540,7 +9538,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-REL</em><span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9569,7 +9567,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb223-15"><a href="#cb223-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb223-16"><a href="#cb223-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> type_is_nothrow_invocable_r<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9591,7 +9589,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9603,7 +9601,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9624,7 +9622,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9642,7 +9640,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9659,7 +9657,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9676,7 +9674,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9703,7 +9701,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9711,7 +9709,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9721,7 +9719,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9743,7 +9741,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -9765,7 +9763,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em></code>
@@ -9773,7 +9771,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -9797,7 +9795,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -9805,27 +9803,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3585,21 +3585,26 @@ Add a new paragraph between [expr.eq]{.sref}/5 and /6:
 
 ### [expr.const]{.sref} Constant Expressions {-}
 
-Add a new paragraph prior to the definition of _manifestly constant evaluated_ ([expr.const]{.sref}/20), and renumber accordingly:
+Add new paragraphs prior to the definition of _manifestly constant evaluated_ ([expr.const]{.sref}/20), and renumber accordingly:
 
 ::: std
 ::: addu
 
-[20]{.pnum} An expression or conversion is _plainly constant-evaluated_ if it is:
+[20]{.pnum} An expression or conversion is _potentially plainly constant-evaluated_ if it is:
 
+* [#.#]{.pnum} a `$constant-expression$`,
 * [#.#]{.pnum} the condition of a constexpr if statement ([stmt.if]{.sref}),
 * [#.#]{.pnum} the initializer of a `constexpr` ([dcl.constexpr]{.sref}) or `constinit` ([dcl.constinit]{.sref}) variable, or
-* [#.#]{.pnum} a `$constant-expression$` or an immediate invocation, unless it
-  * [#.#.#]{.pnum} results from the substitution of template parameters
-    * during template argument deduction ([temp.deduct]{.sref}),
-    * in a `$concept-id$` ([temp.names]{.sref}), or
-    * in a `$requires-expression$` ([expr.prim.req]{.sref}), or
-  * [#.#.#]{.pnum} is an initializer, or a subexpression thereof, for a variable that is neither  `constexpr` ([dcl.constexpr]{.sref}) nor `constinit` ([dcl.constinit]{.sref}).
+* [#.#]{.pnum} an immediate invocation.
+
+[#]{.pnum} A potentially plainly constant-evaluated expression or conversion is also _plainly constant-evaluated_ unless it
+
+* [#.#]{.pnum} is a subexpression of an initializer for a variable that is neither `constexpr` nor `constinit`,
+* [#.#]{.pnum} results from the substitution of template parameters
+  * [#.#.#]{.pnum} during template argument deduction ([temp.deduct]{.sref}),
+  * [#.#.#]{.pnum} in a `$concept-id$` ([temp.names]{.sref}), or
+  * [#.#.#]{.pnum} in a `$requires-expression$` ([expr.prim.req]{.sref}), or
+* [#.#]{.pnum} is an immediate invocation appearing within the body of an immediate-escalating function that contains an immediate-escalating expression.
 
 [Plainly constant-evaluated expressions are evaluated exactly once, and that evaluation precedes any subsequent parsing ([lex.phases]{.sref}). As detailed below, evaluations of such expressions are allowed to produce injected declarations.]{.note}
 
@@ -3634,7 +3639,7 @@ Add a note following the definition of _manifestly constant-evaluated_ to clarif
 
 ::: std
 
-[21]{.pnum} An expression or conversion is _manifestly constant-evaluated_ if it is:
+[#]{.pnum} An expression or conversion is _manifestly constant-evaluated_ if it is:
 
 * [#.#]{.pnum} a `$constant-expression$`, or
 * [#.#]{.pnum} the condition of a constexpr if statement ([stmt.if]{.sref}), or
@@ -3653,17 +3658,14 @@ Add new paragraphs defining _evaluation context_, _injected declaration_, and _i
 ::: std
 ::: addu
 
-[22]{.pnum} The evaluation of an expression `$E$` can introduce an _injected declaration_. For each such declaration `$D$`, the _injected point_ is a corresponding program point which follows the last non-injected point in the translation unit containing `$D$`. The evaluation of `$E$` is said to _produce_ the declaration `$D$`.
+[#]{.pnum} The evaluation of an expression `$E$` can introduce an _injected declaration_. For each such declaration `$D$`, the _injected point_ is a corresponding program point which follows the last non-injected point in the translation unit containing `$D$`. The evaluation of `$E$` is said to _produce_ the declaration `$D$`.
 
 [Special rules concerning reachability apply to injected points ([module.reach]).]{.note13}
 
-[23]{.pnum} The program is ill-formed if an injected declaration is produced by the evaluation of an expression `$E$` that is
+[#]{.pnum} The program is ill-formed if an injected declaration is produced by the evaluation of an expression `$E$` that is
 
-* [#.#]{.pnum} a manifestly constant-evaluated expression that is not plainly constant-evaluated,
-* required for the lookup of a name appearing within an unevaluated operand,
-* within the body of an immediate-escalating function `$F$`, unless
-  * [#.#.#]{.pnum} `$E$` is a plainly constant-evaluated expression or a subexpression thereof, or
-  * [#.#.#]{.pnum} `$F$` does not contain an immediate-escalating expression.
+* [#.#]{.pnum} a manifestly constant-evaluated expression that is not plainly constant-evaluated, or
+* within the body of an immediate-escalating function `$F$`, unless `$E$` is a plainly constant-evaluated expression or a subexpression thereof.
 
 [An immediate invocation within an immediate-escalating function is similar to a trial evaluation of a variable initializer: if it fails to be a constant expression, the implementation may be forced to evaluate it again. The above rule is intended to only permit evaluations to produce declarations when such evaluations can be guaranteed to only happen once.]{.note}
 

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3590,23 +3590,22 @@ Add new paragraphs prior to the definition of _manifestly constant evaluated_ ([
 ::: std
 ::: addu
 
-[20]{.pnum} An expression or conversion is _potentially plainly constant-evaluated_ if it is:
+[20]{.pnum} An expression or conversion is _in substitution context_ if it results from the substitution of template parameters
 
-* [#.#]{.pnum} a `$constant-expression$`,
+* [#.#]{.pnum} during template argument deduction ([temp.deduct]{.sref}),
+* [#.#]{.pnum} in a `$concept-id$` ([temp.names]{.sref}), or
+* [#.#]{.pnum} in a `$requires-expression$` ([expr.prim.req]{.sref}).
+
+[#]{.pnum} An expression or conversion is _plainly constant-evaluated_ if it is
+
+* [#.#]{.pnum} a `$constant-expression$` that is not in substitution context,
 * [#.#]{.pnum} the condition of a constexpr if statement ([stmt.if]{.sref}),
 * [#.#]{.pnum} the initializer of a `constexpr` ([dcl.constexpr]{.sref}) or `constinit` ([dcl.constinit]{.sref}) variable, or
-* [#.#]{.pnum} an immediate invocation.
+* [#.#]{.pnum} an immediate invocation, unless it is
+  * [#.#.#]{.pnum} in substitution context, or
+  * [#.#.#]{.pnum} within the body of an immediate-escalating function that contains an immediate-escalating expression.
 
-[#]{.pnum} A potentially plainly constant-evaluated expression or conversion is also _plainly constant-evaluated_ unless it
-
-* [#.#]{.pnum} is a subexpression of an initializer for a variable that is neither `constexpr` nor `constinit`,
-* [#.#]{.pnum} results from the substitution of template parameters
-  * [#.#.#]{.pnum} during template argument deduction ([temp.deduct]{.sref}),
-  * [#.#.#]{.pnum} in a `$concept-id$` ([temp.names]{.sref}), or
-  * [#.#.#]{.pnum} in a `$requires-expression$` ([expr.prim.req]{.sref}), or
-* [#.#]{.pnum} is an immediate invocation appearing within the body of an immediate-escalating function that contains an immediate-escalating expression.
-
-[Plainly constant-evaluated expressions are evaluated exactly once, and that evaluation precedes any subsequent parsing ([lex.phases]{.sref}). As detailed below, evaluations of such expressions are allowed to produce injected declarations.]{.note}
+[A plainly constant-evaluated expression `$E$` is evaluated exactly once, may produce injected declarations (see below), and any such declarations are reachable at a point immediatelly following `$E$`.]{.note}
 
 ::: example
 ```cpp

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3592,20 +3592,24 @@ Add a new paragraph prior to the definition of _manifestly constant evaluated_ (
 
 [20]{.pnum} An expression or conversion is _plainly constant-evaluated_ if it is:
 
-* [#.#]{.pnum} a `$constant-expression$`, or
 * [#.#]{.pnum} the condition of a constexpr if statement ([stmt.if]{.sref}),
-* [#.#]{.pnum} the initializer of a `constexpr` ([dcl.constexpr]{.sref}) or `constinit` ([dcl.constinit]{.sref}) variable, or a subexpression thereof, or
-* [#.#]{.pnum} an immediate invocation, unless it
+* [#.#]{.pnum} the initializer of a `constexpr` ([dcl.constexpr]{.sref}) or `constinit` ([dcl.constinit]{.sref}) variable, or
+* [#.#]{.pnum} a `$constant-expression$` or an immediate invocation, unless it
   * [#.#.#]{.pnum} results from the substitution of template parameters
     * during template argument deduction ([temp.deduct]{.sref}),
     * in a `$concept-id$` ([temp.names]{.sref}), or
     * in a `$requires-expression$` ([expr.prim.req]{.sref}), or
-  * [#.#.#]{.pnum} is an initializer for a variable that is neither  `constexpr` ([dcl.constexpr]{.sref}) nor `constinit` ([dcl.constinit]{.sref}), or a subexpression thereof.
+  * [#.#.#]{.pnum} is an initializer, or a subexpression thereof, for a variable that is neither  `constexpr` ([dcl.constexpr]{.sref}) nor `constinit` ([dcl.constinit]{.sref}).
 
 [Plainly constant-evaluated expressions are evaluated exactly once, and that evaluation precedes any subsequent parsing ([lex.phases]{.sref}). As detailed below, evaluations of such expressions are allowed to produce injected declarations.]{.note}
 
 ::: example
 ```cpp
+template <class> struct RV {};
+
+// instantiations of 'T::f(0)' are not plainly constant-evaluated
+template <class T> RV<T::f(0)> check(int);
+
 consteval bool cfn(int) { return true; }
 
 template <int V> requires (cfn(V))  // cfn(V) is not plainly constant-evaluated
@@ -3626,17 +3630,14 @@ const bool b2 = cfn(2);             // cfn(2) is not plainly constant-evaluated
 :::
 :::
 
-Modify the definition of _manifestly constant-evaluated_ to leverage that of _plainly constant-evaluated_:
+Add a note following the definition of _manifestly constant-evaluated_ to clarify the relationship with _plainly constant-evaluated_ expressions:
 
 ::: std
 
 [21]{.pnum} An expression or conversion is _manifestly constant-evaluated_ if it is:
 
-* [#.#]{.pnum} a [`$constant-expression$`]{.rm} [plainly constant-evaluated expression]{.addu}, or
-
-::: rm
+* [#.#]{.pnum} a `$constant-expression$`, or
 * [#.#]{.pnum} the condition of a constexpr if statement ([stmt.if]{.sref}), or
-:::
 * [#.#]{.pnum} an immediate invocation, or
 * [#.#]{.pnum} the result of substitution into an atomic constraint expression to determine whether it is satisfied ([temp.constr.atomic]{.sref}), or
 * [#.#]{.pnum} the initializer for a variable that is usable in constant expressions or has constant initialization ([basic.start.static]{.sref}).
@@ -3658,7 +3659,8 @@ Add new paragraphs defining _evaluation context_, _injected declaration_, and _i
 
 [23]{.pnum} The program is ill-formed if an injected declaration is produced by the evaluation of an expression `$E$` that is
 
-* [#.#]{.pnum} a manifestly constant-evaluated expression that is not plainly constant-evaluated, or
+* [#.#]{.pnum} a manifestly constant-evaluated expression that is not plainly constant-evaluated,
+* required for the lookup of a name appearing within an unevaluated operand,
 * within the body of an immediate-escalating function `$F$`, unless
   * [#.#.#]{.pnum} `$E$` is a plainly constant-evaluated expression or a subexpression thereof, or
   * [#.#.#]{.pnum} `$F$` does not contain an immediate-escalating expression.


### PR DESCRIPTION
- Remove `define_static_string` and `define_static_array`. Likely to be reintroduced by a follow-up paper.
- Clarify that `source_location_of` gives a source location corresponding to a reachable declaration.
- Clarify the size of a `std::meta::info`.
- Break _plainly constant-evaluated_ in half: _potentially plainly constant-evaluated_ and _plainly constant-evaluated_. The first half stipulates the things that _can_ be plainly constant-evaluated, and the second half filters it down. This structure helps to clarify that a _constant-expression_ resulting from template substitution during argument deduction (or in a requires clause, etc) also fails to be plainly constant-evaluated.
  - Also add a caveat that an immediate invocation appearing within an immediate-escalated function is not plainly constant-evaluated. This also helps the "injected declaration" language to work a bit more cleanly.