### PR TITLE
Rewrite a lot of the core wording

### DIFF
--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-11-12" />
+  <meta name="dcterms.date" content="2024-11-10" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-11-12</td>
+    <td>2024-11-10</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -772,9 +772,9 @@ types<span></span></a></li>
 expressions<span></span></a></li>
 <li><a href="#expr.prim.id.splice-splice-specifiers" id="toc-expr.prim.id.splice-splice-specifiers">7.5.4.0*
 [expr.prim.id.splice] Splice specifiers<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
@@ -795,13 +795,11 @@ The reflection operator<span></span></a></li>
 <li><a href="#expr.const-constant-expressions" id="toc-expr.const-constant-expressions"><span>7.7
 <span>[expr.const]</span></span> Constant
 Expressions<span></span></a></li>
-<li><a href="#dcl.typedef-the-typedef-specifier" id="toc-dcl.typedef-the-typedef-specifier"><span>9.2.4
-<span>[dcl.typedef]</span></span> The
-<code class="sourceCode cpp"><span class="kw">typedef</span></code>
-specifier<span></span></a></li>
 <li><a href="#dcl.type.simple-simple-type-specifiers" id="toc-dcl.type.simple-simple-type-specifiers"><span>9.2.9.3
 <span>[dcl.type.simple]</span></span> Simple type
 specifiers<span></span></a></li>
+<li><a href="#dcl.type.splice-type-splicing" id="toc-dcl.type.splice-type-splicing">9.2.9* [dcl.type.splice] Type
+splicing<span></span></a></li>
 <li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.4.1
 <span>[dcl.init.general]</span></span> Initializers
 (General)<span></span></a></li>
@@ -822,18 +820,10 @@ directive<span></span></a></li>
 <li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1
 <span>[dcl.attr.grammar]</span></span> Attribute syntax and
 semantics<span></span></a></li>
-<li><a href="#module.global.frag-global-module-fragment" id="toc-module.global.frag-global-module-fragment">[module.global.frag]
-Global module fragment<span></span></a></li>
 <li><a href="#module.reach-reachability" id="toc-module.reach-reachability"><span>10.7
 <span>[module.reach]</span></span> Reachability<span></span></a></li>
-<li><a href="#class.pre-preamble" id="toc-class.pre-preamble">[class.pre] Preamble<span></span></a></li>
-<li><a href="#class.name-class-names" id="toc-class.name-class-names">[class.name] Class
-names<span></span></a></li>
 <li><a href="#class.mem.general-general" id="toc-class.mem.general-general"><span>11.4.1
 <span>[class.mem.general]</span></span> General<span></span></a></li>
-<li><a href="#over.match.class.deduct-class-template-argument-deduction" id="toc-over.match.class.deduct-class-template-argument-deduction"><span>12.2.2.9
-<span>[over.match.class.deduct]</span></span> Class template argument
-deduction<span></span></a></li>
 <li><a href="#over.built-built-in-operators" id="toc-over.built-built-in-operators"><span>12.5
 <span>[over.built]</span></span> Built-in
 operators<span></span></a></li>
@@ -848,18 +838,19 @@ specializations<span></span></a></li>
 <li><a href="#temp.arg.type-template-type-arguments" id="toc-temp.arg.type-template-type-arguments"><span>13.4.2
 <span>[temp.arg.type]</span></span> Template type
 arguments<span></span></a></li>
+<li><a href="#temp.arg.nontype-template-non-type-arguments" id="toc-temp.arg.nontype-template-non-type-arguments"><span>13.4.3
+<span>[temp.arg.nontype]</span></span> Template non-type
+arguments<span></span></a></li>
 <li><a href="#temp.arg.template-template-template-arguments" id="toc-temp.arg.template-template-template-arguments"><span>13.4.4
 <span>[temp.arg.template]</span></span> Template template
 arguments<span></span></a></li>
 <li><a href="#temp.type-type-equivalence" id="toc-temp.type-type-equivalence"><span>13.6
 <span>[temp.type]</span></span> Type equivalence<span></span></a></li>
-<li><a href="#temp.deduct.guide-deduction-guides" id="toc-temp.deduct.guide-deduction-guides"><span>13.7.2.3
-<span>[temp.deduct.guide]</span></span> Deduction
-guides<span></span></a></li>
 <li><a href="#temp.alias-alias-templates" id="toc-temp.alias-alias-templates"><span>13.7.8
 <span>[temp.alias]</span></span> Alias templates<span></span></a></li>
-<li><a href="#temp.res.general-general" id="toc-temp.res.general-general"><span>13.8.1
-<span>[temp.res.general]</span></span> General<span></span></a></li>
+<li><a href="#temp.concept-concept-definitions" id="toc-temp.concept-concept-definitions"><span>13.7.9
+<span>[temp.concept]</span></span> Concept
+definitions<span></span></a></li>
 <li><a href="#temp.dep.expr-type-dependent-expressions" id="toc-temp.dep.expr-type-dependent-expressions"><span>13.8.3.3
 <span>[temp.dep.expr]</span></span> Type-dependent
 expressions<span></span></a></li>
@@ -981,9 +972,6 @@ allow for future use with negative offsets</li>
 <li>renamed the type traits from all being named
 <code class="sourceCode cpp">type_meow</code> to a more bespoke naming
 scheme.</li>
-<li>rewrote core wording for
-<code class="sourceCode cpp"><em>consteval-only type</em></code> and for
-all splicers.</li>
 </ul>
 <p>Since <span class="citation" data-cites="P2996R6">[<a href="https://wg21.link/p2996r6" role="doc-biblioref">P2996R6</a>]</span>:</p>
 <ul>
@@ -1025,7 +1013,7 @@ Aliases”</a> section.</li>
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
 <li>removed <code class="sourceCode cpp">subobjects_of</code> and
 <code class="sourceCode cpp">accessible_subobjects_of</code> (will be
-reintroduced by <span class="citation" data-cites="P3293R1">[<a href="#ref-P3293R1" role="doc-biblioref"><strong>P3293R1?</strong></a>]</span>).</li>
+reintroduced by <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>).</li>
 <li>specified constraints for
 <code class="sourceCode cpp">enumerators_of</code> in terms of
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
@@ -1944,7 +1932,7 @@ initialize members of a defined union using a splicer, as in:</p>
 </blockquote>
 </div>
 <p>Arguably, the answer should be yes - this would be consistent with
-how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="#ref-P3293R1" role="doc-biblioref"><strong>P3293R1?</strong></a>]</span>.</p>
+how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>.</p>
 <p>On Compiler Explorer: <a href="https://godbolt.org/z/Efz5vsjaa">EDG</a>, <a href="https://godbolt.org/z/3bvo97fqf">Clang</a>.</p>
 <h2 data-number="3.10" id="struct-to-struct-of-arrays"><span class="header-section-number">3.10</span> Struct to Struct of Arrays<a href="#struct-to-struct-of-arrays" class="self-link"></a></h2>
 <div class="std">
@@ -2467,27 +2455,25 @@ Proposed Features<a href="#proposed-features" class="self-link"></a></h1>
 <p>The reflection operator produces a reflection value from a
 grammatical construct (its operand):</p>
 <blockquote>
-<div class="line-block"><code class="sourceCode cpp"><em>unary-expression</em></code>:<br />
+<div class="line-block"><em>unary-expression</em>:<br />
       …<br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
 <code class="sourceCode cpp"><span class="op">::</span></code><br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
-<code class="sourceCode cpp"><em>namespace-name</em></code><br />
+<em>namespace-name</em><br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
-<code class="sourceCode cpp"><em>type-id</em></code><br />
+<em>type-id</em><br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
-<code class="sourceCode cpp"><em>id-expression</em></code></div>
+<em>id-expression</em></div>
 </blockquote>
 <p>The expression
 <code class="sourceCode cpp"><span class="op">^::</span></code>
 evaluates to a reflection of the global namespace. When the operand is a
-<code class="sourceCode cpp"><em>namespace-name</em></code> or
-<code class="sourceCode cpp"><em>type-id</em></code>, the resulting
-value is a reflection of the designated namespace or type.</p>
-<p>When the operand is an
-<code class="sourceCode cpp"><em>id-expression</em></code>, the
-resulting value is a reflection of the designated entity found by
-lookup. This might be any of:</p>
+<em>namespace-name</em> or <em>type-id</em>, the resulting value is a
+reflection of the designated namespace or type.</p>
+<p>When the operand is an <em>id-expression</em>, the resulting value is
+a reflection of the designated entity found by lookup. This might be any
+of:</p>
 <ul>
 <li>a variable, static data member, or structured binding</li>
 <li>a function or member function</li>
@@ -2499,15 +2485,15 @@ lookup. This might be any of:</p>
 context, a failure to substitute the operand of a reflection operator
 construct causes that construct to not evaluate to constant.</p>
 <p>Earlier revisions of this paper allowed for taking the reflection of
-any <code class="sourceCode cpp"><em>cast-expression</em></code> that
-could be evaluated as a constant expression, as we believed that a
-constant expression could be internally “represented” by just capturing
-the value to which it evaluated. However, the possibility of side
-effects from constant evaluation (introduced by this very paper) renders
-this approach infeasible: even a constant expression would have to be
-evaluated every time it’s spliced. It was ultimately decided to defer
-all support for expression reflection, but we intend to introduce it
-through a future paper using the syntax <code class="sourceCode cpp"><span class="op">^(</span>expr<span class="op">)</span></code>.</p>
+any <em>cast-expression</em> that could be evaluated as a constant
+expression, as we believed that a constant expression could be
+internally “represented” by just capturing the value to which it
+evaluated. However, the possibility of side effects from constant
+evaluation (introduced by this very paper) renders this approach
+infeasible: even a constant expression would have to be evaluated every
+time it’s spliced. It was ultimately decided to defer all support for
+expression reflection, but we intend to introduce it through a future
+paper using the syntax <code class="sourceCode cpp"><span class="op">^(</span>expr<span class="op">)</span></code>.</p>
 <p>This paper does, however, support reflections of <em>values</em> and
 of <em>objects</em> (including subobjects). Such reflections arise
 naturally when iterating over template arguments.</p>
@@ -4959,12 +4945,10 @@ A function is named by an expression or conversion if it is the selected
 member of an overload set ([basic.lookup], [over.match], [over.over]) in
 an overload resolution performed as part of forming that expression or
 conversion, <span class="addu">or if it is designated by a
-<code class="sourceCode cpp"><em>splice-expression</em></code>
-([expr.prim.splice]),</span> unless it is a pure virtual function and
-either the expression is not an
-<code class="sourceCode cpp"><em>id-expression</em></code> naming the
-function with an explicitly qualified name or the expression forms a
-pointer to member ([expr.unary.op]).</li>
+<em>splice-expression</em> ([expr.prim.splice]),</span> unless it is a
+pure virtual function and either the expression is not an
+<em>id-expression</em> naming the function with an explicitly qualified
+name or the expression forms a pointer to member ([expr.unary.op]).</li>
 </ul>
 </blockquote>
 </div>
@@ -4975,8 +4959,7 @@ variables:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_8" id="pnum_8">5</a></span>
 A variable is named by an expression if the expression is an
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-expression</em></code>
+<em>id-expression</em> <span class="addu">or <em>splice-expression</em>
 ([expr.prim.splice])</span> that designates it.</li>
 </ul>
 </blockquote>
@@ -4988,9 +4971,8 @@ A variable is named by an expression if the expression is an
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_9" id="pnum_9">6</a></span>
 A structured binding is odr-used if it appears as a
 potentially-evaluated expression<span class="addu">, or if a reflection
-representing it is the operand of a potentially-evaluated
-<code class="sourceCode cpp"><em>splice-expression</em></code>
-([expr.prim.splice])</span>.</li>
+of it is the operand of a potentially-evaluated
+<em>splice-expression</em> ([expr.prim.splice])</span>.</li>
 </ul>
 </blockquote>
 </div>
@@ -5038,24 +5020,40 @@ If <code class="sourceCode cpp">T</code> is a class type …</li>
 </div>
 <h3 class="unnumbered" id="basic.lookup.qual.general-general"><span>6.5.5.1 <a href="https://wg21.link/basic.lookup.qual.general">[basic.lookup.qual.general]</a></span>
 General<a href="#basic.lookup.qual.general-general" class="self-link"></a></h3>
-<p>Extend paragraph 1 to cover
-<code class="sourceCode cpp"><em>splice-specifier</em></code>s:</p>
+<p>FIXME. Have to handle splices in here, because they’re not actually
+“component names”. Now
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
+is only a namespace too.</p>
+<p>Extend <span>6.5.5.1 <a href="https://wg21.link/basic.lookup.qual.general">[basic.lookup.qual.general]</a></span>/1-2
+to cover
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">1</a></span>
 Lookup of an <em>identifier</em> followed by a
-<code class="sourceCode cpp"><span class="op">::</span></code> scope
+​<code class="sourceCode cpp"><span class="op">::</span></code>​ scope
 resolution operator considers only namespaces, types, and templates
 whose specializations are types. If a name,
-<code class="sourceCode cpp"><em>template-id</em></code>, <span class="addu"><code class="sourceCode cpp"><em>splice-specifier</em></code>,</span>
-or <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
+<code class="sourceCode cpp"><em>template-id</em></code>, <span class="rm" style="color: #bf0303"><del>or</del></span>
+<code class="sourceCode cpp"><em>computed-type-specifier</em></code><span class="addu">, or
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code></span>
 is followed by a
-<code class="sourceCode cpp"><span class="op">::</span></code>, it shall
-designate a namespace, class, enumeration, <span class="addu">dependent
-<code class="sourceCode cpp"><em>splice-specifier</em></code>,</span> or
-dependent type, and the
-<code class="sourceCode cpp"><span class="op">::</span></code> is never
-interpreted as a complete nested-name-specifier.</p>
+​<code class="sourceCode cpp"><span class="op">::</span></code>​, it shall
+designate a namespace, class, enumeration, or dependent type, and the ​::​
+is never interpreted as a complete nested-name-specifier.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">2</a></span>
+A member-qualified name is the (unique) component name
+([expr.prim.id.unqual]), if any, of</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(2.1)</a></span>
+an <em>unqualified-id</em> or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(2.2)</a></span>
+a <code class="sourceCode cpp"><em>nested-name-specifier</em></code> of
+the form <code class="sourceCode cpp"><em>type-name</em> <span class="op">::</span></code>
+<span class="rm" style="color: #bf0303"><del>or</del></span><span class="addu">,</span> <code class="sourceCode cpp"><em>namespace-name</em> <span class="op">::</span></code><span class="addu">, or <code class="sourceCode cpp"><em>splice-namespace-qualifier</em> <span class="op">::</span></code></span></li>
+</ul>
+<p>in the <em>id-expression</em> of a class member access expression
+([expr.ref]). […]</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="basic.link-program-and-linkage"><span>6.6 <a href="https://wg21.link/basic.link">[basic.link]</a></span> Program and
@@ -5063,30 +5061,30 @@ Linkage<a href="#basic.link-program-and-linkage" class="self-link"></a></h3>
 <p>Add a bullet to paragraph 13:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">13</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>names</em> an entity <code class="sourceCode cpp"><em>E</em></code>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a
-<code class="sourceCode cpp"><em>lambda-expression</em></code> whose
-closure type is <code class="sourceCode cpp"><em>E</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(13.1+)</a></span>
+<em>lambda-expression</em> whose closure type is
+<code class="sourceCode cpp"><em>E</em></code>,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">(13.1+)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code>
-contains a reflection that represents either
+contains an expression that represents either
 <code class="sourceCode cpp"><em>E</em></code> or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> that
 denotes <code class="sourceCode cpp"><em>E</em></code>,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(13.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not a function or
 function template and <code class="sourceCode cpp"><em>D</em></code>
 contains an <em>id-expression</em>, <em>type-specifier</em>,
 <em>nested-name-specifier</em>, <em>template-name</em>, or
 <em>concept-name denoting</em>
 <code class="sourceCode cpp"><em>E</em></code>, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(13.3)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a function or function
 template and <code class="sourceCode cpp"><em>D</em></code> contains an
 expression that names <code class="sourceCode cpp"><em>E</em></code>
@@ -5104,32 +5102,30 @@ also TU-local ]</span></p>
 include reflections:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">16</a></span>
 A value or object is <em>TU-local</em> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(16.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1)</a></span>
 it is, or is a pointer to, a TU-local function or the object associated
 with a TU-local variable, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(16.1a)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1a)</a></span>
 it is a value or object of a TU-local type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(16.1b)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.1b)</a></span>
 it is a reflection representing
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1b.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">(16.1b.1)</a></span>
 a TU-local value or object, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1b.2)</a></span>
-a <code class="sourceCode cpp"><em>typedef-name</em></code>,
-<code class="sourceCode cpp"><em>namespace-alias</em></code>, or
-<code class="sourceCode cpp"><em>base-specifier</em></code> introduced
-by an exposure, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">(16.1b.2)</a></span>
+a <code class="sourceCode cpp"><em>typedef-name</em></code>, namespace
+alias, or base specifier introduced by an exposure, or</li>
 </ul></li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(16.2)</a></span>
 it is an object of class or array type and any of its subobjects or any
 of the objects or functions to which its non-static data members of
 reference type refer is TU-local and is usable in constant
@@ -5143,7 +5139,7 @@ General<a href="#basic.types.general-general" class="self-link"></a></h3>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">9</a></span>
 Arithmetic types (6.8.2), enumeration types, pointer types,
 pointer-to-member types (6.8.4), <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -5156,42 +5152,29 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">*</a></span>
 A <em>consteval-only type</em> is one of the following:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(12.1)</a></span>
-<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
+<li><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(12.2)</a></span>
-a pointer or reference to a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(12.3)</a></span>
-a (possibly multi-dimensional) array of a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.4)</a></span>
-a class type with a base class or non-static data member of
-consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.5)</a></span>
-a function type with a return type or parameter type of consteval-only
-type, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.6)</a></span>
-a pointer-to-member type to a class
+<li>a pointer or reference to a consteval-only type, or</li>
+<li>an (possibly multi-dimensional) array of a consteval-only type,
+or</li>
+<li>a class type with a base class or non-static data member of
+consteval-only type, or</li>
+<li>a function type with a return type or parameter type of
+consteval-only type, or</li>
+<li>a pointer-to-member type to a class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">M</code> where either
 <code class="sourceCode cpp">C</code> or
 <code class="sourceCode cpp">M</code> is a consteval-only type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">13</a></span>
-Every object of consteval-only type shall be</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(13.1)</a></span>
-the object associated with a constexpr variable or a subobject
-thereof,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(13.2)</a></span>
-a template parameter object (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>) or a
-subobject thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(13.3)</a></span>
-an object whose lifetime begins and ends during the evaluation of a
-manifestly constant-evaluated expression.</li>
-</ul>
+<p>An object of consteval-only type shall either end its lifetime during
+the evaluation of a manifestly constant-evaluated expression or
+conversion (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>), or be a
+constexpr variable for which every expression that names the variable is
+within an immediate function context.</p>
 </div>
 </blockquote>
 </div>
@@ -5202,7 +5185,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">17 - 1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">17 - 1</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
@@ -5213,20 +5196,20 @@ reflection</em>; every other reflection is a representation of</p>
 <li>a structured binding,</li>
 <li>a function,</li>
 <li>an enumerator,</li>
-<li>a type or
-<code class="sourceCode cpp"><em>typedef-name</em></code>,</li>
+<li>a type,</li>
+<li>a <code class="sourceCode cpp"><em>typedef-name</em></code>,</li>
 <li>a class member,</li>
 <li>a bit-field,</li>
 <li>a primary class template, function template, primary variable
 template, alias template, or concept,</li>
-<li>a namespace or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>,</li>
-<li>a <code class="sourceCode cpp"><em>base-specifier</em></code>,
-or</li>
+<li>a namespace or namespace alias,</li>
+<li>a base class specifier, or</li>
 <li>a description of a declaration of a non-static data member.</li>
 </ul>
 <p>An expression convertible to a reflection is said to
-<em>represent</em> the corresponding construct. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
+<em>represent</em> the corresponding entity, alias, object, value, base
+class specifier, or description of a declaration of a non-static data
+member. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
 shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span><span class="dt">void</span><span class="op">*)</span></code>.</p>
 </div>
 </blockquote>
@@ -5254,118 +5237,63 @@ as follows:</p>
 </div>
 <h3 class="unnumbered" id="expr.prim.id.splice-splice-specifiers">7.5.4.0*
 [expr.prim.id.splice] Splice specifiers<a href="#expr.prim.id.splice-splice-specifiers" class="self-link"></a></h3>
-<p>Add a new vocabulary of nonterminals for various forms of
-splicers:</p>
+<p>FIXME: The wording here, and usage throughout.</p>
+<p>Add a new grammar term for convenience:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb105"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a><em>splice-specifier</em>:</span>
-<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span>
-<span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a><em>splice-expr-template-specifier</em>:</span>
-<span id="cb105-5"><a href="#cb105-5" aria-hidden="true" tabindex="-1"></a>    template <em>splice-specifier</em></span>
-<span id="cb105-6"><a href="#cb105-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb105-7"><a href="#cb105-7" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
-<span id="cb105-8"><a href="#cb105-8" aria-hidden="true" tabindex="-1"></a>    typename<sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>splice-specifier</em></span></code></pre></div>
-<p>The term <em>splicer</em> generically refers to a
-<code class="sourceCode cpp"><em>splice-specifier</em></code>, a
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>,
-or a
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">1</a></span>
+<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">1</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> shall be
 a converted constant expression ([expr.const]) contextually convertible
-to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.
-A <code class="sourceCode cpp"><em>splice-specifier</em></code>
-designates the construct represented by the converted
-<code class="sourceCode cpp"><em>constant-expression</em></code>, and is
+to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">2</a></span>
+Let <code class="sourceCode cpp">E</code> be the value of the converted
+<code class="sourceCode cpp"><em>constant-expression</em></code>. The
+<code class="sourceCode cpp"><em>splice-specifier</em></code> designates
+what <code class="sourceCode cpp">E</code> represents.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">3</a></span>
+A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if the converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
 value-dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">2</a></span>
-A
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
-or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
-designates the construct designated by the
-<code class="sourceCode cpp"><em>splice-specifier</em></code>. A
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
-designates either a function template a primary variable template, or a
-concept. A
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
-designates either a type,
-<code class="sourceCode cpp"><em>typedef-name</em></code>, primary class
-template, alias template, or concept.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">3</a></span>
-The form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em></code>
-is interpreted as a
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
-when</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">(3.1)</a></span>
-it is preceded by
-<code class="sourceCode cpp"><span class="kw">typename</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">(3.2)</a></span>
-it is within a type-only context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">(3.3)</a></span>
-it is followed by
-<code class="sourceCode cpp"><span class="kw">auto</span></code> or
-<code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span></code>,
-or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">(3.4)</a></span>
-the <code class="sourceCode cpp"><em>splice-specifier</em></code> is not
-dependent and designates a primary class template or alias
-template.</li>
-</ul>
-<p>In all other cases, it is interpreted as a
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">4</a></span>
-The <code class="sourceCode cpp"><span class="kw">typename</span></code>
-in a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
-may only be omitted in a type-only context, or when the
-<code class="sourceCode cpp"><em>splice-specifier</em></code> is
-preceded by
-<code class="sourceCode cpp"><span class="kw">template</span></code>.</p>
-<div class="example">
-<span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb106"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>FIXME</span></code></pre></div>
-<span> — <em>end example</em> ]</span>
-</div>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
-<p>Add a carve-out for reflection in <span>7.5.4.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
+<p>Add a carve-out for reflection in <span>7.5.5.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">4</a></span>
 An <code class="sourceCode cpp"><em>id-expression</em></code> that
 denotes a non-static data member or implicit object member function of a
 class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(4.1)</a></span>
 as part of a class member access (after any implicit transformation (see
 above)) in which the object expression refers to the member’s class or a
 class derived from that class, or</li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(4.2)</a></span>
 as an operand to the reflection operator ([expr.reflect]), or</li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(4.3)</a></span>
 to form a pointer to member ([expr.unary.op]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">(4.4)</a></span>
 if that id-expression denotes a non-static data member and it appears in
 an unevaluated operand.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Add a production to the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -5373,31 +5301,32 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb107"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a>  <em>nested-name-specifier</em>:</span>
-<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
-<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
-<span id="cb107-4"><a href="#cb107-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
-<span id="cb107-5"><a href="#cb107-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em> ::</span></span>
-<span id="cb107-6"><a href="#cb107-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
-<span id="cb107-7"><a href="#cb107-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
-<span id="cb107-8"><a href="#cb107-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span></code></pre></div>
+<div class="sourceCode" id="cb106"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>  <em>nested-name-specifier</em>:</span>
+<span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
+<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
+<span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
+<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-qualifier</em> ::</span></span>
+<span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
+<span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
+<span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span>
+<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-qualifier</em>:</span></span>
+<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
 <p>Add a new paragraph restricting
-<code class="sourceCode cpp"><em>splice-specifier</em></code>, and
-renumber accordingly:</p>
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>,
+and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">0</a></span>
-A <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code>
-either is dependent or designates a type,
-<code class="sourceCode cpp"><em>typedef-name</em></code>, namespace, or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">0</a></span>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
+shall designate a namespace or namespace alias.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">1</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-id</em></code> are […]</p>
 </blockquote>
@@ -5406,7 +5335,7 @@ The component names of a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -5421,8 +5350,7 @@ the <code class="sourceCode cpp"><em>id-expression</em></code> of a
 <p>A declarative
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> shall
 not have a
-<code class="sourceCode cpp"><em>computed-type-specifier</em></code>
-<span class="addu">or a
+<code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>. A
 declaration that uses a declarative
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> shall
@@ -5434,9 +5362,9 @@ being redeclared or specialized.</p>
 “designate” over “nominate”:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">4</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
-<code class="sourceCode cpp"><span class="op">::</span></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
+<code class="sourceCode cpp">​<span class="op">::</span></code>​ <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
 a <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
 <span class="rm" style="color: #bf0303"><del>nominates</del></span>
@@ -5444,13 +5372,13 @@ a <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>,
 which shall be a class or enumeration type. <span class="addu">A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
-a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
-designates an entity itself designates the same entity. A
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
-a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
-designates a name itself designates the entity nominated by that
-name.</span> If a
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code>
+a
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
+<span class="rm" style="color: #bf0303"><del>nominates</del></span>
+<span class="addu">designates</span> the same namespace or namespace
+alias as the
+<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>.</span>
+If a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <em>N</em> is declarative and has a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> with a
 template argument list <em>A</em> that involves a template parameter,
@@ -5462,39 +5390,27 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
 <p><strong>Expression Splicing [expr.prim.splice]</strong></p>
-<div class="sourceCode" id="cb108"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
-<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">1</a></span>
-The <code class="sourceCode cpp"><em>splice-specifier</em></code>
-designates either</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(1.1)</a></span>
-a value or object,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(1.2)</a></span>
-a variable,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(1.3)</a></span>
-a structured binding,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(1.4)</a></span>
-a function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(1.5)</a></span>
-an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(1.6)</a></span>
-a non-static data member.</li>
-</ul>
-<p>The <code class="sourceCode cpp"><em>splice-specifier</em></code>
-shall not designate an unnamed bit-field, a constructor, or a
-destructor.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">2</a></span>
-Let <code class="sourceCode cpp"><em>E</em></code> be the construct
-designated by
+<p>FIXME: text for the template version.</p>
+<div class="sourceCode" id="cb107"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
+<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
+<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">1</a></span>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+not designate an unnamed bit-field, a constructor or destructor, or a
+constructor template or destructor template.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">2</a></span>
+For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
+the form <code class="sourceCode cpp"><em>splice-specifier</em></code>,
+let <code class="sourceCode cpp"><em>E</em></code> be the object, value,
+or entity designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(2.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">(2.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an object, a
 function, or a non-static data member, the expression is an lvalue
 designating <code class="sourceCode cpp"><em>E</em></code>. The
@@ -5502,15 +5418,15 @@ expression has the same type as
 <code class="sourceCode cpp"><em>E</em></code>, and is a bit-field if
 and only if <code class="sourceCode cpp"><em>E</em></code> is a
 bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(2.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">(2.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>E</em></code> is a
 variable or a structured binding, the expression is an lvalue
-designating the object associated with
+designating the same object as
 <code class="sourceCode cpp"><em>E</em></code>. The expression has the
 same type as <code class="sourceCode cpp"><em>E</em></code>, and is a
 bit-field if and only if <code class="sourceCode cpp"><em>E</em></code>
 is a bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(2.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>E</em></code> shall be a
 value or an enumerator. The expression is a prvalue whose evaluation
 computes <code class="sourceCode cpp"><em>E</em></code> and whose type
@@ -5530,15 +5446,13 @@ splices in member access expressions:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb109"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a>[1]{.pnum} Postfix expressions group left-to-right.</span>
-<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>  <em>postfix-expression</em>:</span>
-<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a>    ...</span>
-<span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
-<span id="cb109-5"><a href="#cb109-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>splice-expression</em></span></span>
-<span id="cb109-6"><a href="#cb109-6" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>splice-expr-template-specifier</em></span></span>
-<span id="cb109-7"><a href="#cb109-7" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
-<span id="cb109-8"><a href="#cb109-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>splice-expression</em></span></span>
-<span id="cb109-9"><a href="#cb109-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>splice-expr-template-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb108"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a>[1]{.pnum} Postfix expressions group left-to-right.</span>
+<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>  <em>postfix-expression</em>:</span>
+<span id="cb108-3"><a href="#cb108-3" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb108-4"><a href="#cb108-4" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
+<span id="cb108-5"><a href="#cb108-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span>
+<span id="cb108-6"><a href="#cb108-6" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
+<span id="cb108-7"><a href="#cb108-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5546,19 +5460,16 @@ splices in member access expressions:</p>
 <a href="https://wg21.link/expr.ref">[expr.ref]</a></span> Class member
 access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 <p>Modify paragraph 1 to account for splices in member access
-expressions. Prefer the word “possibly” to “optionally” since
-<code class="sourceCode cpp"><span class="kw">template</span></code>
-cannot precede a <code class="sourceCode cpp">splice<span class="op">-</span>expression</code>:</p>
+expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
-<span class="rm" style="color: #bf0303"><del>optionally</del></span>
-<span class="addu">possibly</span> followed by the keyword template, and
-then followed by an
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or a splicer designating a class member</span>, is a
+optionally followed by the keyword template, and then followed by an
+<em>id-expression</em><span class="addu">, or a
+<em>splice-expression</em> designating a class member</span>, is a
 postfix expression. <span class="note"><span>[ <em>Note 1:</em>
 </span>If the keyword
 <code class="sourceCode cpp"><span class="kw">template</span></code> is
@@ -5566,67 +5477,72 @@ used, the following unqualified name is considered to refer to a
 template ([temp.names]). If a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> results
 and is followed by a
-<code class="sourceCode cpp"><span class="op">::</span></code>, the
-<code class="sourceCode cpp"><em>id-expression</em></code> is a
-<code class="sourceCode cpp"><em>qualified-id</em></code>.<span>
-— <em>end note</em> ]</span></span></p>
+<code class="sourceCode cpp">​<span class="op">::</span></code>​, the
+<em>id-expression</em> <span class="addu">or
+<em>splice-expression</em></span> is a qualified-id.<span> — <em>end
+note</em> ]</span></span></p>
 </blockquote>
 </div>
 <p>Modify paragraph 2 to account for splices in member access
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">2</a></span>
-<span class="rm" style="color: #bf0303"><del>For the first
-option,</del></span> <span class="rm" style="color: #bf0303"><del>if</del></span><span class="addu">If</span>
-the <span class="addu">dot is followed by an</span>
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or splicer designating</span> a static member or an
-enumerator, the first expression is a discarded-value expression
-([expr.context]); if the
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or splicer designates</span> <span class="rm" style="color: #bf0303"><del>names</del></span> a non-static data member,
-the first expression shall be a glvalue. <span class="rm" style="color: #bf0303"><del>For the second option (arrow), the first
-expression</del></span> <span class="addu">A postfix expression followed
-by an arrow</span> shall be a prvalue having pointer type. The
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">2</a></span>
+For the first option, if the <span class="addu">dot is followed by
+an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
+<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+designating</span> a static member or an enumerator, the first
+expression is a discarded-value expression ([expr.context]); if the
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+designates</span> <span class="rm" style="color: #bf0303"><del>names</del></span> a non-static data member,
+the first expression shall be a glvalue. For the second option (arrow),
+the first expression shall be a prvalue having pointer type. The
 expression
 <code class="sourceCode cpp">E1<span class="op">-&gt;</span>E2</code> is
 converted to the equivalent form <code class="sourceCode cpp"><span class="op">(*(</span>E1<span class="op">)).</span>E2</code>;
-the remainder of [expr.ref] will address only <span class="rm" style="color: #bf0303"><del>the first option (dot)</del></span> <span class="addu">expressions containing a dot</span>.</p>
+the remainder of [expr.ref] will address only the first option
+(dot).</p>
 </blockquote>
 </div>
 <p>Modify paragraph 3 to account for splices in member access
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">3</a></span>
 The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or splicer</span>, determines the result of the entire
-postfix expression.</p>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>,
+determines the result of the entire postfix expression.</p>
 </blockquote>
 </div>
 <p>Modify paragraph 4 to account for splices in member access
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">4</a></span>
 Abbreviating <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>postfix-expression</em></code></span>.<span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span>EXPR</code>,
 where <code class="sourceCode cpp">EXPR</code> is the
-<code class="sourceCode cpp"><em>id-expression</em></code> or splicer
-following the dot,</span> as
+<code class="sourceCode cpp"><em>id-expression</em></code> or
+<code class="sourceCode cpp"><em>splice-expression</em></code> following
+the dot,</span> as
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code>,
 <code class="sourceCode cpp">E1</code> is called the
 <code class="sourceCode cpp"><em>object expression</em></code>. […]</p>
 </blockquote>
 </div>
-<p>Adjust the language in paragraphs 6-9 to account for splicers.</p>
+<p>Adjust the language in paragraphs 6-9 to account for
+splice-specifiers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">7</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is declared to have type
 “reference to <code class="sourceCode cpp">T</code>”, then
@@ -5641,13 +5557,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">(7.2)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
 <code class="sourceCode cpp">X</code>”, and the type of
@@ -5668,11 +5584,11 @@ member, then the type of
 </ul>
 <p>[…]</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(7.4)</a></span>
 If <code class="sourceCode cpp">E</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(7.5)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, the expression
@@ -5680,14 +5596,14 @@ If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">8</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static member <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>, the
 program is ill-formed if the class of which <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>
 is directly a member is an ambiguous base ([class.member.lookup]) of the
 naming class ([class.access.base]) of <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -5701,13 +5617,13 @@ General<a href="#expr.unary.general-general" class="self-link"></a></h3>
 paragraph 1 to add productions for the new operator:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
-<div class="sourceCode" id="cb110"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
-<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>     ...</span>
-<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>     <em>delete-expression</em></span>
-<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb109"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
+<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>     ...</span>
+<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a>     <em>delete-expression</em></span>
+<span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5718,13 +5634,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -5734,7 +5650,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -5745,7 +5661,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -5762,108 +5678,116 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <blockquote>
 <div class="addu">
 <p><strong>The Reflection Operator [expr.reflect]</strong></p>
-<div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><em>reflect-expression</em>:</span>
-<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>   ^ ::</span>
-<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>   ^ <em>unqualified-id</em></span>
-<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a>   ^ <em>qualified-id</em></span>
-<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
-<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>pack-index-expression</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">1</a></span>
+<p>FIXME: <code class="sourceCode cpp"><em>template-name</em></code> and
+<code class="sourceCode cpp"><em>id-expression</em></code> can both
+refer to template names, have to handle this better. See wording in the
+template argument parsing section.</p>
+<div class="sourceCode" id="cb110"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><em>reflect-expression</em>:</span>
+<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>   ^ ::</span>
+<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></span>
+<span id="cb110-5"><a href="#cb110-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
+<span id="cb110-6"><a href="#cb110-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
+<span id="cb110-7"><a href="#cb110-7" aria-hidden="true" tabindex="-1"></a>   ^ <em>id-expression</em></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">2</a></span>
-A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
-parsed as the longest possible sequence of tokens that could
-syntactically form a
-<code class="sourceCode cpp"><em>reflect-expression</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">2</a></span>
+A <em>reflect-expression</em> is parsed as the longest possible sequence
+of tokens that could syntactically form a
+<em>reflect-expression</em>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb112"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
-<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a>template&lt;bool&gt; struct X {};</span>
-<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a>bool operator&lt;(std::meta::info, X&lt;false&gt;);</span>
-<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a>consteval void g(std::meta::info r, X&lt;false&gt; xv) {</span>
-<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp; true;    // error: ^ applies to the type-id &quot;int&amp;&amp;&quot;</span>
-<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp; true;     // error: ^ applies to the type-id &quot;int&amp;&quot;</span>
-<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a>  r == (^int) &amp;&amp; true;  // OK</span>
-<span id="cb112-9"><a href="#cb112-9" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp;&amp;&amp; true;  // OK</span>
-<span id="cb112-10"><a href="#cb112-10" aria-hidden="true" tabindex="-1"></a>  ^X &lt; xv;              // error: &lt; starts template argument list</span>
-<span id="cb112-11"><a href="#cb112-11" aria-hidden="true" tabindex="-1"></a>  (^X) &lt; xv;            // OK</span>
-<span id="cb112-12"><a href="#cb112-12" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb112-13"><a href="#cb112-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
+<div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
+<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>template&lt;bool&gt; struct X {};</span>
+<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a>bool operator&lt;(std::meta::info, X&lt;false&gt;);</span>
+<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a>consteval void g(std::meta::info r, X&lt;false&gt; xv) {</span>
+<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp; true;    // error: ^ applies to the type-id &quot;int&amp;&amp;&quot;</span>
+<span id="cb111-7"><a href="#cb111-7" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp; true;     // error: ^ applies to the type-id &quot;int&amp;&quot;</span>
+<span id="cb111-8"><a href="#cb111-8" aria-hidden="true" tabindex="-1"></a>  r == (^int) &amp;&amp; true;  // OK</span>
+<span id="cb111-9"><a href="#cb111-9" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp;&amp;&amp; true;  // OK</span>
+<span id="cb111-10"><a href="#cb111-10" aria-hidden="true" tabindex="-1"></a>  ^X &lt; xv;              // error: &lt; starts template argument list</span>
+<span id="cb111-11"><a href="#cb111-11" aria-hidden="true" tabindex="-1"></a>  (^X) &lt; xv;            // OK</span>
+<span id="cb111-12"><a href="#cb111-12" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb111-13"><a href="#cb111-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">4</a></span>
-A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
-the form <code class="sourceCode cpp"><span class="op">^</span> <span class="op">::</span></code>
-produces a reflection of the global namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">5</a></span>
-A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
-the form <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>
-or <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>
-performs name lookup for the operand following
-<code class="sourceCode cpp"><span class="op">^</span></code> and
-produces a result as follows:</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">4</a></span>
+When applied to
+<code class="sourceCode cpp"><span class="op">::</span></code>, the
+reflection operator produces a reflection for the global namespace. When
+applied to a
+<code class="sourceCode cpp"><em>namespace-name</em></code>, the
+reflection operator produces a reflection for the indicated namespace or
+namespace alias.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">5</a></span>
+When applied to a
+<code class="sourceCode cpp"><em>template-name</em></code>, the
+reflection operator produces a reflection for the indicated
+template.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">6</a></span>
+When applied to a
+<code class="sourceCode cpp"><em>concept-name</em></code>, the
+reflection operator produces a reflection for the indicated concept.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">7</a></span>
+When applied to a
+<code class="sourceCode cpp"><em>typedef-name</em></code>, the
+reflection operator produces a reflection of the indicated
+<code class="sourceCode cpp"><em>typedef-name</em></code>. When applied
+to any other <code class="sourceCode cpp"><em>type-id</em></code>, the
+reflection operator produces a reflection of the indicated type.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">8</a></span>
+When applied to an
+<code class="sourceCode cpp"><em>id-expression</em></code>, the
+reflection operator produces a reflection as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(5.1)</a></span>
-If lookup finds an overload set
-<code class="sourceCode cpp"><em>S</em></code> such that the assignment
-of <code class="sourceCode cpp"><em>S</em></code> to an invented
-variable of type <code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(8.1)</a></span>
+When applied to an enumerator, the reflection operator produces a
+reflection of the enumerator designated by the operand.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(8.2)</a></span>
+Otherwise, when applied to an overload set
+<code class="sourceCode cpp">S</code>, if the assignment of
+<code class="sourceCode cpp">S</code> to an invented variable of type
+<code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
 (<span>9.2.9.7.2 <a href="https://wg21.link/dcl.type.auto.deduct">[dcl.type.auto.deduct]</a></span>)
 would select a unique candidate function
-<code class="sourceCode cpp"><em>F</em></code> from
-<code class="sourceCode cpp"><em>S</em></code>, then the result is a
-reflection of <code class="sourceCode cpp"><em>F</em></code>. If lookup
-finds any other overload set, the program is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(5.2)</a></span>
-Otherwise, if lookup finds a
-<code class="sourceCode cpp"><em>typedef-name</em></code> or a
-<code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
-result is a reflection of the indicated name.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(5.3)</a></span>
-Otherwise, if lookup finds a non-type template parameter, the result is
-a reflection of the result computed by an
-<code class="sourceCode cpp"><em>id-expression</em></code> naming the
-parameter.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(5.4)</a></span>
-Otherwise, if lookup finds a variable, structured binding, function,
-enumerator, type, non-static member, template, or namespace, the result
-is a reflection of the denoted entity.</p></li>
+<code class="sourceCode cpp">F</code> from
+<code class="sourceCode cpp">S</code>, the result is a reflection of
+<code class="sourceCode cpp">F</code>. Otherwise, the expression
+<code class="sourceCode cpp"><span class="op">^</span>S</code> is
+ill-formed.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(8.3)</a></span>
+Otherwise, when applied to one of</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(8.3.1)</a></span>
+a non-type template parameter of non-class and non-reference type
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">(8.3.2)</a></span>
+a <code class="sourceCode cpp"><em>pack-index-expression</em></code> of
+non-class and non-reference type</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">6</a></span>
-A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
-form
-<code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
-produces a reflection of the denoted type. A
-<code class="sourceCode cpp"><em>reflect-expression</em></code> that
-could be validly interpreted as either <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>
-or
-<code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
-is interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>,
-and a <code class="sourceCode cpp"><em>reflect-expression</em></code>
-that could be validly interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>
-or
-<code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
-is interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">7</a></span>
-A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
-the form <code class="sourceCode cpp"><span class="op">^</span> <em>pack-index-expression</em></code>
-produces a reflection of the result computed by the
-<code class="sourceCode cpp"><em>pack-index-expression</em></code>.</p>
+<p>the reflection operator produces a reflection of the value computed
+by the operand.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">(8.4)</a></span>
+Otherwise, the reflection operator produces a reflection of the
+variable, function, or non-static member designated by the operand. The
+<code class="sourceCode cpp"><em>id-expression</em></code> is not
+evaluated.</p></li>
+</ul>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb113"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">!=</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">==</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span><span class="dt">int</span><span class="op">))</span>;</span>
-<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> R <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
-<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> S <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: cannot reflect an overload set</span></span>
-<span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb113-8"><a href="#cb113-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span></code></pre></div>
+<div class="sourceCode" id="cb112"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">!=</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">==</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span><span class="dt">int</span><span class="op">))</span>;</span>
+<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> R <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
+<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> S <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: cannot reflect an overload set</span></span>
+<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -5875,10 +5799,11 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
-pointer-to-member type, <span class="addu">type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
-or type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>.
+pointer-to-member type, or <span class="rm" style="color: #bf0303"><del>type</del></span> <span class="addu">one of
+the types <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
+or</span> <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>.
 The operators
 <code class="sourceCode cpp"><span class="op">==</span></code> and
 <code class="sourceCode cpp"><span class="op">!=</span></code> both
@@ -5893,49 +5818,47 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between <span>7.6.10 <a href="https://wg21.link/expr.eq">[expr.eq]</a></span>/5 and /6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">5</a></span>
-Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
-one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">5</a></span>
+Two operands of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> or
+one operand of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">*</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(*.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">(*.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(*.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">(*.2)</a></span>
 Otherwise, if one operand represents a
 <code class="sourceCode cpp"><em>template-id</em></code> referring to a
 specialization of an alias template, then they compare equal if and only
 if the other operand represents the same
 <code class="sourceCode cpp"><em>template-id</em></code>
 ([temp.type]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(*.3)</a></span>
-Otherwise, if one operand represents a
-<code class="sourceCode cpp"><em>namespace-alias</em></code> or a
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(*.3)</a></span>
+Otherwise, if one operand represents a namespace alias or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then they
-compare equal if and only if the construct represented by the other
-operand represents the same kind of construct, shares the same name, is
-declared within the same enclosing scope, and aliases the same
-underlying entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(*.4)</a></span>
+compare equal if and only if the other operand represents a namespace
+alias or <code class="sourceCode cpp"><em>typedef-name</em></code>
+sharing the same name, declared within the same enclosing scope, and
+aliasing the same underlying entity.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(*.4)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a template-argument-equivalent
 value (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(*.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(*.5)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(*.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">(*.6)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(*.7)</a></span>
-Otherwise, if one operand represents a
-<code class="sourceCode cpp"><em>base-specifier</em></code>, then they
-compare equal if and only if the other operand represents the same
-<code class="sourceCode cpp"><em>base-specifier</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(*.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(*.7)</a></span>
+Otherwise, if one operand represents a base class specifier, then they
+compare equal if and only if the other operand represents the same base
+class specifier.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(*.8)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -5955,7 +5878,7 @@ any), <code class="sourceCode cpp"><em>alignment-specifiers</em></code>
 (if any), width, and attributes.</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -5972,115 +5895,47 @@ Otherwise, the result of each of the operators is unspecified.</p>
 </div>
 <h3 class="unnumbered" id="expr.const-constant-expressions"><span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span> Constant
 Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3>
-<p>Modify paragraph 15 to disallow returning non-consteval-only pointers
-and references to consteval-only objects from constant expressions.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">15</a></span>
-A <em>constant-expression</em> is either a glvalue core constant
-expression that <span class="addu"> </span></p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(15.1)</a></span>
-refers to an entity that is a permitted result of a constant
-expression<span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(15.2)</a></span>
-is of consteval-only type if the entity designated by the expression is
-of consteval-only type,</span></li>
-</ul>
-<p>or a prvalue core constant expression whose value satisfies the
-following constraints:</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(15.3)</a></span>
-if the value is an object of class type, each non-static data member of
-reference type refers to an entity that is a permitted result of a
-constant expression <span class="addu">and has consteval-only type if
-the entity has consteval-only type</span>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(15.4)</a></span>
-if the value is an object of scalar type, it does not have an
-indeterminate or erroneous value ([basic.indet]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(15.5)</a></span>
-if the value is of pointer type, it is a pointer to an object of static
-storage duration, a pointer past the end of such an object ([expr.add]),
-a pointer to a non-immediate function, or a null pointer value,</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(15.6)</a></span>
-if the value is a pointer to an object of consteval-only type, or a
-pointer past the end of such an object, then the prvalue is also of
-consteval-only type,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(15.7)</a></span>
-if the value is of pointer-to-member-function type, it does not
-designate an immediate function, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(15.8)</a></span>
-if the value is an object of class or array type, each subobject
-satisfies these constraints for the value.</li>
-</ul>
-</blockquote>
-</div>
-<p>Modify (and clean up) the definition of <em>immediate-escalating</em>
-to also apply to expressions of consteval-only type.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">18</a></span>
-A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
-<em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
-<span class="addu">nor a subexpression of an immediate
-invocation,</span> and it <span class="rm" style="color: #bf0303"><del>is</del></span> either</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(18.1)</a></span>
-<span class="rm" style="color: #bf0303"><del>a
-potentially-evaluated</del></span> <span class="addu">is an</span>
-<code class="sourceCode cpp"><em>id-expression</em></code> that denotes
-an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that is not a subexpression of an immediate
-invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(18.2)</a></span>
-<span class="addu">is</span> an immediate invocation that is not a
-constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
-invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(18.3)</a></span>
-has consteval-only type ([basic.types.general]).</span></li>
-</ul>
-</blockquote>
-</div>
 <p>Add new paragraphs prior to the definition of <em>manifestly constant
 evaluated</em> (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>/20), and
 renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">20</a></span>
 An expression or conversion is <em>in substitution context</em> if it
 results from the substitution of template parameters</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(20.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(20.1)</a></span>
 during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(20.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(20.2)</a></span>
 in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(20.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(20.3)</a></span>
 in a <code class="sourceCode cpp"><em>requires-expression</em></code>
-(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
+(<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">21</a></span>
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code> that
 is not in substitution context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(21.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.4)</a></span>
 an immediate invocation, unless it is
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(21.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.4.1)</a></span>
 in substitution context, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(21.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.4.2)</a></span>
 within the body of an immediate-escalating function that contains an
 immediate-escalating expression.</li>
 </ul></li>
@@ -6094,24 +5949,24 @@ declarations are reachable at a point immediatelly following
 note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
-<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
-<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
-<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
-<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
-<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
-<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
-<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
-<span id="cb114-18"><a href="#cb114-18" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
+<div class="sourceCode" id="cb113"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
+<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
+<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb113-8"><a href="#cb113-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
+<span id="cb113-9"><a href="#cb113-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb113-10"><a href="#cb113-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
+<span id="cb113-11"><a href="#cb113-11" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
+<span id="cb113-12"><a href="#cb113-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb113-13"><a href="#cb113-13" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
+<span id="cb113-14"><a href="#cb113-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb113-15"><a href="#cb113-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb113-16"><a href="#cb113-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb113-17"><a href="#cb113-17" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
+<span id="cb113-18"><a href="#cb113-18" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6122,22 +5977,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">22</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(22.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(22.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(22.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(22.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(22.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(22.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(22.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(22.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6160,7 +6015,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">23</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6174,12 +6029,12 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">24</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(24.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
 constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
@@ -6196,36 +6051,36 @@ declarations when such evaluations can be guaranteed to only happen
 once.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb115"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
-<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
-<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
-<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
-<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
-<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
-<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
-<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
-<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
-<span id="cb115-14"><a href="#cb115-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
-<span id="cb115-15"><a href="#cb115-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
-<span id="cb115-16"><a href="#cb115-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-17"><a href="#cb115-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb115-18"><a href="#cb115-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
-<span id="cb115-19"><a href="#cb115-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
-<span id="cb115-20"><a href="#cb115-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb115-21"><a href="#cb115-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
-<span id="cb115-22"><a href="#cb115-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
-<span id="cb115-23"><a href="#cb115-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
-<span id="cb115-24"><a href="#cb115-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evaluated.</span></span>
-<span id="cb115-25"><a href="#cb115-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
-<span id="cb115-26"><a href="#cb115-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
-<span id="cb115-27"><a href="#cb115-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
+<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
+<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
+<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
+<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
+<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
+<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
+<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
+<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
+<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
+<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
+<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb114-18"><a href="#cb114-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
+<span id="cb114-19"><a href="#cb114-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
+<span id="cb114-20"><a href="#cb114-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb114-21"><a href="#cb114-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
+<span id="cb114-22"><a href="#cb114-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
+<span id="cb114-23"><a href="#cb114-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
+<span id="cb114-24"><a href="#cb114-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evalauted.</span></span>
+<span id="cb114-25"><a href="#cb114-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
+<span id="cb114-26"><a href="#cb114-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
+<span id="cb114-27"><a href="#cb114-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6234,34 +6089,16 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
-<code class="sourceCode cpp"><em>E</em></code> ([intro.execution]).</li>
+<code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 </div>
-</blockquote>
-</div>
-<h3 class="unnumbered" id="dcl.typedef-the-typedef-specifier"><span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.typedef]</a></span> The
-<code class="sourceCode cpp"><span class="kw">typedef</span></code>
-specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3>
-<p>Account for
-<code class="sourceCode cpp"><em>splice-type-speciifer</em></code>s in
-paragraph 3.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">3</a></span>
-A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
-only a <code class="sourceCode cpp"><em>typedef-name</em></code> if its
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
-designates</span> <span class="rm" style="color: #bf0303"><del>names</del></span> an alias template or a
-template
-<code class="sourceCode cpp"><em>template-parameter</em></code>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.type.simple-simple-type-specifiers"><span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>
@@ -6272,142 +6109,34 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
-<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
-<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
-<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb115"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Add a restriction to paragrpah 2 disallowing splicers from appearing
-after nested name specifiers.</p>
+<h3 class="unnumbered" id="dcl.type.splice-type-splicing">9.2.9*
+[dcl.type.splice] Type splicing<a href="#dcl.type.splice-type-splicing" class="self-link"></a></h3>
+<p>Add a new subsection of <span>9.2.9 <a href="https://wg21.link/dcl.type">[dcl.type]</a></span> following
+<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">2</a></span>
-The component names of a
-<code class="sourceCode cpp"><em>simple-type-specifier</em></code> are
-those of its
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
-<code class="sourceCode cpp"><em>type-name</em></code>,
-<code class="sourceCode cpp"><em>simple-template-id</em></code>,
-<code class="sourceCode cpp"><em>template-name</em></code>, and/or
-<code class="sourceCode cpp"><em>type-constraint</em></code> (if it is a
-<code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>).
-The component name of a
-<code class="sourceCode cpp"><em>type-name</em></code> is the first name
-in it. <span class="addu">The
-<code class="sourceCode cpp"><em>simple-template-id</em></code> in a
-<code class="sourceCode cpp"><em>type-specifier</em></code> of the form
-<code class="sourceCode cpp"><em>nested-name-specifier</em> <span class="kw">template</span> <em>simple-template-id</em></code>
-shall not contain a splicer.</span></p>
-</blockquote>
-</div>
-<p>Indicate that a
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code> can
-be a placeholder for a deduced class type.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">3</a></span>
-A
-<code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
-is a placeholder for a type to be deduced ([dcl.spec.auto]). A
-<code class="sourceCode cpp"><em>type-specifier</em></code> <span class="rm" style="color: #bf0303"><del>of the form <span><code class="sourceCode default">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code></span></del></span>
-is a placeholder for a deduced class type ([dcl.type.class.deduct])
-<span class="addu">if it</span></p>
 <div class="addu">
-<ul>
-<li>is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
-or</li>
-<li>consists of a
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code> that
-designates a class template or alias template.</li>
-</ul>
+<div>
+<div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
-<p>The
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code>, if
-any, shall be non-dependent and the
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
-shall <span class="rm" style="color: #bf0303"><del>name</del></span>
-<span class="addu">designate</span> a deducible template. A
-<em>deducible template</em> is either a class template or is an alias
-template whose
-<code class="sourceCode cpp"><em>defining-type-id</em></code> is of the
-form</p>
-<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
-<p>where the
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code> (if
-any) is non-dependent and the
-<code class="sourceCode cpp"><em>template-name</em></code> of the
-<code class="sourceCode cpp"><em>simple-template-id</em></code> names a
-deducible template.</p>
-</blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">1</a></span>
+The <code class="sourceCode cpp"><span class="kw">typename</span></code>
+may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">2</a></span>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+designate a type. The type designated by the
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
+the same type designated by the
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p>Add a row to [tab:dcl.type.simple] to cover the
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
-production.</p>
-<div class="std">
-<blockquote>
-<center>
-Table 17:
-<code class="sourceCode cpp"><em>simple-type-specifier</em></code>s and
-the types they specify [tab:dcl.type.simple]
-</center>
-<table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th style="text-align: left;"><div style="text-align:center">
-<strong>Specifier(s)</strong>
-</div></th>
-<th style="text-align: left;"><div style="text-align:center">
-<strong>Type</strong>
-</div></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td style="text-align: left;"><code class="sourceCode cpp"><em>type-name</em></code></td>
-<td style="text-align: left;">the type named</td>
-</tr>
-<tr class="even">
-<td style="text-align: left;"><code class="sourceCode cpp"><em>simple-template-id</em></code></td>
-<td style="text-align: left;">the type as defined in [temp.names]</td>
-</tr>
-<tr class="odd">
-<td style="text-align: left;"><code class="sourceCode cpp"><em>decltype-specifier</em></code></td>
-<td style="text-align: left;">the type as defined in
-[dcl.type.decltype]</td>
-</tr>
-<tr class="even">
-<td style="text-align: left;"><code class="sourceCode cpp"><em>pack-index-specifier</em></code></td>
-<td style="text-align: left;">the type as defined in
-[dcl.type.pack.index]</td>
-</tr>
-<tr class="odd">
-<td style="text-align: left;"><code class="sourceCode cpp"><em>placeholder-type-specifier</em></code></td>
-<td style="text-align: left;">the type as defined in
-[dcl.spec.auto]</td>
-</tr>
-<tr class="even">
-<td style="text-align: left;"><code class="sourceCode cpp"><em>template-name</em></code></td>
-<td style="text-align: left;">the type as defined in
-[dcl.type.class.deduct]</td>
-</tr>
-<tr class="odd">
-<td style="text-align: left;"><span class="addu"><code class="sourceCode cpp"><em>splice-type-specifier</em></code></span></td>
-<td style="text-align: left;"><span class="addu">the type as defined in
-[dcl.type.class.deduct]</span></td>
-</tr>
-<tr class="even">
-<td style="text-align: left;"><code class="sourceCode cpp"><span class="op">...</span></code></td>
-<td style="text-align: left;">…</td>
-</tr>
-</tbody>
-</table>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
@@ -6418,45 +6147,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6464,7 +6193,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6473,38 +6202,23 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">9</a></span>
-A function type with a
-<code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
-<code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
-type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">9</a></span>
+A function type with a <em>cv-qualifier-seq</em> or a
+<em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(9.2)</a></span>
-the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(9.3)</a></span>
-the top-level function type of a function typedef declaration or
-<code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(9.4)</a></span>
-the <code class="sourceCode cpp"><em>type-id</em></code> in the default
-argument of a
-<code class="sourceCode cpp"><em>type-parameter</em></code>
-([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(9.5)</a></span>
-the <code class="sourceCode cpp"><em>type-id</em></code> of a
-<code class="sourceCode cpp"><em>template-argument</em></code> for a
-<code class="sourceCode cpp"><em>type-parameter</em></code>
-([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
-or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(9.2)</a></span>
+…</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(9.5)</a></span>
+the <em>type-id</em> of a <em>template-argument</em> for a
+<em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(9.6)</a></span>
-the operand of a
-<code class="sourceCode cpp"><em>reflect-expression</em></code>
-([expr.reflect]).</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(9.6)</a></span>
+the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
 </blockquote>
@@ -6515,10 +6229,10 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
-the reflection operator ([expr.reflect])</span>, is ill-formed.</p>
+the reflection operator</span>, is ill-formed.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.7.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
@@ -6529,30 +6243,28 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb118"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
-<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
-<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
-<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
-<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
+<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
+<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
+<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
+<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Modify paragraph 1 to handle splicers:</p>
+<p>Modify paragraph 1 of <span>9.7.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> as
+follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">1</a></span>
-<span class="addu">A <code class="sourceCode cpp"><span class="kw">using</span><span class="op">-</span><span class="kw">enum</span><span class="op">-</span>declarator</code>
-of the form
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
-considered in a type-only context, and designates the same construct
-designated by the splicer. Any other</span> <span class="rm" style="color: #bf0303"><del>A</del></span>
-<code class="sourceCode cpp"><em>using-enum-declarator</em></code> names
-the set of declarations found by type-only lookup
-([basic.lookup.general]) for the
-<code class="sourceCode cpp"><em>using-enum-declarator</em></code>
-([basic.lookup.unqual], [basic.lookup.qual]). The
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">1</a></span>
+A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
+<span class="addu">that is not a
+<code class="sourceCode cpp"><em>splice-specifier</em></code></span>
+names the set of declarations found by lookup (<span>6.5.3 <a href="https://wg21.link/basic.lookup.unqual">[basic.lookup.unqual]</a></span>,
+<span>6.5.5 <a href="https://wg21.link/basic.lookup.qual">[basic.lookup.qual]</a></span>)
+for the
+<code class="sourceCode cpp"><em>using-enum-declarator</em></code>. The
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> shall
 designate a non-dependent type with a reachable
 <code class="sourceCode cpp"><em>enum-specifier</em></code>.</p>
@@ -6562,14 +6274,20 @@ designate a non-dependent type with a reachable
 <a href="https://wg21.link/namespace.alias">[namespace.alias]</a></span>
 Namespace alias<a href="#namespace.alias-namespace-alias" class="self-link"></a></h3>
 <p>Add a production to the grammar for
-<code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 as follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     namespace <em>identifier</em> = <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb118"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias</em>:</span>
+<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>      <em>identifier</em></span>
+<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
+<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
+<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a>  <em>qualified-namespace-specifier</em>:</span>
+<span id="cb118-8"><a href="#cb118-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb118-9"><a href="#cb118-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6577,40 +6295,47 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">0</a></span>
-A <code class="sourceCode cpp"><em>splice-specifier</em></code>
-appearing in a
-<code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
-shall designate a namespace or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">0</a></span>
+If a
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+is a <code class="sourceCode cpp"><em>splice-specifier</em></code>, the
+<code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+designate a namespace or namespace alias; the
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+designates the same namespace or namespace alias designated by the
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.
+Otherwise, the
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link/basic.lookup.unqual">[basic.lookup.unqual]</a></span>,
+<span>6.5.5 <a href="https://wg21.link/basic.lookup.qual">[basic.lookup.qual]</a></span>).</p>
 </div>
 </blockquote>
 </div>
-<p>Prefer the verb “designate” in the paragraph that immediately
-follows:</p>
+<p>Prefer the verb “designate” for
+<code class="sourceCode cpp"><em>qualified-namespace-specifiers</em></code>
+in the paragraph that immediately follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
 and denotes the namespace <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> by the
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
-<span class="addu">or
-<code class="sourceCode cpp"><em>splice-specifier</em></code></span>.</p>
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
 Using namespace directive<a href="#namespace.udir-using-namespace-directive" class="self-link"></a></h3>
-<p>Add <code class="sourceCode cpp"><em>splice-specifier</em></code> to
-the grammar for
+<p>Use
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+in the grammar for
 <code class="sourceCode cpp"><em>using-directive</em></code>:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
-<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>      <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
-<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>qualified-namespace-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6619,15 +6344,15 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">0</a></span>
-The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
-any, designates a namespace or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>. Neither
-the <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
-nor the <code class="sourceCode cpp"><em>splice-specifier</em></code>
-shall be dependent.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">0</a></span>
+The
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+shall neither contain a dependent
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> nor a
+dependent
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6666,10 +6391,10 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
+<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
+<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6677,13 +6402,13 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb122"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
-<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
-<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
-<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
-<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
-<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
-<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
+<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
+<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
+<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
+<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6691,7 +6416,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6708,98 +6433,34 @@ the two-token sequence
 — <em>end note</em> ]</span></span></span> …</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="module.global.frag-global-module-fragment">[module.global.frag]
-Global module fragment<a href="#module.global.frag-global-module-fragment" class="self-link"></a></h3>
-<p>Extend the caveat in paragraph 3.7 to also apply to
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
-<div class="std">
-<blockquote>
-<p>In this determination, it is unspecified</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.6)</a></span>
-whether a reference to an
-<code class="sourceCode cpp"><em>alias-declaration</em></code>,
-<code class="sourceCode cpp"><span class="kw">typedef</span></code>
-declaration,
-<code class="sourceCode cpp"><em>using-declaration</em></code>, or
-<code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
-is replaced by the declarations they name prior to this
-determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.7)</a></span>
-whether a
-<code class="sourceCode cpp"><em>simple-template-id</em></code> that
-does not denote a dependent type and whose
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
-<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template is replaced by its
-denoted type prior to this determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(3.8)</a></span>
-…</li>
-</ul>
-</blockquote>
-</div>
 <h3 class="unnumbered" id="module.reach-reachability"><span>10.7 <a href="https://wg21.link/module.reach">[module.reach]</a></span>
 Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 <p>Modify the definition of reachability to account for injected
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
 within a <em>private-module-framgent</em>.</li>
 </ul>
-</blockquote>
-</div>
-<h3 class="unnumbered" id="class.pre-preamble">[class.pre] Preamble<a href="#class.pre-preamble" class="self-link"></a></h3>
-<p>Disallow splicers from appearing in a declaration of a
-<code class="sourceCode cpp"><em>class-name</em></code> in paragraph
-1.</p>
-<div class="std">
-<blockquote>
-<p>…</p>
-<p>A class declaration where the
-<code class="sourceCode cpp"><em>class-name</em></code> in the
-<code class="sourceCode cpp"><em>class-head-name</em></code> is a
-<code class="sourceCode cpp"><em>simple-template-id</em></code> shall be
-an explicit specialization ([temp.expl.spec]) or a partial
-specialization ([temp.spec.partial]). <span class="addu">The
-<code class="sourceCode cpp"><em>simple-template-id</em></code> shall
-not contain a splicer.</span> A
-<code class="sourceCode cpp"><em>class-specifier</em></code> whose
-<code class="sourceCode cpp"><em>class-head</em></code> omits the
-<code class="sourceCode cpp"><em>class-head-name</em></code> defines an
-<em>unnamed class</em>.</p>
-</blockquote>
-</div>
-<h3 class="unnumbered" id="class.name-class-names">[class.name] Class
-names<a href="#class.name-class-names" class="self-link"></a></h3>
-<p>Cover `$splice-type-specifier$s in paragraph 5.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">5</a></span>
-A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
-only a <code class="sourceCode cpp"><em>class-name</em></code> if its
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
-<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a class template.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="class.mem.general-general"><span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>
@@ -6809,7 +6470,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6823,50 +6484,9 @@ non-static data member of reference type, there is a unique member
 subobject whose size and alignment is the same as if the data member
 were declared with the corresponding pointer type.</span></p>
 <p><span class="note3"><span>[ <em>Note 3:</em> </span><span class="rm" style="color: #bf0303"><del>A non-static data member of non-reference
-type is a member subobject of a class object.</del></span> <span class="addu">An object of class type has a member subobject
-corresponding to each non-static data member of its class</span><span>
-— <em>end note</em> ]</span></span></p>
-</blockquote>
-</div>
-<h3 class="unnumbered" id="over.match.class.deduct-class-template-argument-deduction"><span>12.2.2.9
-<a href="https://wg21.link/over.match.class.deduct">[over.match.class.deduct]</a></span>
-Class template argument deduction<a href="#over.match.class.deduct-class-template-argument-deduction" class="self-link"></a></h3>
-<p>Extend paragraph 1 to work with
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
-When resolving a placeholder for a deduced class type
-([dcl.type.class.deduct]) where the
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
-<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a primary class template
-<code class="sourceCode cpp">C</code>, a set of functions and function
-templates, called the guides of <code class="sourceCode cpp">C</code>,
-is formed comprising:</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(1.1)</a></span>
-…</li>
-</ul>
-</blockquote>
-</div>
-<p>Extend paragraph 3 to also cover
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">3</a></span>
-When resolving a placeholder for a deduced class type
-([dcl.type.simple]) where the
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
-<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template
-<code class="sourceCode cpp">A</code>, the
-<code class="sourceCode cpp"><em>defining-type-id</em></code> of
-<code class="sourceCode cpp">A</code> must be of the form</p>
-<div class="sourceCode" id="cb123"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
-<p>as specified in [dcl.type.simple]. The guides of
-<code class="sourceCode cpp">A</code> are the set of functions or
-function templates formed as follows. …</p>
+type is a member subobject of a class object.</del></span> An object of
+class type has a member subobject corresponding to each non-static data
+member of its class<span> — <em>end note</em> ]</span></span></p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="over.built-built-in-operators"><span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span> Built-in
@@ -6875,202 +6495,141 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
-or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
+or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 there exist candidate operator functions of the form</p>
-<div class="sourceCode" id="cb124"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
-<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb122"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.param-template-parameters"><span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span> Template
 parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
-<p>Extend the grammar for
-<code class="sourceCode cpp"><em>type-constraint</em></code> to include
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>.</p>
+<p>Extend the last sentence of paragraph 4 to disallow splicing concepts
+in template parameter declarations.</p>
 <div class="std">
 <blockquote>
-<div>
-<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>type-constraint</em>:</span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub>&gt;</span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em></span></span></code></pre></div>
-</div>
-</blockquote>
-</div>
-<p>Add a paragraph after paragraph 3 to restrict the type splicers that
-form <code class="sourceCode cpp"><em>type-constraint</em></code>s.</p>
-<div class="std">
-<blockquote>
-<div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">3+</a></span>
-A non-dependent
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
-forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
-when it designates a concept. A
-<code class="sourceCode cpp"><em>type-constraint</em></code> of the form
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code> shall
-not appear in a
-<code class="sourceCode cpp"><em>type-parameter</em></code>.</p>
-</div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">4</a></span>
+… The concept designated by a type-constraint shall be a type concept
+([temp.concept]) <span class="addu">that is not a
+<code class="sourceCode cpp"><em>splice-template-name</em></code></span>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.names-names-of-template-specializations"><span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span> Names of
 template specializations<a href="#temp.names-names-of-template-specializations" class="self-link"></a></h3>
-<p>Extend
-<code class="sourceCode cpp"><em>simple-template-id</em></code> and
-<code class="sourceCode cpp"><em>template-argument</em></code> to
-leverage splicers.</p>
+<p>Modify the grammars for
+<code class="sourceCode cpp"><em>template-id</em></code> and
+<code class="sourceCode cpp"><em>template-argument</em></code> as
+follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-template-id</em>:</span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>      <em>template-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-expr-template-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
-<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
-<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>  <em>template-id</em>:</span>
-<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>      <em>simple-template-id</em></span>
-<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>      $operator-function-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>      $literal-operator-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a>  </span>
-<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
-<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a>      identifier</span>
-<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a>  <em>template-argument-list</em>:</span>
-<span id="cb126-15"><a href="#cb126-15" aria-hidden="true" tabindex="-1"></a>      <em>template-argument</em> ...<sub><em>opt</em></sub></span>
-<span id="cb126-16"><a href="#cb126-16" aria-hidden="true" tabindex="-1"></a>      <em>template-argument-list</em> , <em>template-argument</em> ...<sub><em>opt</em></sub></span>
-<span id="cb126-17"><a href="#cb126-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-18"><a href="#cb126-18" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
-<span id="cb126-19"><a href="#cb126-19" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
-<span id="cb126-20"><a href="#cb126-20" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
-<span id="cb126-21"><a href="#cb126-21" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
-<span id="cb126-22"><a href="#cb126-22" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
-<span id="cb126-23"><a href="#cb126-23" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb123"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-name</em>:</span></span>
+<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a><span class="va">+     template <em>splice-specifier</em></span></span>
+<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
+<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span>
+<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
+<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a>      identifier</span>
+<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-name</em></span></span>
+<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
+<span id="cb123-12"><a href="#cb123-12" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
+<span id="cb123-13"><a href="#cb123-13" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
+<span id="cb123-14"><a href="#cb123-14" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
+<span id="cb123-15"><a href="#cb123-15" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
+<span id="cb123-16"><a href="#cb123-16" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Extend paragraph 2 to cover
-<code class="sourceCode cpp"><em>simple-template-id</em></code>s and
-<code class="sourceCode cpp"><em>template-id</em></code>s that have no
-component name.</p>
+<p>Extend paragraph 1 to cover template splicers:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">2</a></span>
-The component name of a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>simple-template-id</em></code></span>,
-<span><code class="sourceCode default"><em>template-id</em></code></span>,
-or</del></span>
-<code class="sourceCode cpp"><em>template-name</em></code> is its
-<code class="sourceCode cpp"><em>identifier</em></code> <span class="rm" style="color: #bf0303"><del>the first name in it</del></span>. <span class="addu">The component names of a
-<code class="sourceCode cpp"><em>simple-template-id</em></code> are
-those of its <code class="sourceCode cpp"><em>template-name</em></code>
-(if any). The component names of a
-<code class="sourceCode cpp"><em>template-id</em></code> are those of
-its <code class="sourceCode cpp"><em>simple-template-id</em></code>,
-<code class="sourceCode cpp"><em>operator-function-id</em></code>, or
-<code class="sourceCode cpp"><em>literal-operator-id</em></code>.</span></p>
+<p>The component name of a
+<code class="sourceCode cpp"><em>simple-template-id</em></code>,
+<code class="sourceCode cpp"><em>template-id</em></code>, or
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">that is an
+<code class="sourceCode cpp"><em>identifier</em></code></span> is the
+first name in it. <span class="addu">If the
+<code class="sourceCode cpp"><em>template-name</em></code> is a
+<code class="sourceCode cpp"><em>splice-template-name</em></code>, the
+<code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+designate a concept, variable template, class template, alias template,
+or function template that is not a constructor template or destructor
+template; the
+<code class="sourceCode cpp"><em>splice-template-name</em></code>
+designates the entity designated by the
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></p>
 </blockquote>
 </div>
-<p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
+<p>Extend paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
-interpreted as the delimiter of a
-<code class="sourceCode cpp"><em>template-argument-list</em></code> if
-it follows <span class="addu">either</span></p>
+interpreted as the delimiter of a <em>template-argument-list</em> if it
+follows a name that is not a <em>conversion-function-id</em> and</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.1)</a></span>
-a
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
-or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>,
-or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(3.2)</a></span>
-a name that is not a
-<code class="sourceCode cpp"><em>conversion-function-id</em></code> and
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(3.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(3.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(3.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(3.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
-</ul></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>If the name is an
 identifier, it is then interpreted as a <em>template-name</em>. The
 keyword template is used to indicate that a dependent qualified name
 ([temp.dep.type]) denotes a template where an expression might
 appear.<span> — <em>end note</em> ]</span></span></p>
+<div class="addu">
+<p>A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
+also interpreted as the delimiter of a
+<code class="sourceCode cpp"><em>template-argument-list</em></code> if
+it follows a
+<code class="sourceCode cpp"><em>splice-template-name</em></code>.</p>
+</div>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div>
-<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
-<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>};</span>
-<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
-<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
-<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
-<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
-<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
-<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
-<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
-<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
-<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb124"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
+<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
+<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a>};</span>
+<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
+<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
+<span id="cb124-7"><a href="#cb124-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
+<span id="cb124-8"><a href="#cb124-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
+<span id="cb124-9"><a href="#cb124-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
+<span id="cb124-10"><a href="#cb124-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb124-11"><a href="#cb124-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
+<span id="cb124-12"><a href="#cb124-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
+<span id="cb124-13"><a href="#cb124-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
+<span id="cb124-14"><a href="#cb124-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
 </blockquote>
 </div>
-<p>Extend paragraph 8 to also cover
-<code class="sourceCode cpp"><em>simple-template-id</em></code>s
-containing
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>s.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">8</a></span>
-When the <code class="sourceCode cpp"><em>template-name</em></code>
-<span class="addu">or splicer</span> of a
-<code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a constrained non-function template or a
-constrained template
-<code class="sourceCode cpp"><em>template-parameter</em></code>, and all
-<code class="sourceCode cpp"><em>template-arguments</em></code> in the
-<code class="sourceCode cpp"><em>simple-template-id</em></code> are
-non-dependent ([temp.dep.temp]), the associated contraints
-([temp.constr.decl]) of the constrained template shall be satisfied
-([temp.constr.constr]).</p>
-</blockquote>
-</div>
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">9</a></span>
-A <em>concept-id</em> is a
-<code class="sourceCode cpp"><em>simple-template-id</em></code> where
-<span class="addu">either</span> the
-<code class="sourceCode cpp"><em>template-name</em></code> is a
-<code class="sourceCode cpp"><em>concept-name</em></code> <span class="addu">or the
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
-designates a concept</span>. A concept-id is a prvalue of type
-<code class="sourceCode cpp"><span class="dt">bool</span></code>, and
-does not name a template specialization. A concept-id evaluates to
-<code class="sourceCode cpp"><span class="kw">true</span></code> if the
-concept’s normalized
-<code class="sourceCode cpp"><em>constraint-expression</em></code>
-([temp.constr.decl]) is satisfied ([temp.constr.constr]) by the
-specified template arguments and
-<code class="sourceCode cpp"><span class="kw">false</span></code>
-otherwise.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">9</a></span>
+A <em>concept-id</em> is a <em>simple-template-id</em> where the
+<em>template-name</em> is <span class="addu">either</span> a
+<em>concept-name</em> <span class="addu">or a
+<em>splice-template-name</em> whose <em>splice-specifier</em> designates
+a concept</span>. A concept-id is a prvalue of type bool, and does not
+name a template specialization.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.arg.general-general"><span>13.4.1 <a href="https://wg21.link/temp.arg.general">[temp.arg.general]</a></span>
@@ -7079,28 +6638,33 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">3</a></span>
+<span class="addu">A
+<code class="sourceCode cpp"><em>template-argument</em></code> of the
+form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
+interpreted as a
+<code class="sourceCode cpp"><em>splice-template-argument</em></code>.</span>
 In a <code class="sourceCode cpp"><em>template-argument</em></code>
 <span class="addu">that is not a
-<code class="sourceCode cpp"><em>splice-specifier</em></code></span>, an
-ambiguity between a <code class="sourceCode cpp"><em>type-id</em></code>
-and an expression is resolved to a
-<code class="sourceCode cpp"><em>type-id</em></code>, regardless of the
-form of the corresponding
+<code class="sourceCode cpp"><em>splice-template-argument</em></code></span>,
+an ambiguity between a
+<code class="sourceCode cpp"><em>type-id</em></code> and an expression
+is resolved to a <code class="sourceCode cpp"><em>type-id</em></code>,
+regardless of the form of the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>.</p>
 <div class="example2">
 <span>[ <em>Example 2:</em> </span>
 <div>
-<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
-<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
-<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
-<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
-<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-specifier: calls the first f()</span></span>
-<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-specifier: calls the second f()</span></span>
-<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
+<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
+<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
+<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-template-argument: calls the first f()</span></span>
+<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-template-argument: calls the second f()</span></span>
+<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -7112,13 +6676,42 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
 <code class="sourceCode cpp"><em>type-id</em></code> <span class="addu">or a
-<code class="sourceCode cpp"><em>splice-specifier</em></code> that is
-either dependent or designates a type</span>.</p>
+<code class="sourceCode cpp"><em>splice-template-argument</em></code>
+whose <code class="sourceCode cpp"><em>splice-specifier</em></code>
+designates a type</span>.</p>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="temp.arg.nontype-template-non-type-arguments"><span>13.4.3 <a href="https://wg21.link/temp.arg.nontype">[temp.arg.nontype]</a></span>
+Template non-type arguments<a href="#temp.arg.nontype-template-non-type-arguments" class="self-link"></a></h3>
+<p><span class="draftnote" style="color: #01796F">[ Drafting note: We
+don’t think we have to change anything here, since if
+<code class="sourceCode cpp">E</code> is a <em>splice-specifier</em> the
+requirements already fall out based on how paragraphs 1 and 3 are
+already worded ]</span></p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
+If the type <code class="sourceCode cpp">T</code> of a
+<em>template-parameter</em> ([temp.param]) contains a placeholder type
+([dcl.spec.auto]) or a placeholder for a deduced class type
+([dcl.type.class.deduct]), the type of the parameter is the type deduced
+for the variable x in the invented declaration</p>
+<div class="sourceCode" id="cb126"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
+<p>where <code class="sourceCode cpp"><em>E</em></code> is the template
+argument provided for the parameter.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">2</a></span>
+The value of a non-type <em>template-parameter</em>
+<code class="sourceCode cpp">P</code> of (possibly deduced) type
+<code class="sourceCode cpp">T</code> […]</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">3</a></span>
+Otherwise, a temporary variable</p>
+<div class="sourceCode" id="cb127"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
+<p>is introduced.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.arg.template-template-template-arguments"><span>13.4.4 <a href="https://wg21.link/temp.arg.template">[temp.arg.template]</a></span>
@@ -7127,118 +6720,40 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
-shall be <span class="rm" style="color: #bf0303"><del>the name
-of</del></span> a class template or an alias template, expressed as
-<span class="addu">an</span>
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or a (possibly dependent) splicer</span>. Only primary
-templates are considered when matching the template argument with the
-corresponding parameter; partial specializations are not considered even
-if their parameter lists match that of the template template
-parameter.</p>
+shall be the name of a class template or an alias template, expressed as
+<code class="sourceCode cpp"><em>id-expression</em></code><span class="addu">, or a
+<code class="sourceCode cpp"><em>splice-template-argument</em></code>
+whose <code class="sourceCode cpp"><em>splice-specifier</em></code>
+designates a template</span>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.type-type-equivalence"><span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span> Type
 equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
-<p>Extend <code class="sourceCode cpp"><em>template-id</em></code>
-equivalence as defined by paragraph 1 to cover splicers.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">1</a></span>
-Two <code class="sourceCode cpp"><em>template-id</em></code>s are the
-same if</p>
-<ul>
-<li>their <code class="sourceCode cpp"><em>template-name</em></code>s,
-<span class="addu"><code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>s,
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s,</span>
-<code class="sourceCode cpp"><em>operator-function-id</em></code>s, or
-<code class="sourceCode cpp"><em>literal-operator-id</em></code>s refer
-to the same template, and</li>
-<li>their corresponding type
-<code class="sourceCode cpp"><em>template-argument</em></code>s are the
-same type, and</li>
-<li>the template parameter values determined by their corresponding
-non-type template arguments ([temp.arg.nontype]) are
-template-argument-equivalent (see below), and</li>
-<li>their corresponding template
-<code class="sourceCode cpp"><em>template-argument</em></code>s refer to
-the same template.</li>
-</ul>
-<p>Two <code class="sourceCode cpp"><em>template-id</em></code>s that
-are the same refer to the same class, function, or variable.</p>
-</blockquote>
-</div>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(2.3)</a></span>
-they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(2.3)</a></span>
+they are of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(2.4)</a></span>
+and they compare equal, or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(2.5)</a></span>
 […]</li>
 </ul>
-</blockquote>
-</div>
-<h3 class="unnumbered" id="temp.deduct.guide-deduction-guides"><span>13.7.2.3 <a href="https://wg21.link/temp.deduct.guide">[temp.deduct.guide]</a></span>
-Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link"></a></h3>
-<p>Extend paragraph 1 to clarify that
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s can
-also leverage deduction guides.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
-Deduction guides are used when a
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
-appears as a type specifier for a deduced class type
-([dcl.type.class.deduct]). Deduction guides are not found by name
-lookup. Instead, when performing class template argument deduction
-([over.match.class.deduct]), all reachable deduction guides declared for
-the class template are considered.</p>
-</blockquote>
-</div>
-<p>Notwithstanding the above, extend paragraph 3 to clarify that
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s
-cannot themselves appear in deduction guides.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">3</a></span>
-The same restrictions apply to the
-<code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
-of a deduction guide as in a function declaration ([dcl.fct]), except
-that a generic parameter type placeholder ([dcl.spec.auto]) shall not
-appear in the
-<code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
-of a deduction guide. The
-<code class="sourceCode cpp"><em>simple-template-id</em></code> shall
-name a class template specialization <span class="addu">and shall
-contain a
-<code class="sourceCode cpp"><em>template-name</em></code></span>. The
-<code class="sourceCode cpp"><em>template-name</em></code> shall be the
-same <code class="sourceCode cpp"><em>identifier</em></code> as the
-<code class="sourceCode cpp"><em>template-name</em></code> of the
-<code class="sourceCode cpp"><em>simple-template-id</em></code>. A
-<code class="sourceCode cpp"><em>deduction-guide</em></code> shall
-inhabit the scope to which the corresponding class template belongs and,
-for a member class template, have the same access. Two deduction guide
-declarations for the same class template shall not have equivalent
-<code class="sourceCode cpp"><em>parameter-declaration-clauses</em></code>
-if either is reachable from the other.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.alias-alias-templates"><span>13.7.8 <a href="https://wg21.link/temp.alias">[temp.alias]</a></span> Alias
@@ -7247,7 +6762,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -7259,26 +6774,31 @@ is equivalent to the associated type obtained by substitution of its
 alias template.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="temp.res.general-general"><span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>
-General<a href="#temp.res.general-general" class="self-link"></a></h3>
-<p>Disallow
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s from
-appearing in
-<code class="sourceCode cpp"><em>typename-specifier</em></code>s, since
-splicers can’t follow
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code>s.</p>
+<h3 class="unnumbered" id="temp.concept-concept-definitions"><span>13.7.9 <a href="https://wg21.link/temp.concept">[temp.concept]</a></span> Concept
+definitions<a href="#temp.concept-concept-definitions" class="self-link"></a></h3>
+<p>Extend the grammar of
+<code class="sourceCode cpp"><em>concept-name</em></code> to allow for
+splicing reflections of concepts:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">3</a></span>
-The component names of a
-<code class="sourceCode cpp"><em>typename-specifier</em></code> are its
-<code class="sourceCode cpp"><em>identifier</em></code> (if any) and
-those of its
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code> and
-<code class="sourceCode cpp"><em>simple-template-id</em></code> (if
-any). <span class="addu">The
-<code class="sourceCode cpp"><em>simple-template-id</em></code> shall
-not contain a splicer.</span></p>
+<div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-name</em></span></span></code></pre></div>
+</div>
+</blockquote>
+</div>
+<p>Modify paragraph 2 to account for splicing reflections of
+concepts:</p>
+<div class="std">
+<blockquote>
+<p>A <code class="sourceCode cpp"><em>concept-definition</em></code>
+declares a concept. Its <span class="addu"><code class="sourceCode cpp"><em>concept-name</em></code>
+shall be an <code class="sourceCode cpp"><em>identifier</em></code>, and
+the</span> <code class="sourceCode cpp"><em>identifier</em></code>
+becomes a <em>concept-name</em> referring to that concept within its
+scope. The optional <em>attribute-specifier-seq</em> appertains to the
+concept.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.dep.expr-type-dependent-expressions"><span>13.8.3.3 <a href="https://wg21.link/temp.dep.expr">[temp.dep.expr]</a></span>
@@ -7308,23 +6828,16 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
-is type-dependent if</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(9.1)</a></span>
-the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
-is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(9.2)</a></span>
-the optional
+<code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
+is type-dependent if the
+<code class="sourceCode cpp"><em>splice-specifier</em></code> is
+value-dependent or if the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
-contains a dependent type argument, a value-dependent non-type argument,
-a dependent template template argument, or a dependent
-<code class="sourceCode cpp"><em>splice-specifier</em></code>.</li>
-</ul>
+contains a value-dependent non-type or template argument, or a dependent
+type argument.</p>
 </div>
 </blockquote>
 </div>
@@ -7334,10 +6847,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -7351,33 +6864,28 @@ the <em>type-id</em> is dependent:</p>
 <span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
 <p><span class="addu">A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
-value-dependent if the operand following
-<code class="sourceCode cpp"><span class="op">^</span></code> is a
-dependent name, names a dependent type, or contains a dependent
-<code class="sourceCode cpp"><em>pack-index-expression</em></code>.</span></p>
+value-dependent if the operand of the reflection operator is a
+type-dependent or value-dependent expression or if that operand is a
+dependent <code class="sourceCode cpp"><em>type-id</em></code>, a
+dependent <code class="sourceCode cpp"><em>namespace-name</em></code>,
+or a dependent
+<code class="sourceCode cpp"><em>template-name</em></code>.</span></p>
 </blockquote>
 </div>
-<p>Add a new paragraph after <span>13.8.3.4 <a href="https://wg21.link/temp.dep.constexpr">[temp.dep.constexpr]</a></span>/5:</p>
+<p>Add a new paragraph after <span>13.8.3.4 <a href="https://wg21.link/temp.dep.constexpr">[temp.dep.constexpr]</a></span>/4:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
-is value-dependent if</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.1)</a></span>
-the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
-<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
-is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(6.2)</a></span>
-the optional
+<code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
+is value-dependent if the
+<code class="sourceCode cpp"><em>constant-expression</em></code> is
+value-dependent or if the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
-contains a dependent type argument, a value-dependent non-type argument,
-a dependent template template argument, or a dependent
-<code class="sourceCode cpp"><em>splice-specifier</em></code>.</li>
-</ul>
+contains a value-dependent non-type or template argument, or a dependent
+type argument.</p>
 </div>
 </blockquote>
 </div>
@@ -7389,7 +6897,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -7407,19 +6915,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7432,7 +6940,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7440,7 +6948,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7449,14 +6957,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7902,7 +7410,7 @@ synopsis</strong></p>
 <span id="cb135-345"><a href="#cb135-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb135-346"><a href="#cb135-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb135-347"><a href="#cb135-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
@@ -7918,7 +7426,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -8171,10 +7679,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -8182,11 +7690,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -8201,33 +7709,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -8236,24 +7744,23 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
-namespace, or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>, then
+namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8262,44 +7769,43 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
-identifier introduced by the declaration of what is represented by
-<code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(4.4)</a></span>
+namespace alias, then the identifier introduced by the declaration of
+what is represented by <code class="sourceCode cpp">r</code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8311,21 +7817,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -8343,7 +7849,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-3"><a href="#cb143-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -8351,7 +7857,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -8359,7 +7865,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8367,7 +7873,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -8375,7 +7881,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8384,7 +7890,7 @@ defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8392,7 +7898,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8407,7 +7913,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8425,7 +7931,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8435,7 +7941,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -8443,7 +7949,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8452,7 +7958,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8461,7 +7967,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -8471,7 +7977,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -8482,7 +7988,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-3"><a href="#cb157-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-4"><a href="#cb157-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8491,13 +7997,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8507,13 +8013,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8522,20 +8028,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>. Otherwise,
+namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8543,19 +8049,18 @@ of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
-<code class="sourceCode cpp"><em>typedef-name</em></code> or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>,
-respectively <span class="note"><span>[ <em>Note 3:</em> </span>An
-instantiation of an alias template is a
+<code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
+alias, respectively <span class="note"><span>[ <em>Note 3:</em>
+</span>An instantiation of an alias template is a
 <code class="sourceCode cpp"><em>typedef-name</em></code><span>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8563,7 +8068,7 @@ instantiation of an alias template is a
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-3"><a href="#cb165-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8578,7 +8083,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb166-7"><a href="#cb166-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-8"><a href="#cb166-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-9"><a href="#cb166-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8588,14 +8093,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8612,7 +8117,7 @@ is
 <span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8621,7 +8126,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8630,14 +8135,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8648,7 +8153,7 @@ Otherwise,
 <span id="cb172-3"><a href="#cb172-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-4"><a href="#cb172-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-5"><a href="#cb172-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8656,20 +8161,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8678,11 +8183,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8698,33 +8203,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8740,26 +8245,24 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
-member, bit-field, template, namespace or
-<code class="sourceCode cpp"><em>namespace-alias</em></code> (other than
+member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
-<code class="sourceCode cpp"><em>typedef-name</em></code> or
-<code class="sourceCode cpp"><em>namespace-alias</em></code> <em>A</em>,
-then a reflection representing the entity named by <em>A</em>.
-Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">44</a></span></p>
+<code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
+alias <em>A</em>, then a reflection representing the entity named by
+<em>A</em>. Otherwise, <code class="sourceCode cpp">r</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb181"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8771,15 +8274,15 @@ Otherwise, <code class="sourceCode cpp">r</code>.</p>
 </div>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8801,11 +8304,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8818,13 +8321,13 @@ template, alias template, or concept,</li>
 <li>a function whose constraints (if any) are satisfied,</li>
 <li>a non-static data member,</li>
 <li>a namespace, or</li>
-<li>a <code class="sourceCode cpp"><em>namespace-alias</em></code>.</li>
+<li>a namespace alias.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Counterexamples of
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8835,11 +8338,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8853,14 +8356,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8870,92 +8373,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -8970,32 +8473,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9004,7 +8507,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -9017,7 +8520,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -9026,20 +8529,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -9047,7 +8550,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9056,7 +8559,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -9069,32 +8572,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -9102,7 +8605,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -9110,7 +8613,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -9118,52 +8621,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -9181,36 +8684,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb202-5"><a href="#cb202-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -9222,32 +8725,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -9255,37 +8758,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -9298,18 +8801,18 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9330,71 +8833,71 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -9404,7 +8907,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -9412,7 +8915,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9420,7 +8923,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -9437,32 +8940,32 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
-if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
-then either <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
-or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">==</span> <span class="st">u8&quot;_&quot;</span></code>.
+if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> <span class="st">u8&quot;_&quot;</span> <span class="op">&amp;&amp;</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span> <span class="op">!=</span> <span class="st">u8&quot;_&quot;</span></code>
+is <code class="sourceCode cpp"><span class="kw">true</span></code>,
+then <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>.
 <span class="note"><span>[ <em>Note 2:</em> </span>Every provided
-identifier that is not <code class="sourceCode cpp"><span class="st">&quot;_&quot;</span></code> must
-be unique.<span> — <em>end note</em> ]</span></span></li>
+identifier that is not <code class="sourceCode cpp"><span class="st">&quot;_&quot;</span></code>
+needs to be unique.<span> — <em>end note</em> ]</span></span></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 3:</em>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9474,26 +8977,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -9506,29 +9009,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9540,18 +9043,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9561,10 +9064,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9585,7 +9088,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9607,7 +9110,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb215-13"><a href="#cb215-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb215-14"><a href="#cb215-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb215-15"><a href="#cb215-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb216"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9633,7 +9136,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9655,7 +9158,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9665,7 +9168,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9676,7 +9179,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9762,12 +9265,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9779,10 +9282,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9791,7 +9294,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9803,7 +9306,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9832,7 +9335,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb221-14"><a href="#cb221-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb221-15"><a href="#cb221-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9854,7 +9357,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9866,7 +9369,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9887,7 +9390,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9905,7 +9408,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9922,7 +9425,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9939,7 +9442,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9966,7 +9469,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9974,7 +9477,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9984,7 +9487,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -10006,7 +9509,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb227-9"><a href="#cb227-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb227-10"><a href="#cb227-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb227-11"><a href="#cb227-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -10028,7 +9531,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -10036,7 +9539,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -10060,7 +9563,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -10068,27 +9571,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -10212,6 +9715,10 @@ constant-evaluation. <a href="https://wg21.link/p3068r1"><div class="csl-block">
 <div id="ref-P3096R1" class="csl-entry" role="doc-biblioentry">
 [P3096R1] Adam Lach, Walter Genovese. 2024-05-15. Function Parameter
 Reflection in Reflection for C++26. <a href="https://wg21.link/p3096r1"><div class="csl-block">https://wg21.link/p3096r1</div></a>
+</div>
+<div id="ref-P3293R1" class="csl-entry" role="doc-biblioentry">
+[P3293R1] Barry Revzin, Peter Dimov, Dan Katz, Daveed Vandevoorde.
+2024-10-13. Splicing a base class subobject. <a href="https://wg21.link/p3293r1"><div class="csl-block">https://wg21.link/p3293r1</div></a>
 </div>
 <div id="ref-P3295R0" class="csl-entry" role="doc-biblioentry">
 [P3295R0] Ben Craig. 2024-05-21. Freestanding constexpr containers and

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -886,7 +886,8 @@ synopsis<span></span></a></li>
 <li><a href="#meta.unary.cat-primary-type-categories" id="toc-meta.unary.cat-primary-type-categories"><span>21.3.5.2
 <span>[meta.unary.cat]</span></span> Primary type
 categories<span></span></a></li>
-<li><a href="#meta.synop-header-meta-synopsis" id="toc-meta.synop-header-meta-synopsis">[meta.synop] Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
+<li><a href="#meta.reflection.synop-header-meta-synopsis" id="toc-meta.reflection.synop-header-meta-synopsis">[meta.reflection.synop]
+Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
 synopsis<span></span></a></li>
 <li><a href="#meta.reflection.operators-operator-representations" id="toc-meta.reflection.operators-operator-representations">[meta.reflection.operators]
 Operator representations<span></span></a></li>
@@ -5027,14 +5028,20 @@ as follows:</p>
 specify the types do not contribute to this set. The set of entities is
 determined in the following way:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_13" id="pnum_13">(3.1)</a></span>
-<span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
-its associated set of entities is the singleton containing the function
-<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>is_type</code>.</span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_13" id="pnum_13">(3.1)</a></span>
+If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
+its associated set of entities consists of the function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>is_type</code>
+together with an implementation-defined set of additional entities.
+<span class="note"><span>[ <em>Note 1:</em> </span>For example, an
+implementation might augment a function to the set of associated
+entities to allow a namespace of implementation-provided reflection
+operations to be found by argument-dependent lookup.<span> — <em>end
+note</em> ]</span></span></span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">(3.2)</a></span>
 If <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> fundamental type, its associated set of entities is
 empty.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">(3.3)</a></span>
 If <code class="sourceCode cpp">T</code> is a class type …</li>
 </ul>
 </blockquote>
@@ -5045,7 +5052,7 @@ General<a href="#basic.lookup.qual.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">1</a></span>
 Lookup of an <em>identifier</em> followed by a
 <code class="sourceCode cpp"><span class="op">::</span></code> scope
 resolution operator considers only namespaces, types, and templates
@@ -5066,30 +5073,30 @@ Linkage<a href="#basic.link-program-and-linkage" class="self-link"></a></h3>
 <p>Add a bullet to paragraph 13:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">13</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>names</em> an entity <code class="sourceCode cpp"><em>E</em></code>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(13.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a
 <code class="sourceCode cpp"><em>lambda-expression</em></code> whose
 closure type is <code class="sourceCode cpp"><em>E</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(13.1+)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(13.1+)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code>
 contains a reflection that represents either
 <code class="sourceCode cpp"><em>E</em></code> or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> that
 denotes <code class="sourceCode cpp"><em>E</em></code>,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not a function or
 function template and <code class="sourceCode cpp"><em>D</em></code>
 contains an <em>id-expression</em>, <em>type-specifier</em>,
 <em>nested-name-specifier</em>, <em>template-name</em>, or
 <em>concept-name denoting</em>
 <code class="sourceCode cpp"><em>E</em></code>, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">(13.3)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a function or function
 template and <code class="sourceCode cpp"><em>D</em></code> contains an
 expression that names <code class="sourceCode cpp"><em>E</em></code>
@@ -5107,23 +5114,23 @@ also TU-local ]</span></p>
 include reflections:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">16</a></span>
 A value or object is <em>TU-local</em> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(16.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(16.1)</a></span>
 it is, or is a pointer to, a TU-local function or the object associated
 with a TU-local variable, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(16.1a)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(16.1a)</a></span>
 it is a value or object of a TU-local type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(16.1b)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1b)</a></span>
 it is a reflection representing
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1b.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1b.1)</a></span>
 a TU-local value or object, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1b.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.1b.2)</a></span>
 a <code class="sourceCode cpp"><em>typedef-name</em></code>,
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, or
 <code class="sourceCode cpp"><em>base-specifier</em></code> introduced
@@ -5132,7 +5139,7 @@ by an exposure, or</li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">(16.2)</a></span>
 it is an object of class or array type and any of its subobjects or any
 of the objects or functions to which its non-static data members of
 reference type refer is TU-local and is usable in constant
@@ -5146,7 +5153,7 @@ General<a href="#basic.types.general-general" class="self-link"></a></h3>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">9</a></span>
 Arithmetic types (6.8.2), enumeration types, pointer types,
 pointer-to-member types (6.8.4), <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -5159,39 +5166,39 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">12</a></span>
 A <em>consteval-only type</em> is one of the following:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(12.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(12.1)</a></span>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(12.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(12.2)</a></span>
 a pointer or reference to a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(12.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.3)</a></span>
 a (possibly multi-dimensional) array of a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.4)</a></span>
 a class type with a base class or non-static data member of
 consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.5)</a></span>
 a function type with a return type or parameter type of consteval-only
 type, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">(12.6)</a></span>
 a pointer-to-member type to a class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">M</code> where either
 <code class="sourceCode cpp">C</code> or
 <code class="sourceCode cpp">M</code> is a consteval-only type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">13</a></span>
 Every object of consteval-only type shall be</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(13.1)</a></span>
 the object associated with a constexpr variable or a subobject
 thereof,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(13.2)</a></span>
 a template parameter object (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>) or a
 subobject thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(13.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(13.3)</a></span>
 an object whose lifetime begins and ends during the evaluation of a
 manifestly constant-evaluated expression.</li>
 </ul>
@@ -5205,7 +5212,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">17 - 1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">17 - 1</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
@@ -5224,13 +5231,19 @@ reflection</em>; every other reflection is a representation of</p>
 template, alias template, or concept,</li>
 <li>a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>,</li>
-<li>a <code class="sourceCode cpp"><em>base-specifier</em></code>,
-or</li>
-<li>a description of a declaration of a non-static data member.</li>
+<li>a <code class="sourceCode cpp"><em>base-specifier</em></code>,</li>
+<li>a description of a declaration of a non-static data member, or</li>
+<li>an implementation-defined construct not otherwise specified by this
+document.</li>
 </ul>
 <p>An expression convertible to a reflection is said to
 <em>represent</em> the corresponding construct. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
 shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span><span class="dt">void</span><span class="op">*)</span></code>.</p>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>Implementations
+are discouraged from representing any constructs described by this
+document that are not explicitly enumerated in the list above (e.g.,
+partial template specializations, attributes, placeholder types,
+statements).<span> — <em>end note</em> ]</span></span></p>
 </div>
 </blockquote>
 </div>
@@ -5275,7 +5288,7 @@ splicers:</p>
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>,
 or a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">1</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> shall be
 a converted constant expression ([expr.const]) contextually convertible
@@ -5286,7 +5299,7 @@ designates the construct represented by the converted
 dependent if the converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
 value-dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">2</a></span>
 A
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
@@ -5299,30 +5312,30 @@ concept. A
 designates either a type,
 <code class="sourceCode cpp"><em>typedef-name</em></code>, primary class
 template, alias template, or concept.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">3</a></span>
 The form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em></code>
 is interpreted as a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 when</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">(3.1)</a></span>
 it is preceded by
 <code class="sourceCode cpp"><span class="kw">typename</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">(3.2)</a></span>
 it is within a type-only context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">(3.3)</a></span>
 it is followed by
 <code class="sourceCode cpp"><span class="kw">auto</span></code> or
 <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">(3.4)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> is not
 dependent and designates a primary class template or alias
 template.</li>
 </ul>
 <p>In all other cases, it is interpreted as a
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">4</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
 in a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 may only be omitted in a type-only context, or when the
@@ -5363,31 +5376,39 @@ preceded by
 <h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
-<p>Add a carve-out for reflection in <span>7.5.4.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
+<p>Add a carve-out for reflection in <span>7.5.4.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4.
+Adjust the wording to reflect the fact that a
+<code class="sourceCode cpp"><em>reflect-expression</em></code> operand
+is not formally an
+<code class="sourceCode cpp"><em>id-expression</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">4</a></span>
-An <code class="sourceCode cpp"><em>id-expression</em></code> that
-denotes a non-static data member or implicit object member function of a
-class can only be used:</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">4</a></span>
+<span class="rm" style="color: #bf0303"><del>An
+<span><code class="sourceCode default"><em>id-expression</em></code></span>
+that denotes a</del></span> <span class="addu">A</span> non-static data
+member or implicit object member function of a class can only be <span class="rm" style="color: #bf0303"><del>used</del></span> <span class="addu">denoted</span>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">(4.1)</a></span>
 as part of a class member access (after any implicit transformation (see
 above)) in which the object expression refers to the member’s class or a
 class derived from that class, or</li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">(4.2)</a></span>
-as an operand to the reflection operator ([expr.reflect]), or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">(4.2)</a></span>
+by the operand of a
+<code class="sourceCode cpp"><em>reflect-expression</em></code>
+([expr.reflect]), or</li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">(4.3)</a></span>
 to form a pointer to member ([expr.unary.op]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">(4.4)</a></span>
-if that id-expression denotes a non-static data member and it appears in
-an unevaluated operand.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">(4.4)</a></span>
+<span class="rm" style="color: #bf0303"><del>if that</del></span> <span class="addu">by an</span>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="rm" style="color: #bf0303"><del>denotes</del></span> <span class="addu">denoting</span> a non-static data member <span class="rm" style="color: #bf0303"><del>and it appears</del></span> in an
+unevaluated operand.</li>
 </ul>
 </blockquote>
 </div>
@@ -5416,14 +5437,14 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">0</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 either is dependent or designates a type,
 <code class="sourceCode cpp"><em>typedef-name</em></code>, namespace, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">1</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-id</em></code> are […]</p>
 </blockquote>
@@ -5432,7 +5453,7 @@ The component names of a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -5460,7 +5481,7 @@ being redeclared or specialized.</p>
 “designate” over “nominate”:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">3</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <code class="sourceCode cpp"><span class="op">::</span></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
@@ -5495,32 +5516,32 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <p><strong>Expression Splicing [expr.prim.splice]</strong></p>
 <div class="sourceCode" id="cb108"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
 <span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">1</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>
 designates either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(1.1)</a></span>
 a value or object,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(1.2)</a></span>
 a variable,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(1.3)</a></span>
 a structured binding,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(1.4)</a></span>
 a function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(1.5)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(1.6)</a></span>
 a non-static data member.</li>
 </ul>
 <p>The <code class="sourceCode cpp"><em>splice-specifier</em></code>
 shall not designate an unnamed bit-field, a constructor, or a
 destructor.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">2</a></span>
 Let <code class="sourceCode cpp"><em>E</em></code> be the construct
 designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(2.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(2.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an object, a
 function, or a non-static data member, the expression is an lvalue
 designating <code class="sourceCode cpp"><em>E</em></code>. The
@@ -5528,7 +5549,7 @@ expression has the same type as
 <code class="sourceCode cpp"><em>E</em></code>, and is a bit-field if
 and only if <code class="sourceCode cpp"><em>E</em></code> is a
 bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(2.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(2.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>E</em></code> is a
 variable or a structured binding, the expression is an lvalue
 designating the object associated with
@@ -5536,7 +5557,7 @@ designating the object associated with
 same type as <code class="sourceCode cpp"><em>E</em></code>, and is a
 bit-field if and only if <code class="sourceCode cpp"><em>E</em></code>
 is a bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">(2.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>E</em></code> shall be a
 value or an enumerator. The expression is a prvalue whose evaluation
 computes <code class="sourceCode cpp"><em>E</em></code> and whose type
@@ -5577,7 +5598,7 @@ expressions. Prefer the word “possibly” to “optionally” since
 cannot precede a <code class="sourceCode cpp">splice<span class="op">-</span>expression</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -5602,7 +5623,7 @@ and is followed by a
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">2</a></span>
 <span class="rm" style="color: #bf0303"><del>For the first
 option,</del></span> <span class="rm" style="color: #bf0303"><del>if</del></span><span class="addu">If</span>
 the <span class="addu">dot is followed by an</span>
@@ -5623,7 +5644,7 @@ the remainder of [expr.ref] will address only <span class="rm" style="color: #bf
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">3</a></span>
 The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or splicer</span>, determines the result of the entire
@@ -5634,7 +5655,7 @@ postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">4</a></span>
 Abbreviating <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>postfix-expression</em></code></span>.<span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span>EXPR</code>,
 where <code class="sourceCode cpp">EXPR</code> is the
@@ -5648,11 +5669,11 @@ following the dot,</span> as
 <p>Adjust the language in paragraphs 6-9 to account for splicers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">7</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is declared to have type
 “reference to <code class="sourceCode cpp">T</code>”, then
@@ -5667,13 +5688,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(7.2)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
 <code class="sourceCode cpp">X</code>”, and the type of
@@ -5694,11 +5715,11 @@ member, then the type of
 </ul>
 <p>[…]</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(7.4)</a></span>
 If <code class="sourceCode cpp">E</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(7.5)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, the expression
@@ -5706,14 +5727,14 @@ If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">8</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static member <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>, the
 program is ill-formed if the class of which <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>
 is directly a member is an ambiguous base ([class.member.lookup]) of the
 naming class ([class.access.base]) of <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -5727,7 +5748,7 @@ General<a href="#expr.unary.general-general" class="self-link"></a></h3>
 paragraph 1 to add productions for the new operator:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb110"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -5744,13 +5765,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -5760,7 +5781,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -5771,7 +5792,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -5794,17 +5815,17 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a>   ^ <em>qualified-id</em></span>
 <span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
 <span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>pack-index-expression</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">2</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 parsed as the longest possible sequence of tokens that could
 syntactically form a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb112"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
@@ -5822,11 +5843,11 @@ syntactically form a
 <span id="cb112-13"><a href="#cb112-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">4</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
 the form <code class="sourceCode cpp"><span class="op">^</span> <span class="op">::</span></code>
 produces a reflection of the global namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">5</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
 the form <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>
 or <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>
@@ -5834,33 +5855,40 @@ performs name lookup for the operand following
 <code class="sourceCode cpp"><span class="op">^</span></code> and
 produces a result as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(5.1)</a></span>
-If lookup finds an overload set
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(5.1)</a></span>
+If the lookup finds an overload set
 <code class="sourceCode cpp"><em>S</em></code> such that the assignment
-of <code class="sourceCode cpp"><em>S</em></code> to an invented
-variable of type <code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
+of
+<code class="sourceCode cpp"><span class="op">&amp;</span><em>S</em></code>
+to an invented variable of type <code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
 (<span>9.2.9.7.2 <a href="https://wg21.link/dcl.type.auto.deduct">[dcl.type.auto.deduct]</a></span>)
 would select a unique candidate function
 <code class="sourceCode cpp"><em>F</em></code> from
 <code class="sourceCode cpp"><em>S</em></code>, then the result is a
-reflection of <code class="sourceCode cpp"><em>F</em></code>. If lookup
-finds any other overload set, the program is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(5.2)</a></span>
-Otherwise, if lookup finds a
+reflection of <code class="sourceCode cpp"><em>F</em></code>. If the
+lookup finds any other overload set, the program is ill-formed.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(5.2)</a></span>
+Otherwise, if the lookup finds a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or a
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
 result is a reflection of the indicated name.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(5.3)</a></span>
-Otherwise, if lookup finds a non-type template parameter, the result is
-a reflection of the result computed by an
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(5.3)</a></span>
+Otherwise, if the lookup finds a non-type template parameter, then the
+result is a reflection of the result computed by an
 <code class="sourceCode cpp"><em>id-expression</em></code> naming the
 parameter.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(5.4)</a></span>
-Otherwise, if lookup finds a variable, structured binding, function,
-enumerator, type, non-static member, template, or namespace, the result
-is a reflection of the denoted entity.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(5.4)</a></span>
+Otherwise, if the lookup finds a variable, structured binding, function,
+enumerator, type, non-static member, template, or namespace, then the
+result is a reflection of the denoted entity.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(5.5)</a></span>
+Otherwise, if the lookup finds an implementation-defined construct not
+otherwise specified by this document, then the implementation may
+produce a reflection of the denoted construct.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(5.6)</a></span>
+Otherwise, the program is ill-formed.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">6</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form
 <code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
@@ -5875,7 +5903,7 @@ that could be validly interpreted as <code class="sourceCode cpp"><span class="o
 or
 <code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
 is interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">7</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
 the form <code class="sourceCode cpp"><span class="op">^</span> <em>pack-index-expression</em></code>
 produces a reflection of the result computed by the
@@ -5901,7 +5929,7 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
 pointer-to-member type, <span class="addu">type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>.
@@ -5919,26 +5947,26 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between <span>7.6.10 <a href="https://wg21.link/expr.eq">[expr.eq]</a></span>/5 and /6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">5</a></span>
 Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">*</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(*.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(*.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(*.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(*.2)</a></span>
 Otherwise, if one operand represents a
 <code class="sourceCode cpp"><em>template-id</em></code> referring to a
 specialization of an alias template, then they compare equal if and only
 if the other operand represents the same
 <code class="sourceCode cpp"><em>template-id</em></code>
 ([temp.type]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(*.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(*.3)</a></span>
 Otherwise, if one operand represents a
 <code class="sourceCode cpp"><em>namespace-alias</em></code> or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then they
@@ -5946,22 +5974,22 @@ compare equal if and only if the construct represented by the other
 operand represents the same kind of construct, shares the same name, is
 declared within the same enclosing scope, and aliases the same
 underlying entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(*.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(*.4)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a template-argument-equivalent
 value (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(*.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(*.5)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(*.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(*.6)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(*.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(*.7)</a></span>
 Otherwise, if one operand represents a
 <code class="sourceCode cpp"><em>base-specifier</em></code>, then they
 compare equal if and only if the other operand represents the same
 <code class="sourceCode cpp"><em>base-specifier</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(*.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(*.8)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -5981,7 +6009,7 @@ any), <code class="sourceCode cpp"><em>alignment-specifiers</em></code>
 (if any), width, and attributes.</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -6002,40 +6030,40 @@ Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3
 and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">15</a></span>
 A <em>constant-expression</em> is either a glvalue core constant
 expression that <span class="addu"> </span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(15.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(15.1)</a></span>
 refers to an entity that is a permitted result of a constant
 expression<span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(15.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(15.2)</a></span>
 is of consteval-only type if the entity designated by the expression is
 of consteval-only type,</span></li>
 </ul>
 <p>or a prvalue core constant expression whose value satisfies the
 following constraints:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(15.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(15.3)</a></span>
 if the value is an object of class type, each non-static data member of
 reference type refers to an entity that is a permitted result of a
 constant expression <span class="addu">and has consteval-only type if
 the entity has consteval-only type</span>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(15.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(15.4)</a></span>
 if the value is an object of scalar type, it does not have an
 indeterminate or erroneous value ([basic.indet]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(15.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(15.5)</a></span>
 if the value is of pointer type, it is a pointer to an object of static
 storage duration, a pointer past the end of such an object ([expr.add]),
 a pointer to a non-immediate function, or a null pointer value,</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(15.6)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(15.6)</a></span>
 if the value is a pointer to an object of consteval-only type, or a
 pointer past the end of such an object, then the prvalue is also of
 consteval-only type,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(15.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(15.7)</a></span>
 if the value is of pointer-to-member-function type, it does not
 designate an immediate function, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(15.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(15.8)</a></span>
 if the value is an object of class or array type, each subobject
 satisfies these constraints for the value.</li>
 </ul>
@@ -6045,23 +6073,23 @@ satisfies these constraints for the value.</li>
 to also apply to expressions of consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">18</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it <span class="rm" style="color: #bf0303"><del>is</del></span> either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(18.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(18.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">is an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> that denotes
 an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that is not a subexpression of an immediate
 invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(18.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(18.2)</a></span>
 <span class="addu">is</span> an immediate invocation that is not a
 constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(18.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(18.3)</a></span>
 has consteval-only type ([basic.types.general]).</span></li>
 </ul>
 </blockquote>
@@ -6072,41 +6100,41 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">20</a></span>
 An expression or conversion is <em>in substitution context</em> if it
 results from the substitution of template parameters</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(20.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(20.1)</a></span>
 during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(20.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(20.2)</a></span>
 in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(20.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(20.3)</a></span>
 in a <code class="sourceCode cpp"><em>requires-expression</em></code>
 (<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">21</a></span>
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code> that
 is not in substitution context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(21.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(21.4)</a></span>
 an immediate invocation, unless it is
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(21.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(21.4.1)</a></span>
 in substitution context, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(21.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(21.4.2)</a></span>
 within the body of an immediate-escalating function that contains an
 immediate-escalating expression.</li>
 </ul></li>
@@ -6148,22 +6176,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">22</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(22.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(22.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(22.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(22.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(22.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(22.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(22.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(22.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6186,7 +6214,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">23</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6200,12 +6228,12 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">24</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(24.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
 constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
@@ -6251,7 +6279,7 @@ once.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb115-27"><a href="#cb115-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6260,11 +6288,11 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> ([intro.execution]).</li>
@@ -6280,7 +6308,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 paragraph 3.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">3</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>typedef-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6309,7 +6337,7 @@ follows:</p>
 after nested name specifiers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>simple-type-specifier</em></code> are
 those of its
@@ -6333,7 +6361,7 @@ shall not contain a splicer.</span></p>
 be a placeholder for a deduced class type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -6444,45 +6472,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6490,7 +6518,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6499,26 +6527,26 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
 type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -6527,7 +6555,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -6541,7 +6569,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator ([expr.reflect])</span>, is ill-formed.</p>
@@ -6568,7 +6596,7 @@ follows:</p>
 <p>Modify paragraph 1 to handle splicers:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">1</a></span>
 <span class="addu">A <code class="sourceCode cpp"><span class="kw">using</span><span class="op">-</span><span class="kw">enum</span><span class="op">-</span>declarator</code>
 of the form
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6603,7 +6631,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">0</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code>
 appearing in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
@@ -6616,7 +6644,7 @@ shall designate a namespace or
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6645,7 +6673,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
 any, designates a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>. Neither
@@ -6653,7 +6681,7 @@ the <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 nor the <code class="sourceCode cpp"><em>splice-specifier</em></code>
 shall be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6717,7 +6745,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6742,7 +6770,7 @@ Global module fragment<a href="#module.global.frag-global-module-fragment" class
 <blockquote>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -6751,7 +6779,7 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
@@ -6759,7 +6787,7 @@ does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template is replaced by its
 denoted type prior to this determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(3.8)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -6770,23 +6798,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6820,7 +6848,7 @@ names<a href="#class.name-class-names" class="self-link"></a></h3>
 <p>Cover `$splice-type-specifier$s in paragraph 5.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">5</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>class-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6835,7 +6863,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6861,7 +6889,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.class.deduct]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6871,7 +6899,7 @@ When resolving a placeholder for a deduced class type
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -6880,7 +6908,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">3</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.simple]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6901,7 +6929,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -6930,7 +6958,7 @@ form <code class="sourceCode cpp"><em>type-constraint</em></code>s.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">3+</a></span>
 A non-dependent
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
 forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
@@ -6983,7 +7011,7 @@ leverage splicers.</p>
 component name.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">2</a></span>
 The component name of a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>simple-template-id</em></code></span>,
 <span><code class="sourceCode default"><em>template-id</em></code></span>,
 or</del></span>
@@ -7001,31 +7029,31 @@ its <code class="sourceCode cpp"><em>simple-template-id</em></code>,
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows <span class="addu">either</span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.1)</a></span>
 a
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -7064,7 +7092,7 @@ containing
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or splicer</span> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a constrained non-function template or a
@@ -7080,7 +7108,7 @@ non-dependent ([temp.dep.temp]), the associated contraints
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">9</a></span>
 A <em>concept-id</em> is a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> where
 <span class="addu">either</span> the
@@ -7105,7 +7133,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">3</a></span>
 In a <code class="sourceCode cpp"><em>template-argument</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>, an
@@ -7138,7 +7166,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -7159,7 +7187,7 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
@@ -7168,11 +7196,11 @@ for the variable x in the invented declaration</p>
 <div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">2</a></span>
 The value of a non-type <em>template-parameter</em>
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">3</a></span>
 Otherwise, a temporary variable</p>
 <div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
@@ -7184,7 +7212,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be <span class="rm" style="color: #bf0303"><del>the name
@@ -7203,7 +7231,7 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 equivalence as defined by paragraph 1 to cover splicers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s are the
 same if</p>
 <ul>
@@ -7230,23 +7258,23 @@ are the same refer to the same class, function, or variable.</p>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7258,7 +7286,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -7274,7 +7302,7 @@ the class template are considered.</p>
 cannot themselves appear in deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">3</a></span>
 The same restrictions apply to the
 <code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
 of a deduction guide as in a function declaration ([dcl.fct]), except
@@ -7304,7 +7332,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -7326,7 +7354,7 @@ splicers can’t follow
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">3</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>typename-specifier</em></code> are its
 <code class="sourceCode cpp"><em>identifier</em></code> (if any) and
@@ -7365,17 +7393,17 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is type-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(9.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(9.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7391,10 +7419,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -7418,17 +7446,17 @@ dependent name, names a dependent type, or contains a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is value-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(6.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(6.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7446,7 +7474,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -7464,19 +7492,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7489,7 +7517,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7497,7 +7525,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7506,14 +7534,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7603,9 +7631,9 @@ Comments
 </td>
 </tr>
 </table>
-<h3 class="unnumbered" id="meta.synop-header-meta-synopsis">[meta.synop]
+<h3 class="unnumbered" id="meta.reflection.synop-header-meta-synopsis">[meta.reflection.synop]
 Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
-synopsis<a href="#meta.synop-header-meta-synopsis" class="self-link"></a></h3>
+synopsis<a href="#meta.reflection.synop-header-meta-synopsis" class="self-link"></a></h3>
 <p>Add a new subsection in <span>21 <a href="https://wg21.link/meta">[meta]</a></span> after <span>21.3 <a href="https://wg21.link/type.traits">[type.traits]</a></span>:</p>
 <div class="std">
 <blockquote>
@@ -7959,10 +7987,17 @@ synopsis</strong></p>
 <span id="cb137-345"><a href="#cb137-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb137-346"><a href="#cb137-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb137-347"><a href="#cb137-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">2</a></span>
+Values of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
+may represent implementation-defined constructs not otherwise specified
+by this document (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).
+The behavior of any function specified by this section is
+implementation-defined when a reflection representing such a construct
+is provided as an argument.</p>
 </div>
 </blockquote>
 </div>
@@ -7975,7 +8010,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -8228,10 +8263,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -8239,11 +8274,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -8258,33 +8293,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -8293,24 +8328,24 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8319,44 +8354,44 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
 identifier introduced by the declaration of what is represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8368,21 +8403,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -8400,7 +8435,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -8408,7 +8443,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -8416,7 +8451,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8424,7 +8459,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -8432,7 +8467,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8441,7 +8476,7 @@ defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8449,7 +8484,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8464,7 +8499,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8482,7 +8517,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8492,7 +8527,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -8500,7 +8535,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8509,7 +8544,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8518,7 +8553,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -8528,7 +8563,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -8539,7 +8574,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8548,13 +8583,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8564,13 +8599,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8579,20 +8614,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8600,7 +8635,7 @@ of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8612,7 +8647,7 @@ instantiation of an alias template is a
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8620,7 +8655,7 @@ instantiation of an alias template is a
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8635,7 +8670,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8645,14 +8680,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8669,7 +8704,7 @@ is
 <span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8678,7 +8713,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8687,14 +8722,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8705,7 +8740,7 @@ Otherwise,
 <span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8713,20 +8748,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8735,11 +8770,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8755,33 +8790,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8797,7 +8832,7 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or
@@ -8805,18 +8840,18 @@ member, bit-field, template, namespace or
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> <em>A</em>,
 then a reflection representing the entity named by <em>A</em>.
 Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8828,15 +8863,15 @@ Otherwise, <code class="sourceCode cpp">r</code>.</p>
 </div>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8858,11 +8893,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8881,7 +8916,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8892,11 +8927,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8910,14 +8945,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8927,92 +8962,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -9027,32 +9062,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9061,7 +9096,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -9074,7 +9109,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -9083,20 +9118,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -9104,7 +9139,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9113,7 +9148,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -9126,32 +9161,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -9159,7 +9194,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -9167,7 +9202,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -9175,52 +9210,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -9238,36 +9273,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -9279,32 +9314,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -9312,37 +9347,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -9355,18 +9390,18 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9387,71 +9422,71 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -9461,7 +9496,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -9469,7 +9504,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9477,7 +9512,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -9494,18 +9529,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -9519,7 +9554,7 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9531,26 +9566,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -9563,29 +9598,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9597,18 +9632,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9618,10 +9653,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9642,7 +9677,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9664,7 +9699,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb217-13"><a href="#cb217-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb217-14"><a href="#cb217-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb217-15"><a href="#cb217-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb218"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9690,7 +9725,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9712,7 +9747,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9722,7 +9757,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9733,7 +9768,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9819,12 +9854,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9836,10 +9871,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9848,7 +9883,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9860,7 +9895,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9889,7 +9924,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb223-15"><a href="#cb223-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb223-16"><a href="#cb223-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9911,7 +9946,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9923,7 +9958,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9944,7 +9979,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9962,7 +9997,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9979,7 +10014,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9996,7 +10031,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -10023,7 +10058,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -10031,7 +10066,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -10041,7 +10076,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -10063,7 +10098,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -10085,7 +10120,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -10093,7 +10128,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -10117,7 +10152,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -10125,27 +10160,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-11-13" />
+  <meta name="dcterms.date" content="2024-11-14" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-11-13</td>
+    <td>2024-11-14</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -6186,12 +6186,18 @@ declarations are reachable at a point immediately following
 <span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
 <span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
 <span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="dv">1</span>; <span class="op">}</span></span>
 <span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// &#39;cfn(1)&#39; is plainly constant-evaluated.</span></span>
-<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;      <span class="co">// &#39;cfn(2)&#39; is not plainly constant-evaluated.</span></span>
-<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>b1<span class="op">)</span>;           <span class="co">// &#39;b1&#39; is plainly constant-evaluated.</span></span></code></pre></div>
+<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> b1 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;            <span class="co">// &#39;cfn(1)&#39; is plainly constant-evaluated</span></span>
+<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="kw">constinit</span> <span class="dt">int</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// &#39;cfn(2)&#39; is plainly constant-evaluated</span></span>
+<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">int</span> b3 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">3</span><span class="op">)</span>;                <span class="co">// &#39;cfn(3)&#39; is not plainly constant-evaluated</span></span>
+<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>b1 <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span>;                <span class="co">// &#39;b1 &gt; 0&#39; is plainly constant-evaluated</span></span>
+<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Cls <span class="op">{</span></span>
+<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">int</span> var <span class="op">=</span> cfn<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;  <span class="co">// &#39;cfn(4)&#39; is plainly constant-evaluated</span></span>
+<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> arr<span class="op">[</span>cfn<span class="op">(</span><span class="dv">5</span><span class="op">)]</span>;                    <span class="co">// &#39;cfn(5)&#39; is not plainly constant-evaluated</span></span>
+<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-11-05" />
+  <meta name="dcterms.date" content="2024-11-08" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-11-05</td>
+    <td>2024-11-08</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -767,14 +767,16 @@ Linkage<span></span></a></li>
 <li><a href="#basic.fundamental-fundamental-types" id="toc-basic.fundamental-fundamental-types"><span>6.8.2
 <span>[basic.fundamental]</span></span> Fundamental
 types<span></span></a></li>
+<li><a href="#conv.ptr-pointer-conversions" id="toc-conv.ptr-pointer-conversions"><span>7.3.12
+<span>[conv.ptr]</span></span> Pointer conversions<span></span></a></li>
 <li><a href="#expr.prim-primary-expressions" id="toc-expr.prim-primary-expressions"><span>7.5
 <span>[expr.prim]</span></span> Primary
 expressions<span></span></a></li>
 <li><a href="#expr.prim.id.splice-splice-specifiers" id="toc-expr.prim.id.splice-splice-specifiers">7.5.4.0*
 [expr.prim.id.splice] Splice specifiers<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
@@ -1013,7 +1015,7 @@ Aliases”</a> section.</li>
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
 <li>removed <code class="sourceCode cpp">subobjects_of</code> and
 <code class="sourceCode cpp">accessible_subobjects_of</code> (will be
-reintroduced by <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>).</li>
+reintroduced by <span class="citation" data-cites="P3293R1">[<a href="#ref-P3293R1" role="doc-biblioref"><strong>P3293R1?</strong></a>]</span>).</li>
 <li>specified constraints for
 <code class="sourceCode cpp">enumerators_of</code> in terms of
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
@@ -1932,7 +1934,7 @@ initialize members of a defined union using a splicer, as in:</p>
 </blockquote>
 </div>
 <p>Arguably, the answer should be yes - this would be consistent with
-how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>.</p>
+how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="#ref-P3293R1" role="doc-biblioref"><strong>P3293R1?</strong></a>]</span>.</p>
 <p>On Compiler Explorer: <a href="https://godbolt.org/z/Efz5vsjaa">EDG</a>, <a href="https://godbolt.org/z/3bvo97fqf">Clang</a>.</p>
 <h2 data-number="3.10" id="struct-to-struct-of-arrays"><span class="header-section-number">3.10</span> Struct to Struct of Arrays<a href="#struct-to-struct-of-arrays" class="self-link"></a></h2>
 <div class="std">
@@ -5022,25 +5024,26 @@ If <code class="sourceCode cpp">T</code> is a class type …</li>
 General<a href="#basic.lookup.qual.general-general" class="self-link"></a></h3>
 <p>FIXME. Have to handle splices in here, because they’re not actually
 “component names”. Now
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
+<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>
 is only a namespace too.</p>
 <p>Extend <span>6.5.5.1 <a href="https://wg21.link/basic.lookup.qual.general">[basic.lookup.qual.general]</a></span>/1-2
 to cover
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>:</p>
+<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">1</a></span>
 Lookup of an <em>identifier</em> followed by a
-​<code class="sourceCode cpp"><span class="op">::</span></code>​ scope
+<code class="sourceCode cpp"><span class="op">::</span></code> scope
 resolution operator considers only namespaces, types, and templates
 whose specializations are types. If a name,
 <code class="sourceCode cpp"><em>template-id</em></code>, <span class="rm" style="color: #bf0303"><del>or</del></span>
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code><span class="addu">, or
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code></span>
+<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code></span>
 is followed by a
-​<code class="sourceCode cpp"><span class="op">::</span></code>​, it shall
-designate a namespace, class, enumeration, or dependent type, and the ​::​
-is never interpreted as a complete nested-name-specifier.</p>
+<code class="sourceCode cpp"><span class="op">::</span></code>, it shall
+designate a namespace, class, enumeration, or dependent type, and the
+<code class="sourceCode cpp"><span class="op">::</span></code> is never
+interpreted as a complete nested-name-specifier.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">2</a></span>
 A member-qualified name is the (unique) component name
 ([expr.prim.id.unqual]), if any, of</p>
@@ -5050,7 +5053,7 @@ an <em>unqualified-id</em> or</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(2.2)</a></span>
 a <code class="sourceCode cpp"><em>nested-name-specifier</em></code> of
 the form <code class="sourceCode cpp"><em>type-name</em> <span class="op">::</span></code>
-<span class="rm" style="color: #bf0303"><del>or</del></span><span class="addu">,</span> <code class="sourceCode cpp"><em>namespace-name</em> <span class="op">::</span></code><span class="addu">, or <code class="sourceCode cpp"><em>splice-namespace-qualifier</em> <span class="op">::</span></code></span></li>
+<span class="rm" style="color: #bf0303"><del>or</del></span><span class="addu">,</span> <code class="sourceCode cpp"><em>namespace-name</em> <span class="op">::</span></code><span class="addu">, or <code class="sourceCode cpp"><em>splice-namespace-specifier</em> <span class="op">::</span></code></span></li>
 </ul>
 <p>in the <em>id-expression</em> of a class member access expression
 ([expr.ref]). […]</p>
@@ -5072,7 +5075,7 @@ if</p>
 <code class="sourceCode cpp"><em>E</em></code>,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">(13.1+)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code>
-contains an expression that represents either
+contains a reflection that represents either
 <code class="sourceCode cpp"><em>E</em></code> or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> that
@@ -5152,29 +5155,42 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">12</a></span>
 A <em>consteval-only type</em> is one of the following:</p>
 <ul>
-<li><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.1)</a></span>
+<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 or</li>
-<li>a pointer or reference to a consteval-only type, or</li>
-<li>an (possibly multi-dimensional) array of a consteval-only type,
-or</li>
-<li>a class type with a base class or non-static data member of
-consteval-only type, or</li>
-<li>a function type with a return type or parameter type of
-consteval-only type, or</li>
-<li>a pointer-to-member type to a class
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.2)</a></span>
+a pointer or reference to a consteval-only type,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.3)</a></span>
+an (possibly multi-dimensional) array of a consteval-only type,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">(12.4)</a></span>
+a class type with a base class or non-static data member of
+consteval-only type,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(12.5)</a></span>
+a function type with a return type or parameter type of consteval-only
+type, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(12.6)</a></span>
+a pointer-to-member type to a class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">M</code> where either
 <code class="sourceCode cpp">C</code> or
 <code class="sourceCode cpp">M</code> is a consteval-only type.</li>
 </ul>
-<p>An object of consteval-only type shall either end its lifetime during
-the evaluation of a manifestly constant-evaluated expression or
-conversion (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>), or be a
-constexpr variable for which every expression that names the variable is
-within an immediate function context.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">13</a></span>
+Every object of consteval-only type shall either be</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(13.1)</a></span>
+the object associated with a constexpr variable or a subobject
+thereof,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">(13.2)</a></span>
+a template parameter object (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>) or a
+subobject thereof, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">(13.3)</a></span>
+an object whose lifetime begins and ends during the evaluation of a
+manifestly constant-evaluated expression.</li>
+</ul>
 </div>
 </blockquote>
 </div>
@@ -5185,7 +5201,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">17 - 1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">17 - 1</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
@@ -5212,6 +5228,54 @@ class specifier, or description of a declaration of a non-static data
 member. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
 shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span><span class="dt">void</span><span class="op">*)</span></code>.</p>
 </div>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="conv.ptr-pointer-conversions"><span>7.3.12 <a href="https://wg21.link/conv.ptr">[conv.ptr]</a></span> Pointer
+conversions<a href="#conv.ptr-pointer-conversions" class="self-link"></a></h3>
+<p>Expand paragraph 2 to disallow conversions to <code class="sourceCode cpp"><span class="dt">void</span> <span class="op">*</span></code>
+from pointers of consteval-only types.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">2</a></span>
+A prvalue of type “pointer to
+<code class="sourceCode cpp"><em>cv</em> T</code>”, where
+<code class="sourceCode cpp">T</code> is an object type, can be
+converted to a prvalue of type “pointer to
+<code class="sourceCode cpp"><em>cv</em> <span class="dt">void</span></code>”.
+The pointer value ([basic.compound]) is unchanged by this conversion.
+<span class="addu">If <code class="sourceCode cpp">T</code> is a
+consteval-only type ([basic.types.general]), a program that necessitates
+this conversion is ill-formed.</span></p>
+</blockquote>
+</div>
+<p>Expand paragraph 3 to also disallow conversions from pointers of
+consteval-only type to pointers to base classes that are not of
+consteval-only type.</p>
+<div class="std">
+<blockquote>
+<p>A prvalue <code class="sourceCode cpp">v</code> of type “pointer to
+<code class="sourceCode cpp"><em>cv</em> D</code>”, where
+<code class="sourceCode cpp">D</code> is a complete class type, can be
+converted to a prvalue of type “pointer to
+<code class="sourceCode cpp"><em>cv</em> B</code>”, where
+<code class="sourceCode cpp">B</code> is a base class ([class.derived])
+of <code class="sourceCode cpp">D</code>. If
+<code class="sourceCode cpp">B</code> is an inaccessible
+([class.access]) or ambiguous ([class.member.lookup]) base class of
+<code class="sourceCode cpp">D</code>, <span class="addu">or if
+<code class="sourceCode cpp">D</code> is of consteval-only type
+([basic.types.general]) and <code class="sourceCode cpp">B</code> is
+not,</span> a program that necessitates this conversion is ill-formed.
+If <code class="sourceCode cpp">v</code> is a null pointer value, the
+result is a null pointer value. Otherwise, if
+<code class="sourceCode cpp">B</code> is a virtual base class of
+<code class="sourceCode cpp">D</code> and
+<code class="sourceCode cpp">v</code> does not point to an object whose
+type is similar ([conv.qual]) to <code class="sourceCode cpp">D</code>
+and that is within its lifetime or within its period of construction or
+destruction ([class.dtor]), the behavior is undefined. Otherwise, the
+result is a pointer to the base class subobject of the derived class
+object.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="expr.prim-primary-expressions"><span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> Primary
@@ -5244,17 +5308,17 @@ as follows:</p>
 <div class="addu">
 <div class="sourceCode" id="cb105"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a><em>splice-specifier</em>:</span>
 <span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">1</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> shall be
 a converted constant expression ([expr.const]) contextually convertible
 to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">2</a></span>
 Let <code class="sourceCode cpp">E</code> be the value of the converted
 <code class="sourceCode cpp"><em>constant-expression</em></code>. The
 <code class="sourceCode cpp"><em>splice-specifier</em></code> designates
 what <code class="sourceCode cpp">E</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">3</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if the converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
@@ -5262,38 +5326,38 @@ value-dependent.</p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
-<p>Add a carve-out for reflection in <span>7.5.5.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
+<p>Add a carve-out for reflection in <span>7.5.4.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">4</a></span>
 An <code class="sourceCode cpp"><em>id-expression</em></code> that
 denotes a non-static data member or implicit object member function of a
 class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">(4.1)</a></span>
 as part of a class member access (after any implicit transformation (see
 above)) in which the object expression refers to the member’s class or a
 class derived from that class, or</li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(4.2)</a></span>
 as an operand to the reflection operator ([expr.reflect]), or</li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">(4.3)</a></span>
 to form a pointer to member ([expr.unary.op]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">(4.4)</a></span>
 if that id-expression denotes a non-static data member and it appears in
 an unevaluated operand.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Add a production to the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -5305,28 +5369,28 @@ follows:</p>
 <span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
 <span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
 <span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
-<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-qualifier</em> ::</span></span>
+<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-specifier</em> ::</span></span>
 <span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
 <span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
 <span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span>
 <span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-qualifier</em>:</span></span>
+<span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-specifier</em>:</span></span>
 <span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
 <p>Add a new paragraph restricting
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>,
+<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>,
 and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
+<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>
 shall designate a namespace or namespace alias.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">1</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-id</em></code> are […]</p>
 </blockquote>
@@ -5335,7 +5399,7 @@ The component names of a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -5362,7 +5426,7 @@ being redeclared or specialized.</p>
 “designate” over “nominate”:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">4</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <code class="sourceCode cpp">​<span class="op">::</span></code>​ <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
@@ -5373,11 +5437,9 @@ a <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
 which shall be a class or enumeration type. <span class="addu">A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
 a
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>
-<span class="rm" style="color: #bf0303"><del>nominates</del></span>
-<span class="addu">designates</span> the same namespace or namespace
-alias as the
-<code class="sourceCode cpp"><em>splice-namespace-qualifier</em></code>.</span>
+<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>
+designates the same namespace or namespace alias as the
+<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>.</span>
 If a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <em>N</em> is declarative and has a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> with a
@@ -5390,7 +5452,7 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -5399,18 +5461,18 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <div class="sourceCode" id="cb107"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
 <span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
 <span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">1</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 not designate an unnamed bit-field, a constructor or destructor, or a
 constructor template or destructor template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 let <code class="sourceCode cpp"><em>E</em></code> be the object, value,
 or entity designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">(2.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(2.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an object, a
 function, or a non-static data member, the expression is an lvalue
 designating <code class="sourceCode cpp"><em>E</em></code>. The
@@ -5418,7 +5480,7 @@ expression has the same type as
 <code class="sourceCode cpp"><em>E</em></code>, and is a bit-field if
 and only if <code class="sourceCode cpp"><em>E</em></code> is a
 bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">(2.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(2.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>E</em></code> is a
 variable or a structured binding, the expression is an lvalue
 designating the same object as
@@ -5426,7 +5488,7 @@ designating the same object as
 same type as <code class="sourceCode cpp"><em>E</em></code>, and is a
 bit-field if and only if <code class="sourceCode cpp"><em>E</em></code>
 is a bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(2.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>E</em></code> shall be a
 value or an enumerator. The expression is a prvalue whose evaluation
 computes <code class="sourceCode cpp"><em>E</em></code> and whose type
@@ -5463,7 +5525,7 @@ access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -5487,7 +5549,7 @@ note</em> ]</span></span></p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">2</a></span>
 For the first option, if the <span class="addu">dot is followed by
 an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or
@@ -5510,7 +5572,7 @@ the remainder of [expr.ref] will address only the first option
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">3</a></span>
 The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -5522,7 +5584,7 @@ determines the result of the entire postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">4</a></span>
 Abbreviating <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>postfix-expression</em></code></span>.<span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span>EXPR</code>,
 where <code class="sourceCode cpp">EXPR</code> is the
@@ -5538,11 +5600,11 @@ the dot,</span> as
 splice-specifiers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">7</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is declared to have type
 “reference to <code class="sourceCode cpp">T</code>”, then
@@ -5557,13 +5619,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">(7.2)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
 <code class="sourceCode cpp">X</code>”, and the type of
@@ -5584,11 +5646,11 @@ member, then the type of
 </ul>
 <p>[…]</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">(7.4)</a></span>
 If <code class="sourceCode cpp">E</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(7.5)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, the expression
@@ -5596,14 +5658,14 @@ If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">8</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static member <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>, the
 program is ill-formed if the class of which <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>
 is directly a member is an ambiguous base ([class.member.lookup]) of the
 naming class ([class.access.base]) of <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -5617,7 +5679,7 @@ General<a href="#expr.unary.general-general" class="self-link"></a></h3>
 paragraph 1 to add productions for the new operator:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb109"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -5634,13 +5696,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -5650,7 +5712,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -5661,7 +5723,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -5689,16 +5751,16 @@ template argument parsing section.</p>
 <span id="cb110-5"><a href="#cb110-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
 <span id="cb110-6"><a href="#cb110-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
 <span id="cb110-7"><a href="#cb110-7" aria-hidden="true" tabindex="-1"></a>   ^ <em>id-expression</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">2</a></span>
 A <em>reflect-expression</em> is parsed as the longest possible sequence
 of tokens that could syntactically form a
 <em>reflect-expression</em>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
@@ -5716,7 +5778,7 @@ of tokens that could syntactically form a
 <span id="cb111-13"><a href="#cb111-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">4</a></span>
 When applied to
 <code class="sourceCode cpp"><span class="op">::</span></code>, the
 reflection operator produces a reflection for the global namespace. When
@@ -5724,31 +5786,31 @@ applied to a
 <code class="sourceCode cpp"><em>namespace-name</em></code>, the
 reflection operator produces a reflection for the indicated namespace or
 namespace alias.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">5</a></span>
 When applied to a
 <code class="sourceCode cpp"><em>template-name</em></code>, the
 reflection operator produces a reflection for the indicated
 template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">6</a></span>
 When applied to a
 <code class="sourceCode cpp"><em>concept-name</em></code>, the
 reflection operator produces a reflection for the indicated concept.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">7</a></span>
 When applied to a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, the
 reflection operator produces a reflection of the indicated
 <code class="sourceCode cpp"><em>typedef-name</em></code>. When applied
 to any other <code class="sourceCode cpp"><em>type-id</em></code>, the
 reflection operator produces a reflection of the indicated type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">8</a></span>
 When applied to an
 <code class="sourceCode cpp"><em>id-expression</em></code>, the
 reflection operator produces a reflection as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(8.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(8.1)</a></span>
 When applied to an enumerator, the reflection operator produces a
 reflection of the enumerator designated by the operand.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(8.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(8.2)</a></span>
 Otherwise, when applied to an overload set
 <code class="sourceCode cpp">S</code>, if the assignment of
 <code class="sourceCode cpp">S</code> to an invented variable of type
@@ -5760,19 +5822,19 @@ would select a unique candidate function
 <code class="sourceCode cpp">F</code>. Otherwise, the expression
 <code class="sourceCode cpp"><span class="op">^</span>S</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(8.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(8.3)</a></span>
 Otherwise, when applied to one of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(8.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">(8.3.1)</a></span>
 a non-type template parameter of non-class and non-reference type
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">(8.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(8.3.2)</a></span>
 a <code class="sourceCode cpp"><em>pack-index-expression</em></code> of
 non-class and non-reference type</li>
 </ul>
 <p>the reflection operator produces a reflection of the value computed
 by the operand.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">(8.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(8.4)</a></span>
 Otherwise, the reflection operator produces a reflection of the
 variable, function, or non-static member designated by the operand. The
 <code class="sourceCode cpp"><em>id-expression</em></code> is not
@@ -5799,7 +5861,7 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
 pointer-to-member type, or <span class="rm" style="color: #bf0303"><del>type</del></span> <span class="addu">one of
 the types <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -5818,47 +5880,47 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between <span>7.6.10 <a href="https://wg21.link/expr.eq">[expr.eq]</a></span>/5 and /6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">5</a></span>
 Two operands of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">*</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">(*.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(*.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">(*.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(*.2)</a></span>
 Otherwise, if one operand represents a
 <code class="sourceCode cpp"><em>template-id</em></code> referring to a
 specialization of an alias template, then they compare equal if and only
 if the other operand represents the same
 <code class="sourceCode cpp"><em>template-id</em></code>
 ([temp.type]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(*.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(*.3)</a></span>
 Otherwise, if one operand represents a namespace alias or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then they
-compare equal if and only if the other operand represents a namespace
-alias or <code class="sourceCode cpp"><em>typedef-name</em></code>
-sharing the same name, declared within the same enclosing scope, and
-aliasing the same underlying entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(*.4)</a></span>
+compare equal if and only if the construct represented by the other
+operand represents the same kind of construct, shares the same name, is
+declared within the same enclosing scope, and aliases the same
+underlying entity.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(*.4)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a template-argument-equivalent
 value (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(*.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(*.5)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">(*.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(*.6)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(*.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(*.7)</a></span>
 Otherwise, if one operand represents a base class specifier, then they
 compare equal if and only if the other operand represents the same base
 class specifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(*.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(*.8)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -5878,7 +5940,7 @@ any), <code class="sourceCode cpp"><em>alignment-specifiers</em></code>
 (if any), width, and attributes.</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -5895,47 +5957,72 @@ Otherwise, the result of each of the operators is unspecified.</p>
 </div>
 <h3 class="unnumbered" id="expr.const-constant-expressions"><span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span> Constant
 Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3>
+<p>Modify (and clean up) the definition of <em>immediate-escalating</em>
+to also apply to expressions of consteval-only type.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">18</a></span>
+A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evalauted</span> expression or conversion is
+<em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
+<span class="addu">nor a subexpression of an immediate
+invocation,</span> and it <span class="rm" style="color: #bf0303"><del>is</del></span> either</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(18.1)</a></span>
+<span class="rm" style="color: #bf0303"><del>a
+potentially-evaluated</del></span> <span class="addu">is an</span>
+<code class="sourceCode cpp"><em>id-expression</em></code> that denotes
+an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that is not a subexpression of an immediate
+invocation, or</del></span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(18.2)</a></span>
+<span class="addu">is</span> an immediate invocation that is not a
+constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
+invocation.</del></span></li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(18.3)</a></span>
+has consteval-only type ([basic.types.general]).</span></li>
+</ul>
+</blockquote>
+</div>
 <p>Add new paragraphs prior to the definition of <em>manifestly constant
 evaluated</em> (<span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span>/20), and
 renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">20</a></span>
 An expression or conversion is <em>in substitution context</em> if it
 results from the substitution of template parameters</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(20.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(20.1)</a></span>
 during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(20.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(20.2)</a></span>
 in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(20.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(20.3)</a></span>
 in a <code class="sourceCode cpp"><em>requires-expression</em></code>
-(<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
+(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">21</a></span>
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code> that
 is not in substitution context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(21.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(21.4)</a></span>
 an immediate invocation, unless it is
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(21.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(21.4.1)</a></span>
 in substitution context, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(21.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(21.4.2)</a></span>
 within the body of an immediate-escalating function that contains an
 immediate-escalating expression.</li>
 </ul></li>
@@ -5977,22 +6064,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">22</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(22.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(22.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(22.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(22.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(22.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(22.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(22.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(22.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6015,7 +6102,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">23</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6029,12 +6116,12 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">24</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(24.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
 constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
@@ -6080,7 +6167,7 @@ once.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb114-27"><a href="#cb114-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6089,11 +6176,11 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code>.</li>
@@ -6127,10 +6214,10 @@ follows:</p>
 <div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
 <span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">1</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
 may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">2</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 designate a type. The type designated by the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6147,45 +6234,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6193,7 +6280,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6202,22 +6289,22 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">9</a></span>
 A function type with a <em>cv-qualifier-seq</em> or a
 <em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(9.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(9.5)</a></span>
 the <em>type-id</em> of a <em>template-argument</em> for a
 <em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(9.6)</a></span>
 the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
@@ -6229,7 +6316,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator</span>, is ill-formed.</p>
@@ -6257,7 +6344,7 @@ follows:</p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">1</a></span>
 A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>
@@ -6295,7 +6382,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">0</a></span>
 If a
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 is a <code class="sourceCode cpp"><em>splice-specifier</em></code>, the
@@ -6316,7 +6403,7 @@ designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link
 in the paragraph that immediately follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6344,7 +6431,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">0</a></span>
 The
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 shall neither contain a dependent
@@ -6352,7 +6439,7 @@ shall neither contain a dependent
 dependent
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6416,7 +6503,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6439,23 +6526,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6470,7 +6557,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6495,7 +6582,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
@@ -6510,7 +6597,7 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 in template parameter declarations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">4</a></span>
 … The concept designated by a type-constraint shall be a type concept
 ([temp.concept]) <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-template-name</em></code></span>.</p>
@@ -6567,21 +6654,21 @@ designates the entity designated by the
 <p>Extend paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a <em>template-argument-list</em> if it
 follows a name that is not a <em>conversion-function-id</em> and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(3.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(3.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(3.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(3.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -6623,7 +6710,7 @@ it follows a
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">9</a></span>
 A <em>concept-id</em> is a <em>simple-template-id</em> where the
 <em>template-name</em> is <span class="addu">either</span> a
 <em>concept-name</em> <span class="addu">or a
@@ -6638,7 +6725,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -6676,7 +6763,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -6695,7 +6782,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be the name of a class template or an alias template, expressed as
@@ -6710,23 +6797,23 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and they compare equal, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -6737,7 +6824,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -6803,7 +6890,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6822,10 +6909,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -6851,7 +6938,7 @@ or a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6872,7 +6959,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -6890,19 +6977,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -6915,7 +7002,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -6923,7 +7010,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -6932,14 +7019,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7385,7 +7472,7 @@ synopsis</strong></p>
 <span id="cb133-345"><a href="#cb133-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb133-346"><a href="#cb133-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb133-347"><a href="#cb133-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
@@ -7401,7 +7488,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -7654,10 +7741,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -7665,11 +7752,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -7684,33 +7771,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -7719,23 +7806,23 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7744,43 +7831,43 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 namespace alias, then the identifier introduced by the declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7792,21 +7879,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -7824,7 +7911,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb141-3"><a href="#cb141-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -7832,7 +7919,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -7840,7 +7927,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -7848,7 +7935,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -7856,7 +7943,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -7865,7 +7952,7 @@ defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -7873,7 +7960,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -7888,7 +7975,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -7906,7 +7993,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -7916,7 +8003,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -7924,7 +8011,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -7933,7 +8020,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -7942,7 +8029,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -7952,7 +8039,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb154-3"><a href="#cb154-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -7963,7 +8050,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-3"><a href="#cb155-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-4"><a href="#cb155-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -7972,13 +8059,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -7988,13 +8075,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8003,20 +8090,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8024,7 +8111,7 @@ namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8035,7 +8122,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8043,7 +8130,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb163-3"><a href="#cb163-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8058,7 +8145,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb164-7"><a href="#cb164-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb164-8"><a href="#cb164-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb164-9"><a href="#cb164-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8068,14 +8155,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8092,7 +8179,7 @@ is
 <span id="cb166-7"><a href="#cb166-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-8"><a href="#cb166-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-9"><a href="#cb166-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8101,7 +8188,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8110,14 +8197,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8128,7 +8215,7 @@ Otherwise,
 <span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-5"><a href="#cb170-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8136,20 +8223,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8158,11 +8245,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8178,33 +8265,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8220,24 +8307,24 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
 alias <em>A</em>, then a reflection representing the entity named by
 <em>A</em>. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb179"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8249,15 +8336,15 @@ alias <em>A</em>, then a reflection representing the entity named by
 </div>
 <div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb181"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8279,11 +8366,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8302,7 +8389,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8313,11 +8400,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8331,14 +8418,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8348,92 +8435,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -8448,32 +8535,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8482,7 +8569,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -8495,7 +8582,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -8504,20 +8591,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -8525,7 +8612,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8534,7 +8621,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -8547,32 +8634,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb197-2"><a href="#cb197-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -8580,7 +8667,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -8588,7 +8675,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -8596,52 +8683,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -8659,36 +8746,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb200-5"><a href="#cb200-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -8700,32 +8787,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -8733,37 +8820,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -8776,18 +8863,18 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -8808,71 +8895,71 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -8882,7 +8969,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -8890,7 +8977,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -8898,7 +8985,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -8915,32 +9002,32 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
-if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> <span class="st">u8&quot;_&quot;</span> <span class="op">&amp;&amp;</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span> <span class="op">!=</span> <span class="st">u8&quot;_&quot;</span></code>
-is <code class="sourceCode cpp"><span class="kw">true</span></code>,
-then <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>.
+if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
+then either <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
+or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">==</span> <span class="st">u8&quot;_&quot;</span></code>.
 <span class="note"><span>[ <em>Note 2:</em> </span>Every provided
-identifier that is not <code class="sourceCode cpp"><span class="st">&quot;_&quot;</span></code>
-needs to be unique.<span> — <em>end note</em> ]</span></span></li>
+identifier that is not <code class="sourceCode cpp"><span class="st">&quot;_&quot;</span></code> must
+be unique.<span> — <em>end note</em> ]</span></span></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 3:</em>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -8952,26 +9039,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -8984,29 +9071,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9018,18 +9105,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9039,10 +9126,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9063,7 +9150,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9085,7 +9172,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb213-13"><a href="#cb213-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb213-14"><a href="#cb213-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb213-15"><a href="#cb213-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb214"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9111,7 +9198,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9133,7 +9220,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9143,7 +9230,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9154,7 +9241,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9240,12 +9327,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9257,10 +9344,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9269,7 +9356,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9281,7 +9368,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9310,7 +9397,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb219-14"><a href="#cb219-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb219-15"><a href="#cb219-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb219-16"><a href="#cb219-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9332,7 +9419,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9344,7 +9431,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9365,7 +9452,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9383,7 +9470,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9400,7 +9487,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9417,7 +9504,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9444,7 +9531,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9452,7 +9539,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9462,7 +9549,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9484,7 +9571,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb225-9"><a href="#cb225-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb225-10"><a href="#cb225-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb225-11"><a href="#cb225-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -9506,7 +9593,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -9514,7 +9601,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -9538,7 +9625,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -9546,27 +9633,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -9690,10 +9777,6 @@ constant-evaluation. <a href="https://wg21.link/p3068r1"><div class="csl-block">
 <div id="ref-P3096R1" class="csl-entry" role="doc-biblioentry">
 [P3096R1] Adam Lach, Walter Genovese. 2024-05-15. Function Parameter
 Reflection in Reflection for C++26. <a href="https://wg21.link/p3096r1"><div class="csl-block">https://wg21.link/p3096r1</div></a>
-</div>
-<div id="ref-P3293R1" class="csl-entry" role="doc-biblioentry">
-[P3293R1] Barry Revzin, Peter Dimov, Dan Katz, Daveed Vandevoorde.
-2024-10-13. Splicing a base class subobject. <a href="https://wg21.link/p3293r1"><div class="csl-block">https://wg21.link/p3293r1</div></a>
 </div>
 <div id="ref-P3295R0" class="csl-entry" role="doc-biblioentry">
 [P3295R0] Ben Craig. 2024-05-21. Freestanding constexpr containers and

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-11-14" />
+  <meta name="dcterms.date" content="2024-11-15" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-11-14</td>
+    <td>2024-11-15</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -5403,29 +5403,29 @@ preceded by
 <code class="sourceCode cpp"><span class="kw">template</span></code>.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb106"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> var <span class="op">{}</span>;</span>
+<div class="sourceCode" id="cb106"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> var;</span>
 <span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> cls <span class="op">{}</span>;</span>
-<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> <span class="dt">int</span> t_var <span class="op">{}</span>;</span>
+<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> <span class="dt">int</span> t_var <span class="op">=</span> <span class="dv">0</span>;</span>
 <span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> <span class="kw">struct</span> t_cls <span class="op">{</span> <span class="op">}</span>;</span>
 <span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span><span class="op">&gt;</span> <span class="kw">concept</span> always_true <span class="op">=</span> <span class="kw">requires</span> <span class="op">{</span> <span class="kw">true</span>; <span class="op">}</span>;</span>
 <span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> Var, <span class="kw">auto</span> Cls, <span class="kw">auto</span> TVar, <span class="kw">auto</span> TCls, <span class="kw">auto</span> Concept<span class="op">&gt;</span></span>
 <span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> dependent<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="op">[:</span>Var<span class="op">:]</span> <span class="op">*</span>var; <span class="op">}</span>                        <span class="co">// ok: multiplication of &#39;var * var&#39;.</span></span>
+<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">[:</span>Var<span class="op">:]</span> <span class="op">*</span>var;                      <span class="co">// ok: multiplication of &#39;var * var&#39;.</span></span>
 <span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="kw">typename</span> <span class="op">[:</span>Cls<span class="op">:]</span> <span class="op">*</span>var; <span class="op">}</span>               <span class="co">// ok: declaration of &#39;cls *var&#39;</span></span>
-<span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="kw">template</span> <span class="op">[:</span>TVar<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var; <span class="op">}</span>           <span class="co">// ok: multiplication of &#39;t_var&lt;0&gt; * var&#39;.</span></span>
-<span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="kw">template</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var; <span class="op">}</span>           <span class="co">// error: cannot splice type as expression.</span></span>
-<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var; <span class="op">}</span>           <span class="co">// ok: declaration of &#39;t_cls&lt;0&gt; *var&#39;.</span></span>
-<span id="cb106-15"><a href="#cb106-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="kw">template</span> <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var; <span class="op">}</span>  <span class="co">// also ok.</span></span>
+<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>Cls<span class="op">:]</span> <span class="op">*</span>a;               <span class="co">// ok: declaration of &#39;cls *var&#39;</span></span>
+<span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TVar<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// ok: multiplication of &#39;t_var&lt;0&gt; * var&#39;.</span></span>
+<span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// error: cannot splice type as expression.</span></span>
+<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>b;           <span class="co">// ok: declaration of &#39;t_cls&lt;0&gt; *var&#39;.</span></span>
+<span id="cb106-15"><a href="#cb106-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>c;  <span class="co">// also ok.</span></span>
 <span id="cb106-16"><a href="#cb106-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb106-17"><a href="#cb106-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="kw">template</span> <span class="op">[:</span>Concept<span class="op">:]</span> <span class="kw">auto</span> <span class="op">*</span>var <span class="op">=</span> <span class="dv">0</span>; <span class="op">}</span>  <span class="co">// ok: deduced placeholder type.</span></span>
+<span id="cb106-17"><a href="#cb106-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>Concept<span class="op">:]</span> <span class="kw">auto</span> <span class="op">*</span>d <span class="op">=</span> <span class="dv">0</span>;  <span class="co">// ok: deduced placeholder type.</span></span>
 <span id="cb106-18"><a href="#cb106-18" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb106-19"><a href="#cb106-19" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb106-20"><a href="#cb106-20" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> non_dependent<span class="op">()</span> <span class="op">{</span></span>
 <span id="cb106-21"><a href="#cb106-21" aria-hidden="true" tabindex="-1"></a>  dependent<span class="op">&lt;^</span>var, <span class="op">^</span>cls, <span class="op">^</span>t_var, <span class="op">^</span>t_cls, <span class="op">^</span>always_true<span class="op">&gt;()</span>;</span>
 <span id="cb106-22"><a href="#cb106-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb106-23"><a href="#cb106-23" aria-hidden="true" tabindex="-1"></a>  <span class="op">{</span> <span class="kw">template</span> <span class="op">[:^^</span>t_cls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var; <span class="op">}</span>        <span class="co">// ok in non-dependent context.</span></span>
+<span id="cb106-23"><a href="#cb106-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:^</span>t_cls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;  <span class="co">// ok in non-dependent context.</span></span>
 <span id="cb106-24"><a href="#cb106-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -5497,10 +5497,11 @@ renumber accordingly:</p>
 <blockquote>
 <div class="addu">
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">0</a></span>
-A <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code>
-either is dependent or designates a type,
-<code class="sourceCode cpp"><em>typedef-name</em></code>, namespace, or
+The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>, if
+any, shall either be dependent or designate a class, a
+<code class="sourceCode cpp"><em>typedef-name</em></code> denoting a
+class, a namespace, or a
 <code class="sourceCode cpp"><em>namespace-alias</em></code>.</p>
 </div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">1</a></span>
@@ -5576,8 +5577,8 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <div class="sourceCode" id="cb108"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
 <span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">1</a></span>
-The <code class="sourceCode cpp"><em>splice-specifier</em></code>
-designates either</p>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+designate either</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(1.1)</a></span>
 a value or object,</li>
@@ -5586,15 +5587,15 @@ a variable,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(1.3)</a></span>
 a structured binding,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(1.4)</a></span>
-a function,</li>
+a function other than a constructor or destructor,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(1.5)</a></span>
 an enumerator, or</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(1.6)</a></span>
 a non-static data member.</li>
 </ul>
-<p>The <code class="sourceCode cpp"><em>splice-specifier</em></code>
-shall not designate an unnamed bit-field, a constructor, or a
-destructor.</p>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>Unnamed bit-fields
+are not class members ([class.bit]), and cannot be spliced.<span>
+— <em>end note</em> ]</span></span></p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">2</a></span>
 Let <code class="sourceCode cpp"><em>E</em></code> be the construct
 designated by
@@ -5622,7 +5623,7 @@ value or an enumerator. The expression is a prvalue whose evaluation
 computes <code class="sourceCode cpp"><em>E</em></code> and whose type
 is the same as <code class="sourceCode cpp"><em>E</em></code>.</p></li>
 </ul>
-<p><span class="note"><span>[ <em>Note 1:</em> </span>Access checking of
+<p><span class="note"><span>[ <em>Note 2:</em> </span>Access checking of
 class members occurs during lookup, and therefore does not pertain to
 splicing.<span> — <em>end note</em> ]</span></span></p>
 </div>
@@ -5662,11 +5663,12 @@ A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
 <span class="rm" style="color: #bf0303"><del>optionally</del></span>
-<span class="addu">possibly</span> followed by the keyword template, and
-then followed by an
+<span class="addu">possibly</span> followed by the keyword
+<code class="sourceCode cpp"><span class="kw">template</span></code>,
+and then followed by an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or a splicer designating a class member</span>, is a
-postfix expression. <span class="note"><span>[ <em>Note 1:</em>
-</span>If the keyword
+postfix expression.</p>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>If the keyword
 <code class="sourceCode cpp"><span class="kw">template</span></code> is
 used, the following unqualified name is considered to refer to a
 template ([temp.names]). If a
@@ -5868,6 +5870,17 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <blockquote>
 <div class="addu">
 <p><strong>The Reflection Operator [expr.reflect]</strong></p>
+<p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
+following grammar avoids use of
+<code class="sourceCode default"><em>id-expression</em></code>, even
+though any operand to an
+<code class="sourceCode default"><em>id-expression</em></code> can be an
+operand to a
+<code class="sourceCode default"><em>reflect-expression</em></code>. The
+reason is that the operand of a
+<code class="sourceCode default"><em>reflect-expression</em></code> is
+not necessarily an expression, as it could name a namespace, class
+template, type, etc. ]</span></p>
 <div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><em>reflect-expression</em>:</span>
 <span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>   ^ ::</span>
 <span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>   ^ <em>unqualified-id</em></span>
@@ -6090,15 +6103,27 @@ and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">15</a></span>
-A <em>constant-expression</em> is either a glvalue core constant
+A <em>constant expression</em> is either a glvalue core constant
 expression that <span class="addu"> </span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(15.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(15.1)</a></span>
 refers to an entity that is a permitted result of a constant
-expression<span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(15.2)</a></span>
+expression<span class="addu">, and</span></p></li>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(15.2)</a></span>
 is of consteval-only type if the entity designated by the expression is
-of consteval-only type,</span></li>
+of consteval-only type,</span></p>
+<div class="addu">
+<div class="note">
+<p><span>[ <em>Note 1:</em> </span>For example, given the function</p>
+<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> Base<span class="op">&amp;</span> fn<span class="op">(</span><span class="kw">const</span> Derived<span class="op">&amp;</span> derived<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> derived;</span>
+<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p>where <code class="sourceCode cpp">Derived</code> is a consteval-only
+type, if <code class="sourceCode cpp">Base</code> is not also a
+consteval-only type then <code class="sourceCode cpp">fn<span class="op">(</span>derived<span class="op">)</span></code>
+is never a constant expression.<span> — <em>end note</em> ]</span></p>
+</div>
+</div></li>
 </ul>
 <p>or a prvalue core constant expression whose value satisfies the
 following constraints:</p>
@@ -6107,22 +6132,28 @@ following constraints:</p>
 if the value is an object of class type, each non-static data member of
 reference type refers to an entity that is a permitted result of a
 constant expression <span class="addu">and has consteval-only type if
-the entity has consteval-only type</span>,</li>
+that entity has consteval-only type</span>,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(15.4)</a></span>
 if the value is an object of scalar type, it does not have an
 indeterminate or erroneous value ([basic.indet]),</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(15.5)</a></span>
-if the value is of pointer type, it is a pointer to an object of static
-storage duration, a pointer past the end of such an object ([expr.add]),
-a pointer to a non-immediate function, or a null pointer value,</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(15.6)</a></span>
-if the value is a pointer to an object of consteval-only type, or a
-pointer past the end of such an object, then the prvalue is also of
-consteval-only type,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(15.7)</a></span>
+if the value is of pointer type, <span class="addu">then: </span>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(15.5.1)</a></span>
+it is a pointer to an object of static storage duration<span class="rm" style="color: #bf0303"><del>,</del></span> <span class="addu">or</span>
+a pointer past the end of such an object ([expr.add]), <span class="addu">such that if the type of that object is a consteval-only
+type then that pointer type is also a consteval-only type,
+or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(15.5.2)</a></span>
+<span class="addu">it is</span> a pointer to a non-immediate function,
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(15.5.3)</a></span>
+<span class="addu">it is</span> a null pointer value,</li>
+</ul></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(15.6)</a></span>
 if the value is of pointer-to-member-function type, it does not
 designate an immediate function, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(15.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(15.7)</a></span>
 if the value is an object of class or array type, each subobject
 satisfies these constraints for the value.</li>
 </ul>
@@ -6132,23 +6163,23 @@ satisfies these constraints for the value.</li>
 to also apply to expressions of consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">18</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it <span class="rm" style="color: #bf0303"><del>is</del></span> either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(18.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(18.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">is an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> that denotes
 an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that is not a subexpression of an immediate
 invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(18.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(18.2)</a></span>
 <span class="addu">is</span> an immediate invocation that is not a
 constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(18.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(18.3)</a></span>
 has consteval-only type ([basic.types.general]).</span></li>
 </ul>
 </blockquote>
@@ -6159,16 +6190,16 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">19</a></span>
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(19.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(19.1)</a></span>
 the <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 (<span>9.1 <a href="https://wg21.link/dcl.pre">[dcl.pre]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(19.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(19.2)</a></span>
 an initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
@@ -6176,7 +6207,7 @@ an initializer of a
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable.</li>
 </ul>
-<p><span class="note"><span>[ <em>Note 1:</em> </span>A plainly
+<p><span class="note"><span>[ <em>Note 2:</em> </span>A plainly
 constant-evaluated expression
 <code class="sourceCode cpp"><em>E</em></code> is evaluated exactly
 once, may produce injected declarations (see below), and any such
@@ -6185,23 +6216,23 @@ declarations are reachable at a point immediately following
 — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
-<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
-<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="dv">1</span>; <span class="op">}</span></span>
-<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> b1 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;            <span class="co">// &#39;cfn(1)&#39; is plainly constant-evaluated</span></span>
-<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="kw">constinit</span> <span class="dt">int</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// &#39;cfn(2)&#39; is plainly constant-evaluated</span></span>
-<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">int</span> b3 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">3</span><span class="op">)</span>;                <span class="co">// &#39;cfn(3)&#39; is not plainly constant-evaluated</span></span>
-<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>b1 <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span>;                <span class="co">// &#39;b1 &gt; 0&#39; is plainly constant-evaluated</span></span>
-<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Cls <span class="op">{</span></span>
-<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">int</span> var <span class="op">=</span> cfn<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;  <span class="co">// &#39;cfn(4)&#39; is plainly constant-evaluated</span></span>
-<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> arr<span class="op">[</span>cfn<span class="op">(</span><span class="dv">5</span><span class="op">)]</span>;                    <span class="co">// &#39;cfn(5)&#39; is not plainly constant-evaluated</span></span>
-<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb115"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="dv">1</span>; <span class="op">}</span></span>
+<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> b1 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;            <span class="co">// &#39;cfn(1)&#39; is plainly constant-evaluated</span></span>
+<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a><span class="kw">constinit</span> <span class="dt">int</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// &#39;cfn(2)&#39; is plainly constant-evaluated</span></span>
+<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">int</span> b3 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">3</span><span class="op">)</span>;                <span class="co">// &#39;cfn(3)&#39; is not plainly constant-evaluated</span></span>
+<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>b1 <span class="op">&gt;</span> <span class="dv">0</span><span class="op">)</span>;                <span class="co">// &#39;b1 &gt; 0&#39; is plainly constant-evaluated</span></span>
+<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-14"><a href="#cb115-14" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Cls <span class="op">{</span></span>
+<span id="cb115-15"><a href="#cb115-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">int</span> var <span class="op">=</span> cfn<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;  <span class="co">// &#39;cfn(4)&#39; is plainly constant-evaluated</span></span>
+<span id="cb115-16"><a href="#cb115-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> arr<span class="op">[</span>cfn<span class="op">(</span><span class="dv">5</span><span class="op">)]</span>;                    <span class="co">// &#39;cfn(5)&#39; is not plainly constant-evaluated</span></span>
+<span id="cb115-17"><a href="#cb115-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6212,27 +6243,27 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">20</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(20.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(20.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(20.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(20.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(20.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(20.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(20.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(20.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(20.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(20.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
 <div class="addu">
-<p><span class="note"><span>[ <em>Note 2:</em> </span>All plainly
+<p><span class="note"><span>[ <em>Note 3:</em> </span>All plainly
 constant-evaluated expressions are manifestly constant-evaluated, but
 some manifestly constant-evaluated expressions (e.g., initializers that
 can require trial evaluations) are not plainly constant-evaluated. Such
@@ -6250,7 +6281,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">21</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6264,12 +6295,12 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">22</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(22.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(22.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
 constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
@@ -6286,36 +6317,36 @@ declarations when such evaluations can be guaranteed to only happen
 once.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb115"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
-<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
-<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
-<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
-<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
-<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
-<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
-<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
-<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
-<span id="cb115-14"><a href="#cb115-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
-<span id="cb115-15"><a href="#cb115-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
-<span id="cb115-16"><a href="#cb115-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-17"><a href="#cb115-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb115-18"><a href="#cb115-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
-<span id="cb115-19"><a href="#cb115-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
-<span id="cb115-20"><a href="#cb115-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb115-21"><a href="#cb115-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
-<span id="cb115-22"><a href="#cb115-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
-<span id="cb115-23"><a href="#cb115-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
-<span id="cb115-24"><a href="#cb115-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evaluated.</span></span>
-<span id="cb115-25"><a href="#cb115-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
-<span id="cb115-26"><a href="#cb115-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
-<span id="cb115-27"><a href="#cb115-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb116"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
+<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
+<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
+<span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
+<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-9"><a href="#cb116-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
+<span id="cb116-10"><a href="#cb116-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
+<span id="cb116-11"><a href="#cb116-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
+<span id="cb116-12"><a href="#cb116-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-13"><a href="#cb116-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
+<span id="cb116-14"><a href="#cb116-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
+<span id="cb116-15"><a href="#cb116-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
+<span id="cb116-16"><a href="#cb116-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-17"><a href="#cb116-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb116-18"><a href="#cb116-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
+<span id="cb116-19"><a href="#cb116-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
+<span id="cb116-20"><a href="#cb116-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb116-21"><a href="#cb116-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
+<span id="cb116-22"><a href="#cb116-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
+<span id="cb116-23"><a href="#cb116-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
+<span id="cb116-24"><a href="#cb116-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evaluated.</span></span>
+<span id="cb116-25"><a href="#cb116-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
+<span id="cb116-26"><a href="#cb116-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
+<span id="cb116-27"><a href="#cb116-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6324,11 +6355,11 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> ([intro.execution]).</li>
@@ -6344,7 +6375,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 paragraph 3.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">3</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>typedef-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6362,10 +6393,10 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
-<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
-<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
-<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
+<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
+<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6373,7 +6404,7 @@ follows:</p>
 after nested name specifiers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>simple-type-specifier</em></code> are
 those of its
@@ -6397,7 +6428,7 @@ shall not contain a splicer.</span></p>
 be a placeholder for a deduced class type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -6424,7 +6455,7 @@ shall <span class="rm" style="color: #bf0303"><del>name</del></span>
 template whose
 <code class="sourceCode cpp"><em>defining-type-id</em></code> is of the
 form</p>
-<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
+<div class="sourceCode" id="cb118"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
 <p>where the
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> (if
 any) is non-dependent and the
@@ -6508,45 +6539,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6554,7 +6585,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6563,26 +6594,26 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
 type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -6591,7 +6622,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -6605,7 +6636,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator ([expr.reflect])</span>, is ill-formed.</p>
@@ -6619,20 +6650,20 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb118"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
-<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
-<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
-<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
-<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
+<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
+<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
+<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
 <p>Modify paragraph 1 to handle splicers:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">1</a></span>
 <span class="addu">A <code class="sourceCode cpp"><span class="kw">using</span><span class="op">-</span><span class="kw">enum</span><span class="op">-</span>declarator</code>
 of the form
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6657,9 +6688,9 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     namespace <em>identifier</em> = <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     namespace <em>identifier</em> = <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6667,7 +6698,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">0</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code>
 appearing in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
@@ -6680,7 +6711,7 @@ shall designate a namespace or
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6698,9 +6729,9 @@ the grammar for
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
-<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>      <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
-<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>      <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6709,7 +6740,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
 any, designates a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>. Neither
@@ -6717,7 +6748,7 @@ the <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 nor the <code class="sourceCode cpp"><em>splice-specifier</em></code>
 shall be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6756,10 +6787,10 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
+<div class="sourceCode" id="cb122"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6767,13 +6798,13 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb122"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
-<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
-<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
-<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
-<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
-<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
-<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
+<div class="sourceCode" id="cb123"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
+<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
+<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
+<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
+<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
+<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
+<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6781,7 +6812,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6806,7 +6837,7 @@ Global module fragment<a href="#module.global.frag-global-module-fragment" class
 <blockquote>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -6815,7 +6846,7 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
@@ -6823,7 +6854,7 @@ does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template is replaced by its
 denoted type prior to this determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(3.8)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -6834,23 +6865,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6884,7 +6915,7 @@ names<a href="#class.name-class-names" class="self-link"></a></h3>
 <p>Cover `$splice-type-specifier$s in paragraph 5.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">5</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>class-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6899,7 +6930,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6925,7 +6956,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">1</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.class.deduct]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6935,7 +6966,7 @@ When resolving a placeholder for a deduced class type
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -6944,7 +6975,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">3</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.simple]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6953,7 +6984,7 @@ When resolving a placeholder for a deduced class type
 <code class="sourceCode cpp">A</code>, the
 <code class="sourceCode cpp"><em>defining-type-id</em></code> of
 <code class="sourceCode cpp">A</code> must be of the form</p>
-<div class="sourceCode" id="cb123"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
+<div class="sourceCode" id="cb124"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
 <p>as specified in [dcl.type.simple]. The guides of
 <code class="sourceCode cpp">A</code> are the set of functions or
 function templates formed as follows. …</p>
@@ -6965,13 +6996,13 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 there exist candidate operator functions of the form</p>
-<div class="sourceCode" id="cb124"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
-<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.param-template-parameters"><span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span> Template
@@ -6982,10 +7013,10 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>type-constraint</em>:</span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub>&gt;</span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>  <em>type-constraint</em>:</span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
+<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub>&gt;</span>
+<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6994,7 +7025,7 @@ form <code class="sourceCode cpp"><em>type-constraint</em></code>s.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">3+</a></span>
 A non-dependent
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
 forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
@@ -7015,29 +7046,29 @@ leverage splicers.</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-template-id</em>:</span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>      <em>template-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-expr-template-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
-<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
-<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>  <em>template-id</em>:</span>
-<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>      <em>simple-template-id</em></span>
-<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>      $operator-function-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>      $literal-operator-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a>  </span>
-<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
-<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a>      identifier</span>
-<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a>  <em>template-argument-list</em>:</span>
-<span id="cb126-15"><a href="#cb126-15" aria-hidden="true" tabindex="-1"></a>      <em>template-argument</em> ...<sub><em>opt</em></sub></span>
-<span id="cb126-16"><a href="#cb126-16" aria-hidden="true" tabindex="-1"></a>      <em>template-argument-list</em> , <em>template-argument</em> ...<sub><em>opt</em></sub></span>
-<span id="cb126-17"><a href="#cb126-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-18"><a href="#cb126-18" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
-<span id="cb126-19"><a href="#cb126-19" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
-<span id="cb126-20"><a href="#cb126-20" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
-<span id="cb126-21"><a href="#cb126-21" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
-<span id="cb126-22"><a href="#cb126-22" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
-<span id="cb126-23"><a href="#cb126-23" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-template-id</em>:</span>
+<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>      <em>template-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-expr-template-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
+<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
+<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>  <em>template-id</em>:</span>
+<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>      <em>simple-template-id</em></span>
+<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>      $operator-function-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>      $literal-operator-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
+<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a>      identifier</span>
+<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>  <em>template-argument-list</em>:</span>
+<span id="cb127-15"><a href="#cb127-15" aria-hidden="true" tabindex="-1"></a>      <em>template-argument</em> ...<sub><em>opt</em></sub></span>
+<span id="cb127-16"><a href="#cb127-16" aria-hidden="true" tabindex="-1"></a>      <em>template-argument-list</em> , <em>template-argument</em> ...<sub><em>opt</em></sub></span>
+<span id="cb127-17"><a href="#cb127-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb127-18"><a href="#cb127-18" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
+<span id="cb127-19"><a href="#cb127-19" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
+<span id="cb127-20"><a href="#cb127-20" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
+<span id="cb127-21"><a href="#cb127-21" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
+<span id="cb127-22"><a href="#cb127-22" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
+<span id="cb127-23"><a href="#cb127-23" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7047,7 +7078,7 @@ leverage splicers.</p>
 component name.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">2</a></span>
 The component name of a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>simple-template-id</em></code></span>,
 <span><code class="sourceCode default"><em>template-id</em></code></span>,
 or</del></span>
@@ -7065,31 +7096,31 @@ its <code class="sourceCode cpp"><em>simple-template-id</em></code>,
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows <span class="addu">either</span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(3.1)</a></span>
 a
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -7103,20 +7134,20 @@ appear.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div>
-<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
-<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>};</span>
-<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
-<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
-<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
-<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
-<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
-<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
-<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
-<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
-<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
+<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>};</span>
+<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
+<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
+<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
+<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
+<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
+<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb128-11"><a href="#cb128-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
+<span id="cb128-12"><a href="#cb128-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
+<span id="cb128-13"><a href="#cb128-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
+<span id="cb128-14"><a href="#cb128-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -7128,7 +7159,7 @@ containing
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or splicer</span> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a constrained non-function template or a
@@ -7144,7 +7175,7 @@ non-dependent ([temp.dep.temp]), the associated contraints
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">9</a></span>
 A <em>concept-id</em> is a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> where
 <span class="addu">either</span> the
@@ -7169,7 +7200,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">3</a></span>
 In a <code class="sourceCode cpp"><em>template-argument</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>, an
@@ -7181,16 +7212,16 @@ form of the corresponding
 <div class="example2">
 <span>[ <em>Example 2:</em> </span>
 <div>
-<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
-<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
-<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
-<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
-<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-specifier: calls the first f()</span></span>
-<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-specifier: calls the second f()</span></span>
-<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
+<div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
+<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
+<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
+<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
+<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-specifier: calls the first f()</span></span>
+<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-specifier: calls the second f()</span></span>
+<span id="cb129-10"><a href="#cb129-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -7202,7 +7233,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -7223,22 +7254,22 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
 ([dcl.type.class.deduct]), the type of the parameter is the type deduced
 for the variable x in the invented declaration</p>
-<div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
+<div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">2</a></span>
 The value of a non-type <em>template-parameter</em>
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">3</a></span>
 Otherwise, a temporary variable</p>
-<div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
+<div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
 </blockquote>
 </div>
@@ -7248,7 +7279,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be <span class="rm" style="color: #bf0303"><del>the name
@@ -7267,7 +7298,7 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 equivalence as defined by paragraph 1 to cover splicers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s are the
 same if</p>
 <ul>
@@ -7294,23 +7325,23 @@ are the same refer to the same class, function, or variable.</p>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7322,7 +7353,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -7338,7 +7369,7 @@ the class template are considered.</p>
 cannot themselves appear in deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">3</a></span>
 The same restrictions apply to the
 <code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
 of a deduction guide as in a function declaration ([dcl.fct]), except
@@ -7368,7 +7399,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -7390,7 +7421,7 @@ splicers can’t follow
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">3</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>typename-specifier</em></code> are its
 <code class="sourceCode cpp"><em>identifier</em></code> (if any) and
@@ -7406,7 +7437,7 @@ not contain a splicer.</span></p>
 instantiation.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">6</a></span>
 The validity of a templated entity may be checked prior to any
 instantiation.</p>
 <p><span class="note3"><span>[ <em>Note 3:</em> </span>Knowing which
@@ -7414,42 +7445,42 @@ names are type names allows the syntax of every template to be checked
 in this way.<span> — <em>end note</em> ]</span></span></p>
 <p>The program is ill-formed, no diagnostic required, if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(6.1)</a></span>
 no valid specialization, ignoring
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>s
 that fail ([dcl.pre]), can be generated for a templated entity or a
 substatement of a constexpr if statement ([stmt.if]) within a templaetd
 entity and the innermost enclosing template is not instantiated, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(6.2)</a></span>
 no valid specialization, ignoring
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>s
 that fail, can be generated for a default
 <code class="sourceCode cpp"><em>template-argument</em></code> and the
 default <code class="sourceCode cpp"><em>template-argument</em></code>
 is not used in any instantiation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(6.3)</a></span>
 no specialization of an alias template ([temp.alias]) is valid and no
 specialization of the alias template is named in the program, or</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(6.4)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(6.4)</a></span>
 any non-dependent plainly constant-evaluated expression within a
 templated entity produces an injected declaration ([expr.const]),
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(6.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(6.5)</a></span>
 any <code class="sourceCode cpp"><em>constraint-expression</em></code>
 in the program, introduced or otherwise, has (in its normal form) an
 atomic constraint <code class="sourceCode cpp"><em>A</em></code> where
 no satisfaction check of <code class="sourceCode cpp"><em>A</em></code>
 could be well-formed and no satisfaction check of
 <code class="sourceCode cpp"><em>A</em></code> is performed, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(6.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.6)</a></span>
 every valid specialization of a variadic template requires an empty
 template parameter pack, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(6.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(6.7)</a></span>
 a hypothetical instantiation of a templated entity immediately following
 its definition would be ill-formed due to a construct (other than a
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 that fails) that does not depend on a template parameter, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(6.8)</a></span>
 the interpretation of such a construct in the hypothetical instantiation
 is different from the interpretation of the corresponding construct in
 any actual instantiation of the templated entity.</li>
@@ -7463,19 +7494,19 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb131"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
-<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
-<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
-<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
-<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
-<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
-<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
-<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
-<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
-<span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
-<span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
-<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
-<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb132"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
+<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
+<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
+<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
+<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
+<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
+<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
+<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7483,17 +7514,17 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is type-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(9.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(9.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7509,21 +7540,21 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
 <em>unary-expression</em> or <em>expression</em> is type-dependent or
 the <em>type-id</em> is dependent:</p>
-<div class="sourceCode" id="cb132"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
-<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
-<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
-<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
-<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
+<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
+<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
+<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
+<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
+<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
 <p><span class="addu">A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 value-dependent if the operand following
@@ -7536,17 +7567,17 @@ dependent name, names a dependent type, or contains a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is value-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(6.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(6.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7564,10 +7595,10 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">9</a></span>
 Preprocessing directives of the forms</p>
-<div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
-<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
+<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
+<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
 <p>check whether the controlling constant expression evaluates to
 nonzero. <span class="addu">The program is ill-formed if a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> or
@@ -7582,19 +7613,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7607,7 +7638,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7615,7 +7646,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7624,14 +7655,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7646,20 +7677,20 @@ synopsis<a href="#meta.type.synop-header-type_traits-synopsis" class="self-link"
 synopsis</strong></p>
 <p>…</p>
 <div>
-<div class="sourceCode" id="cb134"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
-<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
-<span id="cb134-5"><a href="#cb134-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
-<span id="cb134-6"><a href="#cb134-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb134-7"><a href="#cb134-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb134-8"><a href="#cb134-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb134-9"><a href="#cb134-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
-<span id="cb134-10"><a href="#cb134-10" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb134-11"><a href="#cb134-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb134-12"><a href="#cb134-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
-<span id="cb134-13"><a href="#cb134-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
-<span id="cb134-14"><a href="#cb134-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
+<div class="sourceCode" id="cb135"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
+<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
+<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
+<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-7"><a href="#cb135-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb135-8"><a href="#cb135-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb135-9"><a href="#cb135-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
+<span id="cb135-10"><a href="#cb135-10" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb135-11"><a href="#cb135-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb135-12"><a href="#cb135-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
+<span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
+<span id="cb135-14"><a href="#cb135-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7681,8 +7712,8 @@ Comments
 </tr>
 <tr>
 <td>
-<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
+<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
 </td>
 <td style="text-align:center; vertical-align: middle">
 <code class="sourceCode cpp">T</code> is
@@ -7705,8 +7736,8 @@ Comments
 <tr>
 <td>
 <div class="addu">
-<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
+<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
 </div>
 </td>
 <td style="text-align:center; vertical-align: middle">
@@ -7730,358 +7761,358 @@ synopsis<a href="#meta.reflection.synop-header-meta-synopsis" class="self-link">
 <div class="addu">
 <p><strong>Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
 synopsis</strong></p>
-<div class="sourceCode" id="cb137"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
-<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
-<span id="cb137-3"><a href="#cb137-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
-<span id="cb137-4"><a href="#cb137-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
-<span id="cb137-5"><a href="#cb137-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-6"><a href="#cb137-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb137-7"><a href="#cb137-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
-<span id="cb137-8"><a href="#cb137-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-9"><a href="#cb137-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
-<span id="cb137-10"><a href="#cb137-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
-<span id="cb137-11"><a href="#cb137-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
-<span id="cb137-12"><a href="#cb137-12" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb137-13"><a href="#cb137-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
-<span id="cb137-14"><a href="#cb137-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
-<span id="cb137-15"><a href="#cb137-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
-<span id="cb137-16"><a href="#cb137-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
-<span id="cb137-17"><a href="#cb137-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-18"><a href="#cb137-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
-<span id="cb137-19"><a href="#cb137-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
-<span id="cb137-20"><a href="#cb137-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-21"><a href="#cb137-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
-<span id="cb137-22"><a href="#cb137-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
-<span id="cb137-23"><a href="#cb137-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-24"><a href="#cb137-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
-<span id="cb137-25"><a href="#cb137-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
-<span id="cb137-26"><a href="#cb137-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-27"><a href="#cb137-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
-<span id="cb137-28"><a href="#cb137-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-29"><a href="#cb137-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
-<span id="cb137-30"><a href="#cb137-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
-<span id="cb137-31"><a href="#cb137-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
-<span id="cb137-32"><a href="#cb137-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
-<span id="cb137-33"><a href="#cb137-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-34"><a href="#cb137-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
-<span id="cb137-35"><a href="#cb137-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
-<span id="cb137-36"><a href="#cb137-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
-<span id="cb137-37"><a href="#cb137-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
-<span id="cb137-38"><a href="#cb137-38" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-39"><a href="#cb137-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
-<span id="cb137-40"><a href="#cb137-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
-<span id="cb137-41"><a href="#cb137-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
-<span id="cb137-42"><a href="#cb137-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
-<span id="cb137-43"><a href="#cb137-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
-<span id="cb137-44"><a href="#cb137-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
-<span id="cb137-45"><a href="#cb137-45" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-46"><a href="#cb137-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
-<span id="cb137-47"><a href="#cb137-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
-<span id="cb137-48"><a href="#cb137-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-49"><a href="#cb137-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
-<span id="cb137-50"><a href="#cb137-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
-<span id="cb137-51"><a href="#cb137-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
-<span id="cb137-52"><a href="#cb137-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
-<span id="cb137-53"><a href="#cb137-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
-<span id="cb137-54"><a href="#cb137-54" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-55"><a href="#cb137-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
-<span id="cb137-56"><a href="#cb137-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
-<span id="cb137-57"><a href="#cb137-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
-<span id="cb137-58"><a href="#cb137-58" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-59"><a href="#cb137-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
-<span id="cb137-60"><a href="#cb137-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
-<span id="cb137-61"><a href="#cb137-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
-<span id="cb137-62"><a href="#cb137-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
-<span id="cb137-63"><a href="#cb137-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-64"><a href="#cb137-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
-<span id="cb137-65"><a href="#cb137-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
-<span id="cb137-66"><a href="#cb137-66" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-67"><a href="#cb137-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
-<span id="cb137-68"><a href="#cb137-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
-<span id="cb137-69"><a href="#cb137-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
-<span id="cb137-70"><a href="#cb137-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
-<span id="cb137-71"><a href="#cb137-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
-<span id="cb137-72"><a href="#cb137-72" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-73"><a href="#cb137-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
-<span id="cb137-74"><a href="#cb137-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
-<span id="cb137-75"><a href="#cb137-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
-<span id="cb137-76"><a href="#cb137-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
-<span id="cb137-77"><a href="#cb137-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
-<span id="cb137-78"><a href="#cb137-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
-<span id="cb137-79"><a href="#cb137-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
-<span id="cb137-80"><a href="#cb137-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
-<span id="cb137-81"><a href="#cb137-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
-<span id="cb137-82"><a href="#cb137-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
-<span id="cb137-83"><a href="#cb137-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
-<span id="cb137-84"><a href="#cb137-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
-<span id="cb137-85"><a href="#cb137-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
-<span id="cb137-86"><a href="#cb137-86" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-87"><a href="#cb137-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
-<span id="cb137-88"><a href="#cb137-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
-<span id="cb137-89"><a href="#cb137-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
-<span id="cb137-90"><a href="#cb137-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
-<span id="cb137-91"><a href="#cb137-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
-<span id="cb137-92"><a href="#cb137-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
-<span id="cb137-93"><a href="#cb137-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
-<span id="cb137-94"><a href="#cb137-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
-<span id="cb137-95"><a href="#cb137-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
-<span id="cb137-96"><a href="#cb137-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
-<span id="cb137-97"><a href="#cb137-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
-<span id="cb137-98"><a href="#cb137-98" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-99"><a href="#cb137-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
-<span id="cb137-100"><a href="#cb137-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
-<span id="cb137-101"><a href="#cb137-101" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-102"><a href="#cb137-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
-<span id="cb137-103"><a href="#cb137-103" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-104"><a href="#cb137-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
-<span id="cb137-105"><a href="#cb137-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
-<span id="cb137-106"><a href="#cb137-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
-<span id="cb137-107"><a href="#cb137-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
-<span id="cb137-108"><a href="#cb137-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
-<span id="cb137-109"><a href="#cb137-109" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-110"><a href="#cb137-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
-<span id="cb137-111"><a href="#cb137-111" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-112"><a href="#cb137-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
-<span id="cb137-113"><a href="#cb137-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
-<span id="cb137-114"><a href="#cb137-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
-<span id="cb137-115"><a href="#cb137-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
-<span id="cb137-116"><a href="#cb137-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
-<span id="cb137-117"><a href="#cb137-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
-<span id="cb137-118"><a href="#cb137-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
-<span id="cb137-119"><a href="#cb137-119" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-120"><a href="#cb137-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
-<span id="cb137-121"><a href="#cb137-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
-<span id="cb137-122"><a href="#cb137-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
-<span id="cb137-123"><a href="#cb137-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
-<span id="cb137-124"><a href="#cb137-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
-<span id="cb137-125"><a href="#cb137-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
-<span id="cb137-126"><a href="#cb137-126" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-127"><a href="#cb137-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
-<span id="cb137-128"><a href="#cb137-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
-<span id="cb137-129"><a href="#cb137-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
-<span id="cb137-130"><a href="#cb137-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
-<span id="cb137-131"><a href="#cb137-131" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-132"><a href="#cb137-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
-<span id="cb137-133"><a href="#cb137-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
-<span id="cb137-134"><a href="#cb137-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
-<span id="cb137-135"><a href="#cb137-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
-<span id="cb137-136"><a href="#cb137-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
-<span id="cb137-137"><a href="#cb137-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
-<span id="cb137-138"><a href="#cb137-138" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb137-139"><a href="#cb137-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
-<span id="cb137-140"><a href="#cb137-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
-<span id="cb137-141"><a href="#cb137-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
-<span id="cb137-142"><a href="#cb137-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
-<span id="cb137-143"><a href="#cb137-143" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-144"><a href="#cb137-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
-<span id="cb137-145"><a href="#cb137-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb137-146"><a href="#cb137-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
-<span id="cb137-147"><a href="#cb137-147" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-148"><a href="#cb137-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
-<span id="cb137-149"><a href="#cb137-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
-<span id="cb137-150"><a href="#cb137-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
-<span id="cb137-151"><a href="#cb137-151" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-152"><a href="#cb137-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-153"><a href="#cb137-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb137-154"><a href="#cb137-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-155"><a href="#cb137-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb137-156"><a href="#cb137-156" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-157"><a href="#cb137-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
-<span id="cb137-158"><a href="#cb137-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb137-159"><a href="#cb137-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
-<span id="cb137-160"><a href="#cb137-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb137-161"><a href="#cb137-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
-<span id="cb137-162"><a href="#cb137-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb137-163"><a href="#cb137-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
-<span id="cb137-164"><a href="#cb137-164" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-165"><a href="#cb137-165" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define.aggregate], class definition generation</span>
-<span id="cb137-166"><a href="#cb137-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options {</span>
-<span id="cb137-167"><a href="#cb137-167" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
-<span id="cb137-168"><a href="#cb137-168" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
-<span id="cb137-169"><a href="#cb137-169" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb137-170"><a href="#cb137-170" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-171"><a href="#cb137-171" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
-<span id="cb137-172"><a href="#cb137-172" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb137-173"><a href="#cb137-173" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-174"><a href="#cb137-174" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
-<span id="cb137-175"><a href="#cb137-175" aria-hidden="true" tabindex="-1"></a>    };</span>
-<span id="cb137-176"><a href="#cb137-176" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-177"><a href="#cb137-177" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
-<span id="cb137-178"><a href="#cb137-178" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
-<span id="cb137-179"><a href="#cb137-179" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; bit_width;</span>
-<span id="cb137-180"><a href="#cb137-180" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
-<span id="cb137-181"><a href="#cb137-181" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb137-182"><a href="#cb137-182" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
-<span id="cb137-183"><a href="#cb137-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options options = {});</span>
-<span id="cb137-184"><a href="#cb137-184" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
-<span id="cb137-185"><a href="#cb137-185" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-186"><a href="#cb137-186" aria-hidden="true" tabindex="-1"></a>  consteval info define_aggregate(info type_class, R&amp;&amp;);</span>
-<span id="cb137-187"><a href="#cb137-187" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-188"><a href="#cb137-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
-<span id="cb137-189"><a href="#cb137-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type);</span>
-<span id="cb137-190"><a href="#cb137-190" aria-hidden="true" tabindex="-1"></a>  consteval bool is_null_pointer_type(info type);</span>
-<span id="cb137-191"><a href="#cb137-191" aria-hidden="true" tabindex="-1"></a>  consteval bool is_integral_type(info type);</span>
-<span id="cb137-192"><a href="#cb137-192" aria-hidden="true" tabindex="-1"></a>  consteval bool is_floating_point_type(info type);</span>
-<span id="cb137-193"><a href="#cb137-193" aria-hidden="true" tabindex="-1"></a>  consteval bool is_array_type(info type);</span>
-<span id="cb137-194"><a href="#cb137-194" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_type(info type);</span>
-<span id="cb137-195"><a href="#cb137-195" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_type(info type);</span>
-<span id="cb137-196"><a href="#cb137-196" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_type(info type);</span>
-<span id="cb137-197"><a href="#cb137-197" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_object_pointer_type(info type);</span>
-<span id="cb137-198"><a href="#cb137-198" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_function_pointer_type(info type);</span>
-<span id="cb137-199"><a href="#cb137-199" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enum_type(info type);</span>
-<span id="cb137-200"><a href="#cb137-200" aria-hidden="true" tabindex="-1"></a>  consteval bool is_union_type(info type);</span>
-<span id="cb137-201"><a href="#cb137-201" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_type(info type);</span>
-<span id="cb137-202"><a href="#cb137-202" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_type(info type);</span>
-<span id="cb137-203"><a href="#cb137-203" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reflection_type(info type);</span>
-<span id="cb137-204"><a href="#cb137-204" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-205"><a href="#cb137-205" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
-<span id="cb137-206"><a href="#cb137-206" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reference_type(info type);</span>
-<span id="cb137-207"><a href="#cb137-207" aria-hidden="true" tabindex="-1"></a>  consteval bool is_arithmetic_type(info type);</span>
-<span id="cb137-208"><a href="#cb137-208" aria-hidden="true" tabindex="-1"></a>  consteval bool is_fundamental_type(info type);</span>
-<span id="cb137-209"><a href="#cb137-209" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object_type(info type);</span>
-<span id="cb137-210"><a href="#cb137-210" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scalar_type(info type);</span>
-<span id="cb137-211"><a href="#cb137-211" aria-hidden="true" tabindex="-1"></a>  consteval bool is_compound_type(info type);</span>
-<span id="cb137-212"><a href="#cb137-212" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_pointer_type(info type);</span>
-<span id="cb137-213"><a href="#cb137-213" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-214"><a href="#cb137-214" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
-<span id="cb137-215"><a href="#cb137-215" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const_type(info type);</span>
-<span id="cb137-216"><a href="#cb137-216" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile_type(info type);</span>
-<span id="cb137-217"><a href="#cb137-217" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivial_type(info type);</span>
-<span id="cb137-218"><a href="#cb137-218" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copyable_type(info type);</span>
-<span id="cb137-219"><a href="#cb137-219" aria-hidden="true" tabindex="-1"></a>  consteval bool is_standard_layout_type(info type);</span>
-<span id="cb137-220"><a href="#cb137-220" aria-hidden="true" tabindex="-1"></a>  consteval bool is_empty_type(info type);</span>
-<span id="cb137-221"><a href="#cb137-221" aria-hidden="true" tabindex="-1"></a>  consteval bool is_polymorphic_type(info type);</span>
-<span id="cb137-222"><a href="#cb137-222" aria-hidden="true" tabindex="-1"></a>  consteval bool is_abstract_type(info type);</span>
-<span id="cb137-223"><a href="#cb137-223" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final_type(info type);</span>
-<span id="cb137-224"><a href="#cb137-224" aria-hidden="true" tabindex="-1"></a>  consteval bool is_aggregate_type(info type);</span>
-<span id="cb137-225"><a href="#cb137-225" aria-hidden="true" tabindex="-1"></a>  consteval bool is_signed_type(info type);</span>
-<span id="cb137-226"><a href="#cb137-226" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unsigned_type(info type);</span>
-<span id="cb137-227"><a href="#cb137-227" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bounded_array_type(info type);</span>
-<span id="cb137-228"><a href="#cb137-228" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unbounded_array_type(info type);</span>
-<span id="cb137-229"><a href="#cb137-229" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scoped_enum_type(info type);</span>
-<span id="cb137-230"><a href="#cb137-230" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-231"><a href="#cb137-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-232"><a href="#cb137-232" aria-hidden="true" tabindex="-1"></a>    consteval bool is_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb137-233"><a href="#cb137-233" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructible_type(info type);</span>
-<span id="cb137-234"><a href="#cb137-234" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructible_type(info type);</span>
-<span id="cb137-235"><a href="#cb137-235" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructible_type(info type);</span>
-<span id="cb137-236"><a href="#cb137-236" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-237"><a href="#cb137-237" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignable_type(info type_dst, info type_src);</span>
-<span id="cb137-238"><a href="#cb137-238" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignable_type(info type);</span>
-<span id="cb137-239"><a href="#cb137-239" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignable_type(info type);</span>
-<span id="cb137-240"><a href="#cb137-240" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-241"><a href="#cb137-241" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_with_type(info type_dst, info type_src);</span>
-<span id="cb137-242"><a href="#cb137-242" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_type(info type);</span>
-<span id="cb137-243"><a href="#cb137-243" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-244"><a href="#cb137-244" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructible_type(info type);</span>
-<span id="cb137-245"><a href="#cb137-245" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-246"><a href="#cb137-246" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-247"><a href="#cb137-247" aria-hidden="true" tabindex="-1"></a>    consteval bool is_trivially_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb137-248"><a href="#cb137-248" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_default_constructible_type(info type);</span>
-<span id="cb137-249"><a href="#cb137-249" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_constructible_type(info type);</span>
-<span id="cb137-250"><a href="#cb137-250" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_constructible_type(info type);</span>
-<span id="cb137-251"><a href="#cb137-251" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-252"><a href="#cb137-252" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_assignable_type(info type_dst, info type_src);</span>
-<span id="cb137-253"><a href="#cb137-253" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_assignable_type(info type);</span>
-<span id="cb137-254"><a href="#cb137-254" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_assignable_type(info type);</span>
-<span id="cb137-255"><a href="#cb137-255" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_destructible_type(info type);</span>
-<span id="cb137-256"><a href="#cb137-256" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-257"><a href="#cb137-257" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-258"><a href="#cb137-258" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb137-259"><a href="#cb137-259" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_default_constructible_type(info type);</span>
-<span id="cb137-260"><a href="#cb137-260" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_constructible_type(info type);</span>
-<span id="cb137-261"><a href="#cb137-261" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_constructible_type(info type);</span>
-<span id="cb137-262"><a href="#cb137-262" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-263"><a href="#cb137-263" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_assignable_type(info type_dst, info type_src);</span>
-<span id="cb137-264"><a href="#cb137-264" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_assignable_type(info type);</span>
-<span id="cb137-265"><a href="#cb137-265" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_assignable_type(info type);</span>
-<span id="cb137-266"><a href="#cb137-266" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-267"><a href="#cb137-267" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_with_type(info type_dst, info type_src);</span>
-<span id="cb137-268"><a href="#cb137-268" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_type(info type);</span>
-<span id="cb137-269"><a href="#cb137-269" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-270"><a href="#cb137-270" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_destructible_type(info type);</span>
-<span id="cb137-271"><a href="#cb137-271" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-272"><a href="#cb137-272" aria-hidden="true" tabindex="-1"></a>  consteval bool is_implicit_lifetime_type(info type);</span>
-<span id="cb137-273"><a href="#cb137-273" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-274"><a href="#cb137-274" aria-hidden="true" tabindex="-1"></a>  consteval bool has_virtual_destructor(info type);</span>
-<span id="cb137-275"><a href="#cb137-275" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-276"><a href="#cb137-276" aria-hidden="true" tabindex="-1"></a>  consteval bool has_unique_object_representations(info type);</span>
-<span id="cb137-277"><a href="#cb137-277" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-278"><a href="#cb137-278" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_constructs_from_temporary(info type_dst, info type_src);</span>
-<span id="cb137-279"><a href="#cb137-279" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_converts_from_temporary(info type_dst, info type_src);</span>
-<span id="cb137-280"><a href="#cb137-280" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-281"><a href="#cb137-281" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
-<span id="cb137-282"><a href="#cb137-282" aria-hidden="true" tabindex="-1"></a>  consteval size_t rank(info type);</span>
-<span id="cb137-283"><a href="#cb137-283" aria-hidden="true" tabindex="-1"></a>  consteval size_t extent(info type, unsigned i = 0);</span>
-<span id="cb137-284"><a href="#cb137-284" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-285"><a href="#cb137-285" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
-<span id="cb137-286"><a href="#cb137-286" aria-hidden="true" tabindex="-1"></a>  consteval bool is_same_type(info type1, info type2);</span>
-<span id="cb137-287"><a href="#cb137-287" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base_of_type(info type_base, info type_derived);</span>
-<span id="cb137-288"><a href="#cb137-288" aria-hidden="true" tabindex="-1"></a>  consteval bool is_convertible_type(info type_src, info type_dst);</span>
-<span id="cb137-289"><a href="#cb137-289" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_convertible_type(info type_src, info type_dst);</span>
-<span id="cb137-290"><a href="#cb137-290" aria-hidden="true" tabindex="-1"></a>  consteval bool is_layout_compatible_type(info type1, info type2);</span>
-<span id="cb137-291"><a href="#cb137-291" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_interconvertible_base_of_type(info type_base, info type_derived);</span>
-<span id="cb137-292"><a href="#cb137-292" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-293"><a href="#cb137-293" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-294"><a href="#cb137-294" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb137-295"><a href="#cb137-295" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-296"><a href="#cb137-296" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb137-297"><a href="#cb137-297" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-298"><a href="#cb137-298" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-299"><a href="#cb137-299" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb137-300"><a href="#cb137-300" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-301"><a href="#cb137-301" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb137-302"><a href="#cb137-302" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-303"><a href="#cb137-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
-<span id="cb137-304"><a href="#cb137-304" aria-hidden="true" tabindex="-1"></a>  consteval info remove_const(info type);</span>
-<span id="cb137-305"><a href="#cb137-305" aria-hidden="true" tabindex="-1"></a>  consteval info remove_volatile(info type);</span>
-<span id="cb137-306"><a href="#cb137-306" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cv(info type);</span>
-<span id="cb137-307"><a href="#cb137-307" aria-hidden="true" tabindex="-1"></a>  consteval info add_const(info type);</span>
-<span id="cb137-308"><a href="#cb137-308" aria-hidden="true" tabindex="-1"></a>  consteval info add_volatile(info type);</span>
-<span id="cb137-309"><a href="#cb137-309" aria-hidden="true" tabindex="-1"></a>  consteval info add_cv(info type);</span>
-<span id="cb137-310"><a href="#cb137-310" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-311"><a href="#cb137-311" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
-<span id="cb137-312"><a href="#cb137-312" aria-hidden="true" tabindex="-1"></a>  consteval info remove_reference(info type);</span>
-<span id="cb137-313"><a href="#cb137-313" aria-hidden="true" tabindex="-1"></a>  consteval info add_lvalue_reference(info type);</span>
-<span id="cb137-314"><a href="#cb137-314" aria-hidden="true" tabindex="-1"></a>  consteval info add_rvalue_reference(info type);</span>
-<span id="cb137-315"><a href="#cb137-315" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-316"><a href="#cb137-316" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
-<span id="cb137-317"><a href="#cb137-317" aria-hidden="true" tabindex="-1"></a>  consteval info make_signed(info type);</span>
-<span id="cb137-318"><a href="#cb137-318" aria-hidden="true" tabindex="-1"></a>  consteval info make_unsigned(info type);</span>
-<span id="cb137-319"><a href="#cb137-319" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-320"><a href="#cb137-320" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
-<span id="cb137-321"><a href="#cb137-321" aria-hidden="true" tabindex="-1"></a>  consteval info remove_extent(info type);</span>
-<span id="cb137-322"><a href="#cb137-322" aria-hidden="true" tabindex="-1"></a>  consteval info remove_all_extents(info type);</span>
-<span id="cb137-323"><a href="#cb137-323" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-324"><a href="#cb137-324" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
-<span id="cb137-325"><a href="#cb137-325" aria-hidden="true" tabindex="-1"></a>  consteval info remove_pointer(info type);</span>
-<span id="cb137-326"><a href="#cb137-326" aria-hidden="true" tabindex="-1"></a>  consteval info add_pointer(info type);</span>
-<span id="cb137-327"><a href="#cb137-327" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-328"><a href="#cb137-328" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
-<span id="cb137-329"><a href="#cb137-329" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cvref(info type);</span>
-<span id="cb137-330"><a href="#cb137-330" aria-hidden="true" tabindex="-1"></a>  consteval info decay(info type);</span>
-<span id="cb137-331"><a href="#cb137-331" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-332"><a href="#cb137-332" aria-hidden="true" tabindex="-1"></a>    consteval info common_type(R&amp;&amp; type_args);</span>
-<span id="cb137-333"><a href="#cb137-333" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-334"><a href="#cb137-334" aria-hidden="true" tabindex="-1"></a>    consteval info common_reference(R&amp;&amp; type_args);</span>
-<span id="cb137-335"><a href="#cb137-335" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
-<span id="cb137-336"><a href="#cb137-336" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb137-337"><a href="#cb137-337" aria-hidden="true" tabindex="-1"></a>    `consteval info invoke_result(info type, R&amp;&amp; type_args);</span>
-<span id="cb137-338"><a href="#cb137-338" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_reference(info type);</span>
-<span id="cb137-339"><a href="#cb137-339" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_ref_decay(info type);</span>
-<span id="cb137-340"><a href="#cb137-340" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-341"><a href="#cb137-341" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
-<span id="cb137-342"><a href="#cb137-342" aria-hidden="true" tabindex="-1"></a>  consteval size_t tuple_size(info type);</span>
-<span id="cb137-343"><a href="#cb137-343" aria-hidden="true" tabindex="-1"></a>  consteval info tuple_element(size_t index, info type);</span>
-<span id="cb137-344"><a href="#cb137-344" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb137-345"><a href="#cb137-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
-<span id="cb137-346"><a href="#cb137-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
-<span id="cb137-347"><a href="#cb137-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">1</a></span>
+<div class="sourceCode" id="cb138"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
+<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
+<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
+<span id="cb138-5"><a href="#cb138-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-6"><a href="#cb138-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb138-7"><a href="#cb138-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
+<span id="cb138-8"><a href="#cb138-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-9"><a href="#cb138-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
+<span id="cb138-10"><a href="#cb138-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
+<span id="cb138-11"><a href="#cb138-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
+<span id="cb138-12"><a href="#cb138-12" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb138-13"><a href="#cb138-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
+<span id="cb138-14"><a href="#cb138-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
+<span id="cb138-15"><a href="#cb138-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
+<span id="cb138-16"><a href="#cb138-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
+<span id="cb138-17"><a href="#cb138-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-18"><a href="#cb138-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
+<span id="cb138-19"><a href="#cb138-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
+<span id="cb138-20"><a href="#cb138-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-21"><a href="#cb138-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
+<span id="cb138-22"><a href="#cb138-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
+<span id="cb138-23"><a href="#cb138-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-24"><a href="#cb138-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
+<span id="cb138-25"><a href="#cb138-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
+<span id="cb138-26"><a href="#cb138-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-27"><a href="#cb138-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
+<span id="cb138-28"><a href="#cb138-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-29"><a href="#cb138-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
+<span id="cb138-30"><a href="#cb138-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
+<span id="cb138-31"><a href="#cb138-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
+<span id="cb138-32"><a href="#cb138-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
+<span id="cb138-33"><a href="#cb138-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-34"><a href="#cb138-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
+<span id="cb138-35"><a href="#cb138-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
+<span id="cb138-36"><a href="#cb138-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
+<span id="cb138-37"><a href="#cb138-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
+<span id="cb138-38"><a href="#cb138-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-39"><a href="#cb138-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
+<span id="cb138-40"><a href="#cb138-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
+<span id="cb138-41"><a href="#cb138-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
+<span id="cb138-42"><a href="#cb138-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
+<span id="cb138-43"><a href="#cb138-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
+<span id="cb138-44"><a href="#cb138-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
+<span id="cb138-45"><a href="#cb138-45" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-46"><a href="#cb138-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
+<span id="cb138-47"><a href="#cb138-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
+<span id="cb138-48"><a href="#cb138-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-49"><a href="#cb138-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
+<span id="cb138-50"><a href="#cb138-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
+<span id="cb138-51"><a href="#cb138-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
+<span id="cb138-52"><a href="#cb138-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
+<span id="cb138-53"><a href="#cb138-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
+<span id="cb138-54"><a href="#cb138-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-55"><a href="#cb138-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
+<span id="cb138-56"><a href="#cb138-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
+<span id="cb138-57"><a href="#cb138-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
+<span id="cb138-58"><a href="#cb138-58" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-59"><a href="#cb138-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
+<span id="cb138-60"><a href="#cb138-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
+<span id="cb138-61"><a href="#cb138-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
+<span id="cb138-62"><a href="#cb138-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
+<span id="cb138-63"><a href="#cb138-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-64"><a href="#cb138-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
+<span id="cb138-65"><a href="#cb138-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
+<span id="cb138-66"><a href="#cb138-66" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-67"><a href="#cb138-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
+<span id="cb138-68"><a href="#cb138-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
+<span id="cb138-69"><a href="#cb138-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
+<span id="cb138-70"><a href="#cb138-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
+<span id="cb138-71"><a href="#cb138-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
+<span id="cb138-72"><a href="#cb138-72" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-73"><a href="#cb138-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
+<span id="cb138-74"><a href="#cb138-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
+<span id="cb138-75"><a href="#cb138-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
+<span id="cb138-76"><a href="#cb138-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
+<span id="cb138-77"><a href="#cb138-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
+<span id="cb138-78"><a href="#cb138-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
+<span id="cb138-79"><a href="#cb138-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
+<span id="cb138-80"><a href="#cb138-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
+<span id="cb138-81"><a href="#cb138-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
+<span id="cb138-82"><a href="#cb138-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
+<span id="cb138-83"><a href="#cb138-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
+<span id="cb138-84"><a href="#cb138-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
+<span id="cb138-85"><a href="#cb138-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
+<span id="cb138-86"><a href="#cb138-86" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-87"><a href="#cb138-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
+<span id="cb138-88"><a href="#cb138-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
+<span id="cb138-89"><a href="#cb138-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
+<span id="cb138-90"><a href="#cb138-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
+<span id="cb138-91"><a href="#cb138-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
+<span id="cb138-92"><a href="#cb138-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
+<span id="cb138-93"><a href="#cb138-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
+<span id="cb138-94"><a href="#cb138-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
+<span id="cb138-95"><a href="#cb138-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
+<span id="cb138-96"><a href="#cb138-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
+<span id="cb138-97"><a href="#cb138-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
+<span id="cb138-98"><a href="#cb138-98" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-99"><a href="#cb138-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
+<span id="cb138-100"><a href="#cb138-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
+<span id="cb138-101"><a href="#cb138-101" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-102"><a href="#cb138-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
+<span id="cb138-103"><a href="#cb138-103" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-104"><a href="#cb138-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
+<span id="cb138-105"><a href="#cb138-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
+<span id="cb138-106"><a href="#cb138-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
+<span id="cb138-107"><a href="#cb138-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
+<span id="cb138-108"><a href="#cb138-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
+<span id="cb138-109"><a href="#cb138-109" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-110"><a href="#cb138-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
+<span id="cb138-111"><a href="#cb138-111" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-112"><a href="#cb138-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
+<span id="cb138-113"><a href="#cb138-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
+<span id="cb138-114"><a href="#cb138-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
+<span id="cb138-115"><a href="#cb138-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
+<span id="cb138-116"><a href="#cb138-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
+<span id="cb138-117"><a href="#cb138-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
+<span id="cb138-118"><a href="#cb138-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
+<span id="cb138-119"><a href="#cb138-119" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-120"><a href="#cb138-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
+<span id="cb138-121"><a href="#cb138-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
+<span id="cb138-122"><a href="#cb138-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
+<span id="cb138-123"><a href="#cb138-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
+<span id="cb138-124"><a href="#cb138-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
+<span id="cb138-125"><a href="#cb138-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
+<span id="cb138-126"><a href="#cb138-126" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-127"><a href="#cb138-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
+<span id="cb138-128"><a href="#cb138-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
+<span id="cb138-129"><a href="#cb138-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
+<span id="cb138-130"><a href="#cb138-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
+<span id="cb138-131"><a href="#cb138-131" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-132"><a href="#cb138-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
+<span id="cb138-133"><a href="#cb138-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
+<span id="cb138-134"><a href="#cb138-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
+<span id="cb138-135"><a href="#cb138-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
+<span id="cb138-136"><a href="#cb138-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
+<span id="cb138-137"><a href="#cb138-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
+<span id="cb138-138"><a href="#cb138-138" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb138-139"><a href="#cb138-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
+<span id="cb138-140"><a href="#cb138-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
+<span id="cb138-141"><a href="#cb138-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
+<span id="cb138-142"><a href="#cb138-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
+<span id="cb138-143"><a href="#cb138-143" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-144"><a href="#cb138-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
+<span id="cb138-145"><a href="#cb138-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb138-146"><a href="#cb138-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
+<span id="cb138-147"><a href="#cb138-147" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-148"><a href="#cb138-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
+<span id="cb138-149"><a href="#cb138-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
+<span id="cb138-150"><a href="#cb138-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
+<span id="cb138-151"><a href="#cb138-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-152"><a href="#cb138-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-153"><a href="#cb138-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb138-154"><a href="#cb138-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-155"><a href="#cb138-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb138-156"><a href="#cb138-156" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-157"><a href="#cb138-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
+<span id="cb138-158"><a href="#cb138-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb138-159"><a href="#cb138-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
+<span id="cb138-160"><a href="#cb138-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb138-161"><a href="#cb138-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
+<span id="cb138-162"><a href="#cb138-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb138-163"><a href="#cb138-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
+<span id="cb138-164"><a href="#cb138-164" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-165"><a href="#cb138-165" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define.aggregate], class definition generation</span>
+<span id="cb138-166"><a href="#cb138-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options {</span>
+<span id="cb138-167"><a href="#cb138-167" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
+<span id="cb138-168"><a href="#cb138-168" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
+<span id="cb138-169"><a href="#cb138-169" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb138-170"><a href="#cb138-170" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-171"><a href="#cb138-171" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
+<span id="cb138-172"><a href="#cb138-172" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb138-173"><a href="#cb138-173" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-174"><a href="#cb138-174" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
+<span id="cb138-175"><a href="#cb138-175" aria-hidden="true" tabindex="-1"></a>    };</span>
+<span id="cb138-176"><a href="#cb138-176" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-177"><a href="#cb138-177" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
+<span id="cb138-178"><a href="#cb138-178" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
+<span id="cb138-179"><a href="#cb138-179" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; bit_width;</span>
+<span id="cb138-180"><a href="#cb138-180" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
+<span id="cb138-181"><a href="#cb138-181" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb138-182"><a href="#cb138-182" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
+<span id="cb138-183"><a href="#cb138-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options options = {});</span>
+<span id="cb138-184"><a href="#cb138-184" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
+<span id="cb138-185"><a href="#cb138-185" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-186"><a href="#cb138-186" aria-hidden="true" tabindex="-1"></a>  consteval info define_aggregate(info type_class, R&amp;&amp;);</span>
+<span id="cb138-187"><a href="#cb138-187" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-188"><a href="#cb138-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
+<span id="cb138-189"><a href="#cb138-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type);</span>
+<span id="cb138-190"><a href="#cb138-190" aria-hidden="true" tabindex="-1"></a>  consteval bool is_null_pointer_type(info type);</span>
+<span id="cb138-191"><a href="#cb138-191" aria-hidden="true" tabindex="-1"></a>  consteval bool is_integral_type(info type);</span>
+<span id="cb138-192"><a href="#cb138-192" aria-hidden="true" tabindex="-1"></a>  consteval bool is_floating_point_type(info type);</span>
+<span id="cb138-193"><a href="#cb138-193" aria-hidden="true" tabindex="-1"></a>  consteval bool is_array_type(info type);</span>
+<span id="cb138-194"><a href="#cb138-194" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_type(info type);</span>
+<span id="cb138-195"><a href="#cb138-195" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_type(info type);</span>
+<span id="cb138-196"><a href="#cb138-196" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_type(info type);</span>
+<span id="cb138-197"><a href="#cb138-197" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_object_pointer_type(info type);</span>
+<span id="cb138-198"><a href="#cb138-198" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_function_pointer_type(info type);</span>
+<span id="cb138-199"><a href="#cb138-199" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enum_type(info type);</span>
+<span id="cb138-200"><a href="#cb138-200" aria-hidden="true" tabindex="-1"></a>  consteval bool is_union_type(info type);</span>
+<span id="cb138-201"><a href="#cb138-201" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_type(info type);</span>
+<span id="cb138-202"><a href="#cb138-202" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_type(info type);</span>
+<span id="cb138-203"><a href="#cb138-203" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reflection_type(info type);</span>
+<span id="cb138-204"><a href="#cb138-204" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-205"><a href="#cb138-205" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
+<span id="cb138-206"><a href="#cb138-206" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reference_type(info type);</span>
+<span id="cb138-207"><a href="#cb138-207" aria-hidden="true" tabindex="-1"></a>  consteval bool is_arithmetic_type(info type);</span>
+<span id="cb138-208"><a href="#cb138-208" aria-hidden="true" tabindex="-1"></a>  consteval bool is_fundamental_type(info type);</span>
+<span id="cb138-209"><a href="#cb138-209" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object_type(info type);</span>
+<span id="cb138-210"><a href="#cb138-210" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scalar_type(info type);</span>
+<span id="cb138-211"><a href="#cb138-211" aria-hidden="true" tabindex="-1"></a>  consteval bool is_compound_type(info type);</span>
+<span id="cb138-212"><a href="#cb138-212" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_pointer_type(info type);</span>
+<span id="cb138-213"><a href="#cb138-213" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-214"><a href="#cb138-214" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
+<span id="cb138-215"><a href="#cb138-215" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const_type(info type);</span>
+<span id="cb138-216"><a href="#cb138-216" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile_type(info type);</span>
+<span id="cb138-217"><a href="#cb138-217" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivial_type(info type);</span>
+<span id="cb138-218"><a href="#cb138-218" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copyable_type(info type);</span>
+<span id="cb138-219"><a href="#cb138-219" aria-hidden="true" tabindex="-1"></a>  consteval bool is_standard_layout_type(info type);</span>
+<span id="cb138-220"><a href="#cb138-220" aria-hidden="true" tabindex="-1"></a>  consteval bool is_empty_type(info type);</span>
+<span id="cb138-221"><a href="#cb138-221" aria-hidden="true" tabindex="-1"></a>  consteval bool is_polymorphic_type(info type);</span>
+<span id="cb138-222"><a href="#cb138-222" aria-hidden="true" tabindex="-1"></a>  consteval bool is_abstract_type(info type);</span>
+<span id="cb138-223"><a href="#cb138-223" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final_type(info type);</span>
+<span id="cb138-224"><a href="#cb138-224" aria-hidden="true" tabindex="-1"></a>  consteval bool is_aggregate_type(info type);</span>
+<span id="cb138-225"><a href="#cb138-225" aria-hidden="true" tabindex="-1"></a>  consteval bool is_signed_type(info type);</span>
+<span id="cb138-226"><a href="#cb138-226" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unsigned_type(info type);</span>
+<span id="cb138-227"><a href="#cb138-227" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bounded_array_type(info type);</span>
+<span id="cb138-228"><a href="#cb138-228" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unbounded_array_type(info type);</span>
+<span id="cb138-229"><a href="#cb138-229" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scoped_enum_type(info type);</span>
+<span id="cb138-230"><a href="#cb138-230" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-231"><a href="#cb138-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-232"><a href="#cb138-232" aria-hidden="true" tabindex="-1"></a>    consteval bool is_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb138-233"><a href="#cb138-233" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructible_type(info type);</span>
+<span id="cb138-234"><a href="#cb138-234" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructible_type(info type);</span>
+<span id="cb138-235"><a href="#cb138-235" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructible_type(info type);</span>
+<span id="cb138-236"><a href="#cb138-236" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-237"><a href="#cb138-237" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignable_type(info type_dst, info type_src);</span>
+<span id="cb138-238"><a href="#cb138-238" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignable_type(info type);</span>
+<span id="cb138-239"><a href="#cb138-239" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignable_type(info type);</span>
+<span id="cb138-240"><a href="#cb138-240" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-241"><a href="#cb138-241" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_with_type(info type_dst, info type_src);</span>
+<span id="cb138-242"><a href="#cb138-242" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_type(info type);</span>
+<span id="cb138-243"><a href="#cb138-243" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-244"><a href="#cb138-244" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructible_type(info type);</span>
+<span id="cb138-245"><a href="#cb138-245" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-246"><a href="#cb138-246" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-247"><a href="#cb138-247" aria-hidden="true" tabindex="-1"></a>    consteval bool is_trivially_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb138-248"><a href="#cb138-248" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_default_constructible_type(info type);</span>
+<span id="cb138-249"><a href="#cb138-249" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_constructible_type(info type);</span>
+<span id="cb138-250"><a href="#cb138-250" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_constructible_type(info type);</span>
+<span id="cb138-251"><a href="#cb138-251" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-252"><a href="#cb138-252" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_assignable_type(info type_dst, info type_src);</span>
+<span id="cb138-253"><a href="#cb138-253" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_assignable_type(info type);</span>
+<span id="cb138-254"><a href="#cb138-254" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_assignable_type(info type);</span>
+<span id="cb138-255"><a href="#cb138-255" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_destructible_type(info type);</span>
+<span id="cb138-256"><a href="#cb138-256" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-257"><a href="#cb138-257" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-258"><a href="#cb138-258" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb138-259"><a href="#cb138-259" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_default_constructible_type(info type);</span>
+<span id="cb138-260"><a href="#cb138-260" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_constructible_type(info type);</span>
+<span id="cb138-261"><a href="#cb138-261" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_constructible_type(info type);</span>
+<span id="cb138-262"><a href="#cb138-262" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-263"><a href="#cb138-263" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_assignable_type(info type_dst, info type_src);</span>
+<span id="cb138-264"><a href="#cb138-264" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_assignable_type(info type);</span>
+<span id="cb138-265"><a href="#cb138-265" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_assignable_type(info type);</span>
+<span id="cb138-266"><a href="#cb138-266" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-267"><a href="#cb138-267" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_with_type(info type_dst, info type_src);</span>
+<span id="cb138-268"><a href="#cb138-268" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_type(info type);</span>
+<span id="cb138-269"><a href="#cb138-269" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-270"><a href="#cb138-270" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_destructible_type(info type);</span>
+<span id="cb138-271"><a href="#cb138-271" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-272"><a href="#cb138-272" aria-hidden="true" tabindex="-1"></a>  consteval bool is_implicit_lifetime_type(info type);</span>
+<span id="cb138-273"><a href="#cb138-273" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-274"><a href="#cb138-274" aria-hidden="true" tabindex="-1"></a>  consteval bool has_virtual_destructor(info type);</span>
+<span id="cb138-275"><a href="#cb138-275" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-276"><a href="#cb138-276" aria-hidden="true" tabindex="-1"></a>  consteval bool has_unique_object_representations(info type);</span>
+<span id="cb138-277"><a href="#cb138-277" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-278"><a href="#cb138-278" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_constructs_from_temporary(info type_dst, info type_src);</span>
+<span id="cb138-279"><a href="#cb138-279" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_converts_from_temporary(info type_dst, info type_src);</span>
+<span id="cb138-280"><a href="#cb138-280" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-281"><a href="#cb138-281" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
+<span id="cb138-282"><a href="#cb138-282" aria-hidden="true" tabindex="-1"></a>  consteval size_t rank(info type);</span>
+<span id="cb138-283"><a href="#cb138-283" aria-hidden="true" tabindex="-1"></a>  consteval size_t extent(info type, unsigned i = 0);</span>
+<span id="cb138-284"><a href="#cb138-284" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-285"><a href="#cb138-285" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
+<span id="cb138-286"><a href="#cb138-286" aria-hidden="true" tabindex="-1"></a>  consteval bool is_same_type(info type1, info type2);</span>
+<span id="cb138-287"><a href="#cb138-287" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base_of_type(info type_base, info type_derived);</span>
+<span id="cb138-288"><a href="#cb138-288" aria-hidden="true" tabindex="-1"></a>  consteval bool is_convertible_type(info type_src, info type_dst);</span>
+<span id="cb138-289"><a href="#cb138-289" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_convertible_type(info type_src, info type_dst);</span>
+<span id="cb138-290"><a href="#cb138-290" aria-hidden="true" tabindex="-1"></a>  consteval bool is_layout_compatible_type(info type1, info type2);</span>
+<span id="cb138-291"><a href="#cb138-291" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_interconvertible_base_of_type(info type_base, info type_derived);</span>
+<span id="cb138-292"><a href="#cb138-292" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-293"><a href="#cb138-293" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-294"><a href="#cb138-294" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb138-295"><a href="#cb138-295" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-296"><a href="#cb138-296" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb138-297"><a href="#cb138-297" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-298"><a href="#cb138-298" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-299"><a href="#cb138-299" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb138-300"><a href="#cb138-300" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-301"><a href="#cb138-301" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb138-302"><a href="#cb138-302" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-303"><a href="#cb138-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
+<span id="cb138-304"><a href="#cb138-304" aria-hidden="true" tabindex="-1"></a>  consteval info remove_const(info type);</span>
+<span id="cb138-305"><a href="#cb138-305" aria-hidden="true" tabindex="-1"></a>  consteval info remove_volatile(info type);</span>
+<span id="cb138-306"><a href="#cb138-306" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cv(info type);</span>
+<span id="cb138-307"><a href="#cb138-307" aria-hidden="true" tabindex="-1"></a>  consteval info add_const(info type);</span>
+<span id="cb138-308"><a href="#cb138-308" aria-hidden="true" tabindex="-1"></a>  consteval info add_volatile(info type);</span>
+<span id="cb138-309"><a href="#cb138-309" aria-hidden="true" tabindex="-1"></a>  consteval info add_cv(info type);</span>
+<span id="cb138-310"><a href="#cb138-310" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-311"><a href="#cb138-311" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
+<span id="cb138-312"><a href="#cb138-312" aria-hidden="true" tabindex="-1"></a>  consteval info remove_reference(info type);</span>
+<span id="cb138-313"><a href="#cb138-313" aria-hidden="true" tabindex="-1"></a>  consteval info add_lvalue_reference(info type);</span>
+<span id="cb138-314"><a href="#cb138-314" aria-hidden="true" tabindex="-1"></a>  consteval info add_rvalue_reference(info type);</span>
+<span id="cb138-315"><a href="#cb138-315" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-316"><a href="#cb138-316" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
+<span id="cb138-317"><a href="#cb138-317" aria-hidden="true" tabindex="-1"></a>  consteval info make_signed(info type);</span>
+<span id="cb138-318"><a href="#cb138-318" aria-hidden="true" tabindex="-1"></a>  consteval info make_unsigned(info type);</span>
+<span id="cb138-319"><a href="#cb138-319" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-320"><a href="#cb138-320" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
+<span id="cb138-321"><a href="#cb138-321" aria-hidden="true" tabindex="-1"></a>  consteval info remove_extent(info type);</span>
+<span id="cb138-322"><a href="#cb138-322" aria-hidden="true" tabindex="-1"></a>  consteval info remove_all_extents(info type);</span>
+<span id="cb138-323"><a href="#cb138-323" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-324"><a href="#cb138-324" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
+<span id="cb138-325"><a href="#cb138-325" aria-hidden="true" tabindex="-1"></a>  consteval info remove_pointer(info type);</span>
+<span id="cb138-326"><a href="#cb138-326" aria-hidden="true" tabindex="-1"></a>  consteval info add_pointer(info type);</span>
+<span id="cb138-327"><a href="#cb138-327" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-328"><a href="#cb138-328" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
+<span id="cb138-329"><a href="#cb138-329" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cvref(info type);</span>
+<span id="cb138-330"><a href="#cb138-330" aria-hidden="true" tabindex="-1"></a>  consteval info decay(info type);</span>
+<span id="cb138-331"><a href="#cb138-331" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-332"><a href="#cb138-332" aria-hidden="true" tabindex="-1"></a>    consteval info common_type(R&amp;&amp; type_args);</span>
+<span id="cb138-333"><a href="#cb138-333" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-334"><a href="#cb138-334" aria-hidden="true" tabindex="-1"></a>    consteval info common_reference(R&amp;&amp; type_args);</span>
+<span id="cb138-335"><a href="#cb138-335" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
+<span id="cb138-336"><a href="#cb138-336" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb138-337"><a href="#cb138-337" aria-hidden="true" tabindex="-1"></a>    `consteval info invoke_result(info type, R&amp;&amp; type_args);</span>
+<span id="cb138-338"><a href="#cb138-338" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_reference(info type);</span>
+<span id="cb138-339"><a href="#cb138-339" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_ref_decay(info type);</span>
+<span id="cb138-340"><a href="#cb138-340" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-341"><a href="#cb138-341" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
+<span id="cb138-342"><a href="#cb138-342" aria-hidden="true" tabindex="-1"></a>  consteval size_t tuple_size(info type);</span>
+<span id="cb138-343"><a href="#cb138-343" aria-hidden="true" tabindex="-1"></a>  consteval info tuple_element(size_t index, info type);</span>
+<span id="cb138-344"><a href="#cb138-344" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb138-345"><a href="#cb138-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
+<span id="cb138-346"><a href="#cb138-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
+<span id="cb138-347"><a href="#cb138-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">2</a></span>
 The behavior of any function specified by this section is
 implementation-defined when a reflection of a construct not otherwise
 specified by this document is provided as an argument.</p>
@@ -8097,11 +8128,11 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
-<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
-<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">1</a></span>
+<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
+<span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
+<span id="cb139-3"><a href="#cb139-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb139-4"><a href="#cb139-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -8353,23 +8384,23 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tr>
 </tbody>
 </table>
-<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">2</a></span>
+<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
 unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
-<span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">4</a></span>
+<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
+<span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -8383,34 +8414,34 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">1</a></span>
+<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -8419,24 +8450,24 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8445,44 +8476,44 @@ description of a declaration of a non-static data member, then letting
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
-<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">2</a></span>
+<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
 identifier introduced by the declaration of what is represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8492,23 +8523,23 @@ then the <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> contents of <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
-<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">5</a></span>
+<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
-<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">7</a></span>
+<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -8523,59 +8554,59 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">1</a></span>
+<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb146-3"><a href="#cb146-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
 class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">2</a></span>
+<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
 function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">3</a></span>
+<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
 is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">4</a></span>
+<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">5</a></span>
+<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 ([dcl.fct.def.default]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">6</a></span>
+<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.def.default">[dcl.fct.def.default]</a></span>),
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">7</a></span>
+<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8589,8 +8620,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">8</a></span>
+<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8607,8 +8638,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">9</a></span>
+<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8617,16 +8648,16 @@ declaration of a non-static data member for which any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">10</a></span>
+<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">11</a></span>
+<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8634,38 +8665,38 @@ type (respectively), a const- or volatile-qualified function type
 (respectively), or an object, variable, non-static data member, or
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">12</a></span>
+<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><span class="kw">mutable</span></code>
 non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">13</a></span>
+<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
 rvalue-reference qualified function type (respectively), or a member
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">14</a></span>
+<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
 that has static, thread, or automatic storage duration, respectively
 ([basic.stc]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">15</a></span>
+<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb160-3"><a href="#cb160-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb160-4"><a href="#cb160-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8673,14 +8704,14 @@ type, template, or namespace whose name has internal linkage, module
 linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">16</a></span>
+<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8689,14 +8720,14 @@ there is some point in the evaluation context from which the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">18</a></span>
+<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8704,29 +8735,29 @@ or enumeration type <code class="sourceCode cpp"><em>E</em></code>, such
 that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">20</a></span>
+<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">21</a></span>
+<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">22</a></span>
+<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">23</a></span>
+<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8737,31 +8768,31 @@ instantiation of an alias template is a
 <code class="sourceCode cpp"><em>typedef-name</em></code><span>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">24</a></span>
+<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">25</a></span>
+<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
 operator function, or literal operator, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-4"><a href="#cb168-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-5"><a href="#cb168-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-6"><a href="#cb168-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">26</a></span>
+<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-4"><a href="#cb169-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-5"><a href="#cb169-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-6"><a href="#cb169-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-7"><a href="#cb169-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-8"><a href="#cb169-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-9"><a href="#cb169-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8770,15 +8801,15 @@ constructor, a move constructor, an assignment operator, a copy
 assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">27</a></span>
+<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8786,16 +8817,16 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code> but
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-5"><a href="#cb170-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-6"><a href="#cb170-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">29</a></span>
+<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-2"><a href="#cb171-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-3"><a href="#cb171-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-4"><a href="#cb171-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-5"><a href="#cb171-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-6"><a href="#cb171-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-7"><a href="#cb171-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-8"><a href="#cb171-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb171-9"><a href="#cb171-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8803,56 +8834,56 @@ variable template, class template, alias template, conversion function
 template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">30</a></span>
+<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
 function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">31</a></span>
+<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb173-2"><a href="#cb173-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">32</a></span>
+<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-2"><a href="#cb174-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">33</a></span>
+<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb175-2"><a href="#cb175-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb175-3"><a href="#cb175-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb175-4"><a href="#cb175-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb175-5"><a href="#cb175-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
 namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">34</a></span>
+<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">35</a></span>
+<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8860,70 +8891,70 @@ entity, object, or value, then the type of what is represented by
 then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">37</a></span>
+<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
-<span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
-<span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-4"><a href="#cb178-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb178-5"><a href="#cb178-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
-<span id="cb178-6"><a href="#cb178-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
-<span id="cb178-7"><a href="#cb178-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
+<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
+<span id="cb179-2"><a href="#cb179-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
+<span id="cb179-3"><a href="#cb179-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb179-4"><a href="#cb179-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb179-5"><a href="#cb179-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
+<span id="cb179-6"><a href="#cb179-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
+<span id="cb179-7"><a href="#cb179-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">39</a></span>
+<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb180-3"><a href="#cb180-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb180-4"><a href="#cb180-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb180-5"><a href="#cb180-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
-<span id="cb180-6"><a href="#cb180-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
-<span id="cb180-7"><a href="#cb180-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
-<span id="cb180-8"><a href="#cb180-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
+<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb181-3"><a href="#cb181-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb181-4"><a href="#cb181-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb181-5"><a href="#cb181-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
+<span id="cb181-6"><a href="#cb181-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
+<span id="cb181-7"><a href="#cb181-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
+<span id="cb181-8"><a href="#cb181-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">41</a></span>
+<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or
@@ -8931,48 +8962,48 @@ member, bit-field, template, namespace or
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">43</a></span>
+<div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> <em>A</em>,
 then a reflection representing the entity named by <em>A</em>.
 Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
-<div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
-<span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
-<span id="cb183-3"><a href="#cb183-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
-<span id="cb183-4"><a href="#cb183-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
-<span id="cb183-5"><a href="#cb183-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
+<div class="sourceCode" id="cb184"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
+<span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
+<span id="cb184-3"><a href="#cb184-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
+<span id="cb184-4"><a href="#cb184-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
+<span id="cb184-5"><a href="#cb184-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">45</a></span>
+<div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
-<div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
-<span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
-<span id="cb185-3"><a href="#cb185-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb185-4"><a href="#cb185-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
-<span id="cb185-5"><a href="#cb185-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
-<span id="cb185-6"><a href="#cb185-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb185-7"><a href="#cb185-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
-<span id="cb185-8"><a href="#cb185-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
+<div class="sourceCode" id="cb186"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
+<span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
+<span id="cb186-3"><a href="#cb186-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb186-4"><a href="#cb186-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
+<span id="cb186-5"><a href="#cb186-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
+<span id="cb186-6"><a href="#cb186-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb186-7"><a href="#cb186-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
+<span id="cb186-8"><a href="#cb186-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -8983,12 +9014,12 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">1</a></span>
+<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -9007,7 +9038,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -9018,11 +9049,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -9035,15 +9066,15 @@ declared within the member-specification of
 unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">6</a></span>
+<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -9052,93 +9083,93 @@ of all the direct base class specifiers, if any, of
 indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
-<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">9</a></span>
+<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">12</a></span>
+<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">15</a></span>
+<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">17</a></span>
+<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">20</a></span>
+<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">23</a></span>
+<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">26</a></span>
+<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -9152,33 +9183,33 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">1</a></span>
+<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
-<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">2</a></span>
+<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">5</a></span>
+<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9187,7 +9218,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -9199,8 +9230,8 @@ Otherwise, <code class="sourceCode cpp">size_of<span class="op">(</span>type_of<
 corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">7</a></span>
+<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -9209,28 +9240,28 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
 data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">9</a></span>
+<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9239,7 +9270,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -9252,32 +9283,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
-<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">3</a></span>
+<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">6</a></span>
+<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -9285,7 +9316,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -9293,7 +9324,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -9301,52 +9332,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">8</a></span>
+<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">11</a></span>
+<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -9357,43 +9388,43 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
-<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
-<span id="cb204-3"><a href="#cb204-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb204-4"><a href="#cb204-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">1</a></span>
+<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
+<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
+<span id="cb205-3"><a href="#cb205-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb205-4"><a href="#cb205-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb205-5"><a href="#cb205-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
-<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">5</a></span>
+<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -9403,72 +9434,72 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">1</a></span>
+<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
 value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">4</a></span>
+<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">7</a></span>
+<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -9481,19 +9512,19 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">name_type</code> are consteval-only types
 ([basic.types.general]), and are not a structural types
 ([temp.param]).</p>
-<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span>
+<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">3</a></span>
+<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9508,77 +9539,77 @@ ordinary string literal (or
 <code class="sourceCode cpp">string</code>, etc) or a UTF-8 string
 literal (or <code class="sourceCode cpp">u8string_view</code>,
 <code class="sourceCode cpp">u8string</code>, etc) equally well.</p>
-<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
-<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
 <span> — <em>end note</em> ]</span>
 </div>
-<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
+<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
+<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -9587,16 +9618,16 @@ Certain other functions in
 <code class="sourceCode cpp">identifier_of</code>) can also be used to
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
-<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">4</a></span>
+<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
 declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">5</a></span>
+<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9604,7 +9635,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -9621,18 +9652,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -9646,37 +9677,37 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
 {<code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub>k</sub></code>}
 be a sequence of <code class="sourceCode cpp">data_member_options</code>
 values such that</p>
-<div class="sourceCode" id="cb216"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
+<div class="sourceCode" id="cb217"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -9689,29 +9720,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9723,18 +9754,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9744,10 +9775,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9768,44 +9799,44 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.unary.cat]</a></span>.</p>
-<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-3"><a href="#cb217-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-4"><a href="#cb217-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-5"><a href="#cb217-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-6"><a href="#cb217-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-7"><a href="#cb217-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-8"><a href="#cb217-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-9"><a href="#cb217-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-10"><a href="#cb217-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-11"><a href="#cb217-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-12"><a href="#cb217-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-13"><a href="#cb217-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-14"><a href="#cb217-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb217-15"><a href="#cb217-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span></p>
+<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-4"><a href="#cb218-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-5"><a href="#cb218-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-6"><a href="#cb218-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-9"><a href="#cb218-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-10"><a href="#cb218-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-11"><a href="#cb218-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-12"><a href="#cb218-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-14"><a href="#cb218-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-15"><a href="#cb218-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb218"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
-<span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
-<span id="cb218-4"><a href="#cb218-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
-<span id="cb218-5"><a href="#cb218-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb218-6"><a href="#cb218-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
-<span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
-<span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
-<span id="cb218-9"><a href="#cb218-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
-<span id="cb218-10"><a href="#cb218-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
-<span id="cb218-11"><a href="#cb218-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
-<span id="cb218-12"><a href="#cb218-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb219"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
+<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
+<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
+<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
+<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
+<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
+<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
+<span id="cb219-10"><a href="#cb219-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
+<span id="cb219-11"><a href="#cb219-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
+<span id="cb219-12"><a href="#cb219-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb219-13"><a href="#cb219-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -9816,20 +9847,20 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.3 <a href="https://wg21.link/meta.unary.comp">[meta.unary.comp]</a></span>.</p>
-<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9838,7 +9869,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9848,7 +9879,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9859,7 +9890,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9871,71 +9902,71 @@ each function template <code class="sourceCode cpp">std<span class="op">::</span
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-TRAIT</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivial_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-8"><a href="#cb220-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-9"><a href="#cb220-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-10"><a href="#cb220-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-11"><a href="#cb220-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-12"><a href="#cb220-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-13"><a href="#cb220-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-14"><a href="#cb220-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-15"><a href="#cb220-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-16"><a href="#cb220-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-17"><a href="#cb220-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb220-18"><a href="#cb220-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb220-19"><a href="#cb220-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-20"><a href="#cb220-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-21"><a href="#cb220-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-22"><a href="#cb220-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-23"><a href="#cb220-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb220-24"><a href="#cb220-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-25"><a href="#cb220-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-26"><a href="#cb220-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-27"><a href="#cb220-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb220-28"><a href="#cb220-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-29"><a href="#cb220-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-30"><a href="#cb220-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-31"><a href="#cb220-31" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-32"><a href="#cb220-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb220-33"><a href="#cb220-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb220-34"><a href="#cb220-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-35"><a href="#cb220-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-36"><a href="#cb220-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-37"><a href="#cb220-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-38"><a href="#cb220-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb220-39"><a href="#cb220-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-40"><a href="#cb220-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-41"><a href="#cb220-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-42"><a href="#cb220-42" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-43"><a href="#cb220-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb220-44"><a href="#cb220-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb220-45"><a href="#cb220-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-46"><a href="#cb220-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-47"><a href="#cb220-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-48"><a href="#cb220-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-49"><a href="#cb220-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb220-50"><a href="#cb220-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-51"><a href="#cb220-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-52"><a href="#cb220-52" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-53"><a href="#cb220-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb220-54"><a href="#cb220-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-55"><a href="#cb220-55" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-56"><a href="#cb220-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-57"><a href="#cb220-57" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-58"><a href="#cb220-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-59"><a href="#cb220-59" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-60"><a href="#cb220-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-61"><a href="#cb220-61" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-62"><a href="#cb220-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-63"><a href="#cb220-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb220-64"><a href="#cb220-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb220-65"><a href="#cb220-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivial_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-4"><a href="#cb221-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-5"><a href="#cb221-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-6"><a href="#cb221-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-8"><a href="#cb221-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-9"><a href="#cb221-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-10"><a href="#cb221-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-11"><a href="#cb221-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-12"><a href="#cb221-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-13"><a href="#cb221-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-14"><a href="#cb221-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-15"><a href="#cb221-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-17"><a href="#cb221-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-18"><a href="#cb221-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-19"><a href="#cb221-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-20"><a href="#cb221-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-21"><a href="#cb221-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-22"><a href="#cb221-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-23"><a href="#cb221-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-24"><a href="#cb221-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-25"><a href="#cb221-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-26"><a href="#cb221-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-27"><a href="#cb221-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-28"><a href="#cb221-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-29"><a href="#cb221-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-30"><a href="#cb221-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-31"><a href="#cb221-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-32"><a href="#cb221-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-33"><a href="#cb221-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-34"><a href="#cb221-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-35"><a href="#cb221-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-36"><a href="#cb221-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-37"><a href="#cb221-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-38"><a href="#cb221-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-39"><a href="#cb221-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-40"><a href="#cb221-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-41"><a href="#cb221-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-42"><a href="#cb221-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-43"><a href="#cb221-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-44"><a href="#cb221-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-45"><a href="#cb221-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-46"><a href="#cb221-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-47"><a href="#cb221-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-48"><a href="#cb221-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-49"><a href="#cb221-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-50"><a href="#cb221-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-51"><a href="#cb221-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-52"><a href="#cb221-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-53"><a href="#cb221-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-54"><a href="#cb221-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-55"><a href="#cb221-55" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-56"><a href="#cb221-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-57"><a href="#cb221-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-58"><a href="#cb221-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-59"><a href="#cb221-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-60"><a href="#cb221-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-61"><a href="#cb221-61" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-62"><a href="#cb221-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-63"><a href="#cb221-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-64"><a href="#cb221-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb221-65"><a href="#cb221-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9944,13 +9975,13 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">1</a></span>
+<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
-<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">2</a></span>
+<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9962,10 +9993,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9974,7 +10005,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9986,7 +10017,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9999,23 +10030,23 @@ each ternary function template <code class="sourceCode cpp">std<span class="op">
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL-R</em><span class="op">(^</span>R, <span class="op">^</span>T, r<span class="op">)</span>_type</code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL-R</em>_v<span class="op">&lt;</span>R, T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb223-3"><a href="#cb223-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb223-4"><a href="#cb223-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb223-5"><a href="#cb223-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb223-6"><a href="#cb223-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb223-7"><a href="#cb223-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb223-8"><a href="#cb223-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb223-9"><a href="#cb223-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb223-10"><a href="#cb223-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb223-11"><a href="#cb223-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb223-12"><a href="#cb223-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb223-13"><a href="#cb223-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb223-15"><a href="#cb223-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb223-16"><a href="#cb223-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">5</a></span>
+<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb224-3"><a href="#cb224-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb224-4"><a href="#cb224-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb224-5"><a href="#cb224-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb224-6"><a href="#cb224-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb224-7"><a href="#cb224-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb224-8"><a href="#cb224-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb224-9"><a href="#cb224-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb224-10"><a href="#cb224-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb224-11"><a href="#cb224-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb224-12"><a href="#cb224-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb224-13"><a href="#cb224-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb224-14"><a href="#cb224-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb224-15"><a href="#cb224-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb224-16"><a href="#cb224-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -10037,7 +10068,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -10049,59 +10080,24 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">1</a></span>
-For any type or
-<code class="sourceCode cpp"><em>typedef-name</em></code>
-<code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
-defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
-returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
-as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
-<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-3"><a href="#cb224-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-4"><a href="#cb224-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-5"><a href="#cb224-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-6"><a href="#cb224-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-</div>
-</blockquote>
-</div>
-<h4 class="unnumbered" id="meta.reflection.trans.ref-reference-modifications">[meta.reflection.trans.ref],
-Reference modifications<a href="#meta.reflection.trans.ref-reference-modifications" class="self-link"></a></h4>
-<div class="std">
-<blockquote>
-<div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
-For any type or
-<code class="sourceCode cpp"><em>typedef-name</em></code>
-<code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
-defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
-returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
-as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
-<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-</div>
-</blockquote>
-</div>
-<h4 class="unnumbered" id="meta.reflection.trans.sign-sign-modifications">[meta.reflection.trans.sign],
-Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class="self-link"></a></h4>
-<div class="std">
-<blockquote>
-<div class="addu">
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
-as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
-<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
+<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-4"><a href="#cb225-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-5"><a href="#cb225-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-6"><a href="#cb225-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<h4 class="unnumbered" id="meta.reflection.trans.arr-array-modifications">[meta.reflection.trans.arr],
-Array modifications<a href="#meta.reflection.trans.arr-array-modifications" class="self-link"></a></h4>
+<h4 class="unnumbered" id="meta.reflection.trans.ref-reference-modifications">[meta.reflection.trans.ref],
+Reference modifications<a href="#meta.reflection.trans.ref-reference-modifications" class="self-link"></a></h4>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -10111,14 +10107,15 @@ For any type or
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
-as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
-<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
+<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-3"><a href="#cb226-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<h4 class="unnumbered" id="meta.reflection.trans.ptr-pointer-modifications">[meta.reflection.trans.ptr],
-Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" class="self-link"></a></h4>
+<h4 class="unnumbered" id="meta.reflection.trans.sign-sign-modifications">[meta.reflection.trans.sign],
+Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class="self-link"></a></h4>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -10128,9 +10125,43 @@ For any type or
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
+as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
+<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+</div>
+</blockquote>
+</div>
+<h4 class="unnumbered" id="meta.reflection.trans.arr-array-modifications">[meta.reflection.trans.arr],
+Array modifications<a href="#meta.reflection.trans.arr-array-modifications" class="self-link"></a></h4>
+<div class="std">
+<blockquote>
+<div class="addu">
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">1</a></span>
+For any type or
+<code class="sourceCode cpp"><em>typedef-name</em></code>
+<code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
+defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
+returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
+as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
+<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+</div>
+</blockquote>
+</div>
+<h4 class="unnumbered" id="meta.reflection.trans.ptr-pointer-modifications">[meta.reflection.trans.ptr],
+Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" class="self-link"></a></h4>
+<div class="std">
+<blockquote>
+<div class="addu">
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">1</a></span>
+For any type or
+<code class="sourceCode cpp"><em>typedef-name</em></code>
+<code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
+defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
+returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.6 <a href="https://wg21.link/meta.trans.ptr">[meta.trans.ptr]</a></span>.</p>
-<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10149,7 +10180,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -10157,7 +10188,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -10167,7 +10198,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -10178,29 +10209,29 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>invoke_result<span class="op">(^</span>T, r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span>invoke_result_t<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 (<span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>).</p>
-<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb229-3"><a href="#cb229-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb229-4"><a href="#cb229-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb229-5"><a href="#cb229-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb229-6"><a href="#cb229-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb229-7"><a href="#cb229-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb229-8"><a href="#cb229-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">4</a></span></p>
+<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb230-3"><a href="#cb230-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb230-4"><a href="#cb230-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb230-5"><a href="#cb230-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb230-6"><a href="#cb230-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb230-7"><a href="#cb230-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb230-8"><a href="#cb230-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb230-9"><a href="#cb230-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb230-10"><a href="#cb230-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb230-11"><a href="#cb230-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
-<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb230-3"><a href="#cb230-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb230-4"><a href="#cb230-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb230-5"><a href="#cb230-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb230-6"><a href="#cb230-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb230-7"><a href="#cb230-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
-<span id="cb230-8"><a href="#cb230-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb230-9"><a href="#cb230-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
+<span id="cb231-2"><a href="#cb231-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb231-3"><a href="#cb231-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
+<span id="cb231-4"><a href="#cb231-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb231-5"><a href="#cb231-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb231-6"><a href="#cb231-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb231-7"><a href="#cb231-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
+<span id="cb231-8"><a href="#cb231-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb231-9"><a href="#cb231-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -10211,7 +10242,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -10219,7 +10250,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -10228,11 +10259,11 @@ defined in this clause with the signature <code class="sourceCode cpp">info<span
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^</span>T<span class="op">)</span></code>
 returns a reflection representing the type <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb231-2"><a href="#cb231-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb231-3"><a href="#cb231-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb231-4"><a href="#cb231-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb231-5"><a href="#cb231-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb232"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb232-3"><a href="#cb232-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb232-4"><a href="#cb232-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb232-5"><a href="#cb232-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10243,7 +10274,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -10251,27 +10282,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -10289,10 +10320,10 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb232"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
-<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
-<span id="cb232-3"><a href="#cb232-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
-<span id="cb232-4"><a href="#cb232-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
+<div class="sourceCode" id="cb233"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
+<span id="cb233-2"><a href="#cb233-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
+<span id="cb233-3"><a href="#cb233-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
+<span id="cb233-4"><a href="#cb233-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10300,7 +10331,7 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb233"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb234"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-11-12" />
+  <meta name="dcterms.date" content="2024-11-13" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-11-12</td>
+    <td>2024-11-13</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -4871,32 +4871,93 @@ reflection <em>designates</em> that source construct. For instance,
 <h3 class="unnumbered" id="lex.phases-phases-of-translation"><span>5.2
 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span> Phases of
 translation<a href="#lex.phases-phases-of-translation" class="self-link"></a></h3>
+<p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: In
+addition to changes necessary for this proposal, we are applying the
+“drive-by fix” of merging phases 7/8, in order to clarify that template
+instantiation is interleaved with translation. ]</span></p>
 <p>Modify the wording for phases 7-8 of <span>5.2 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span> as
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_5" id="pnum_5">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_5" id="pnum_5">7-8</a></span>
 Whitespace characters separating tokens are no longer significant. Each
-preprocessing token is converted into a token (5.6). The resulting
-tokens constitute a translation unit and are syntactically and
-semantically analyzed and translated. <span class="addu">Plainly
-constant-evaluated expressions ([expr.const]) appearing outside template
-declarations are evaluated in lexical order. Diagnosable rules
+preprocessing token is converted into a token (<span>5.6 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). The
+resulting tokens constitute a translation unit and are syntactically and
+semantically analyzed and translated <span class="addu">alongside any
+instantiation units (see below) that are produced</span>. <span class="addu">During this process, non-dependent plainly
+constant-evaluated expressions ([expr.const]) are evaluated in lexical
+order. Diagnosable rules (<span>4.1.1 <a href="https://wg21.link/intro.compliance.general">[intro.compliance.general]</a></span>)
+that apply to constructs whose syntactic end point occurs lexically
+after the syntactic end point of a non-dependent plainly
+constant-evaluated expression
+<code class="sourceCode cpp"><em>X</em></code> are considered in a
+context where <code class="sourceCode cpp"><em>X</em></code> has been
+evaluated exactly once.</span></p>
+<p><span class="note3"><span>[ <em>Note 3:</em> </span>The process of
+analyzing and translating the tokens can occasionally result in one
+token being replaced by a sequence of other tokens ([temp.names])<span>
+— <em>end note</em> ]</span></span></p>
+<p>It is implementation-defined whether the sources for module-units and
+header units on which the current translation unit has an interface
+dependency (<span>10.1 <a href="https://wg21.link/module.unit">[module.unit]</a></span>,
+<span>10.3 <a href="https://wg21.link/module.import">[module.import]</a></span>) are
+required to be available.</p>
+<p><span class="note"><span>[ <em>Note 4:</em> </span>Source files,
+translation units and translated translation units need not necessarily
+be stored as files, nor need there be any one-to-one correspondence
+between these entities and any external representation. The description
+is conceptual only, and does not specify any particular
+implementation.<span> — <em>end note</em> ]</span></span></p>
+<p><span class="addu">While the tokens constituting translation units
+are being analyzed and translated, a collection of required
+instantiations is produced.</span></p>
+<p><span class="rm" style="color: #bf0303"><del>Translated translation
+units and instantiation units are combined as follows:</del></span></p>
+<p><span class="rm" style="color: #bf0303"><del><span class="note5"><span>[ <em>Note 5:</em> </span>Some or all of these can
+be supplied from a library.<span> — <em>end
+note</em> ]</span></span></del></span></p>
+<p><span class="rm" style="color: #bf0303"><del>Each translated
+translation unit is examined to produce a list of required
+instantiations.</del></span></p>
+<p><span class="note5"><span>[ <em>Note 5:</em> </span>This can include
+instantiations which have been explicitly requested
+([temp.explicit]).<span> — <em>end note</em> ]</span></span></p>
+<p>The definitions of the required templates are located. It is
+implementation-defined whether the source of the translation units
+containing these definitions is required to be available.</p>
+<p><span class="rm" style="color: #bf0303"><del><span class="note"><span>[ <em>Note 6:</em> </span>An implementation can
+choose to encode sufficient information into the translated translation
+unit so as to ensure the source is not required here.<span> — <em>end
+note</em> ]</span></span></del></span></p>
+<p>All required instantiations are perfomed to produce <em>instantiation
+units</em>.</p>
+<p><span class="note"><span>[ <em>Note 7:</em> </span>These are similar
+to translated translation units, but contain no references to
+uninstantiated templates and no template definitions.<span> — <em>end
+note</em> ]</span></span></p>
+<p><span class="addu">The contexts from which instantiations may be
+performed are determined by their respective points of instantiation
+([temp.point]), and may be further constrained by other requirements in
+this document.</span></p>
+<p><span class="addu"><span class="note"><span>[ <em>Note 8:</em>
+</span>For example, a constexpr function template specialization might
+have a point of instantation at the end of a translation unit, but its
+use in certain constant expressions could require that it be
+instantiated from an earlier point ([temp.inst]).<span> — <em>end
+note</em> ]</span></span></span></p>
+<p><span class="addu">During this process, plainly constant-evaluated
+expressions appearing in the same instantiation unit are evaluated in
+lexical order as part of the instantiation process. Diagnosable rules
 (<span>4.1.1 <a href="https://wg21.link/intro.compliance.general">[intro.compliance.general]</a></span>)
 that apply to constructs whose syntactic end point occurs lexically
 after the syntactic end point of a plainly constant-evaluated expression
-X are considered in a context where X has been evaluated exactly
-once.</span> […]</p>
+<code class="sourceCode cpp"><em>X</em></code> in the same instantiation
+unit are considered in a context where
+<code class="sourceCode cpp"><em>X</em></code> has been evaluated
+exactly once.</span></p>
+<p>The program is ill-formed if any instantiation fails.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_6" id="pnum_6">8</a></span>
-[…] All the required instantiations are performed to produce
-instantiation units. <span class="addu">Plainly constant-evaluated
-expressions ([expr.const]) appearing in those instantiation units are
-evaluated in lexical order as part of the instantiation process.
-Diagnosable rules (<span>4.1.1 <a href="https://wg21.link/intro.compliance.general">[intro.compliance.general]</a></span>)
-that apply to constructs whose syntactic end point occurs lexically
-after the syntactic end point of a plainly constant-evaluated expression
-X are considered in a context where X has been evaluated exactly
-once.</span> […]</p>
+All external entity references are resolved. […]</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.4
@@ -5030,18 +5091,12 @@ determined in the following way:</p>
 <ul>
 <li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_13" id="pnum_13">(3.1)</a></span>
 If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
-its associated set of entities consists of the function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>is_type</code>
-together with an implementation-defined set of additional entities.
-<span class="note"><span>[ <em>Note 1:</em> </span>For example, an
-implementation might augment a function to the set of associated
-entities to allow a namespace of implementation-provided reflection
-operations to be found by argument-dependent lookup.<span> — <em>end
-note</em> ]</span></span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">(3.2)</a></span>
+its associated set of entities is the singleton containing the function
+<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>is_type</code>.</span>
 If <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> fundamental type, its associated set of entities is
 empty.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">(3.2)</a></span>
 If <code class="sourceCode cpp">T</code> is a class type …</li>
 </ul>
 </blockquote>
@@ -5052,7 +5107,7 @@ General<a href="#basic.lookup.qual.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">1</a></span>
 Lookup of an <em>identifier</em> followed by a
 <code class="sourceCode cpp"><span class="op">::</span></code> scope
 resolution operator considers only namespaces, types, and templates
@@ -5073,30 +5128,30 @@ Linkage<a href="#basic.link-program-and-linkage" class="self-link"></a></h3>
 <p>Add a bullet to paragraph 13:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">13</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>names</em> an entity <code class="sourceCode cpp"><em>E</em></code>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(13.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a
 <code class="sourceCode cpp"><em>lambda-expression</em></code> whose
 closure type is <code class="sourceCode cpp"><em>E</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(13.1+)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(13.1+)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code>
 contains a reflection that represents either
 <code class="sourceCode cpp"><em>E</em></code> or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> that
 denotes <code class="sourceCode cpp"><em>E</em></code>,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(13.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not a function or
 function template and <code class="sourceCode cpp"><em>D</em></code>
 contains an <em>id-expression</em>, <em>type-specifier</em>,
 <em>nested-name-specifier</em>, <em>template-name</em>, or
 <em>concept-name denoting</em>
 <code class="sourceCode cpp"><em>E</em></code>, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">(13.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.3)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a function or function
 template and <code class="sourceCode cpp"><em>D</em></code> contains an
 expression that names <code class="sourceCode cpp"><em>E</em></code>
@@ -5114,23 +5169,23 @@ also TU-local ]</span></p>
 include reflections:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">16</a></span>
 A value or object is <em>TU-local</em> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(16.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(16.1)</a></span>
 it is, or is a pointer to, a TU-local function or the object associated
 with a TU-local variable, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(16.1a)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(16.1a)</a></span>
 it is a value or object of a TU-local type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1b)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(16.1b)</a></span>
 it is a reflection representing
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1b.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1b.1)</a></span>
 a TU-local value or object, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.1b.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1b.2)</a></span>
 a <code class="sourceCode cpp"><em>typedef-name</em></code>,
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, or
 <code class="sourceCode cpp"><em>base-specifier</em></code> introduced
@@ -5139,7 +5194,7 @@ by an exposure, or</li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">(16.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.2)</a></span>
 it is an object of class or array type and any of its subobjects or any
 of the objects or functions to which its non-static data members of
 reference type refer is TU-local and is usable in constant
@@ -5153,7 +5208,7 @@ General<a href="#basic.types.general-general" class="self-link"></a></h3>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">9</a></span>
 Arithmetic types (6.8.2), enumeration types, pointer types,
 pointer-to-member types (6.8.4), <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -5166,39 +5221,39 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">12</a></span>
 A <em>consteval-only type</em> is one of the following:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(12.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(12.1)</a></span>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(12.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(12.2)</a></span>
 a pointer or reference to a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(12.3)</a></span>
 a (possibly multi-dimensional) array of a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.4)</a></span>
 a class type with a base class or non-static data member of
 consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.5)</a></span>
 a function type with a return type or parameter type of consteval-only
 type, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">(12.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.6)</a></span>
 a pointer-to-member type to a class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">M</code> where either
 <code class="sourceCode cpp">C</code> or
 <code class="sourceCode cpp">M</code> is a consteval-only type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">13</a></span>
 Every object of consteval-only type shall be</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(13.1)</a></span>
 the object associated with a constexpr variable or a subobject
 thereof,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(13.2)</a></span>
 a template parameter object (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>) or a
 subobject thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(13.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(13.3)</a></span>
 an object whose lifetime begins and ends during the evaluation of a
 manifestly constant-evaluated expression.</li>
 </ul>
@@ -5212,7 +5267,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">17 - 1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">17 - 1</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
@@ -5239,11 +5294,11 @@ document.</li>
 <p>An expression convertible to a reflection is said to
 <em>represent</em> the corresponding construct. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
 shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span><span class="dt">void</span><span class="op">*)</span></code>.</p>
-<p><span class="note"><span>[ <em>Note 1:</em> </span>Implementations
-are discouraged from representing any constructs described by this
-document that are not explicitly enumerated in the list above (e.g.,
-partial template specializations, attributes, placeholder types,
-statements).<span> — <em>end note</em> ]</span></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">17 - 2</a></span>
+<em>Recommended practice</em>: Implementations are discouraged from
+representing any constructs described by this document that are not
+explicitly enumerated in the list above (e.g., partial template
+specializations, attributes, placeholder types, statements).</p>
 </div>
 </blockquote>
 </div>
@@ -6100,72 +6155,43 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">20</a></span>
-An expression or conversion is <em>in substitution context</em> if it
-results from the substitution of template parameters</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(20.1)</a></span>
-during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(20.2)</a></span>
-in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
-<a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(20.3)</a></span>
-in a <code class="sourceCode cpp"><em>requires-expression</em></code>
-(<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">19</a></span>
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(21.1)</a></span>
-a <code class="sourceCode cpp"><em>constant-expression</em></code> that
-is not in substitution context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(21.2)</a></span>
-the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(21.3)</a></span>
-the initializer of a
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(19.1)</a></span>
+the <code class="sourceCode cpp"><em>constant-expression</em></code> of
+a <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
+(<span>9.1 <a href="https://wg21.link/dcl.pre">[dcl.pre]</a></span>),
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(19.2)</a></span>
+an initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
-variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(21.4)</a></span>
-an immediate invocation, unless it is
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(21.4.1)</a></span>
-in substitution context, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(21.4.2)</a></span>
-within the body of an immediate-escalating function that contains an
-immediate-escalating expression.</li>
-</ul></li>
+variable.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>A plainly
 constant-evaluated expression
 <code class="sourceCode cpp"><em>E</em></code> is evaluated exactly
 once, may produce injected declarations (see below), and any such
-declarations are reachable at a point immediatelly following
-<code class="sourceCode cpp"><em>E</em></code>.<span> — <em>end
-note</em> ]</span></span></p>
+declarations are reachable at a point immediately following
+<code class="sourceCode cpp"><em>E</em></code> (<span>5.2 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span>).<span>
+— <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
+<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
 <span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
 <span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
 <span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
 <span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
-<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
-<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
-<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
-<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
-<span id="cb114-18"><a href="#cb114-18" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
+<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// &#39;cfn(1)&#39; is plainly constant-evaluated.</span></span>
+<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;      <span class="co">// &#39;cfn(2)&#39; is not plainly constant-evaluated.</span></span>
+<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>b1<span class="op">)</span>;           <span class="co">// &#39;b1&#39; is plainly constant-evaluated.</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6176,22 +6202,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">20</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(22.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(20.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(22.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(20.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(20.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(20.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(22.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(20.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6214,7 +6240,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">21</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6228,12 +6254,12 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">22</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(22.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
 constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
@@ -6279,7 +6305,7 @@ once.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb115-27"><a href="#cb115-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6288,11 +6314,11 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> ([intro.execution]).</li>
@@ -6308,7 +6334,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 paragraph 3.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">3</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>typedef-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6337,7 +6363,7 @@ follows:</p>
 after nested name specifiers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>simple-type-specifier</em></code> are
 those of its
@@ -6361,7 +6387,7 @@ shall not contain a splicer.</span></p>
 be a placeholder for a deduced class type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -6472,45 +6498,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6518,7 +6544,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6527,26 +6553,26 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
 type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -6555,7 +6581,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -6569,7 +6595,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator ([expr.reflect])</span>, is ill-formed.</p>
@@ -6596,7 +6622,7 @@ follows:</p>
 <p>Modify paragraph 1 to handle splicers:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">1</a></span>
 <span class="addu">A <code class="sourceCode cpp"><span class="kw">using</span><span class="op">-</span><span class="kw">enum</span><span class="op">-</span>declarator</code>
 of the form
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6631,7 +6657,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">0</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code>
 appearing in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
@@ -6644,7 +6670,7 @@ shall designate a namespace or
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6673,7 +6699,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
 any, designates a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>. Neither
@@ -6681,7 +6707,7 @@ the <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 nor the <code class="sourceCode cpp"><em>splice-specifier</em></code>
 shall be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6745,7 +6771,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6770,7 +6796,7 @@ Global module fragment<a href="#module.global.frag-global-module-fragment" class
 <blockquote>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -6779,7 +6805,7 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
@@ -6787,7 +6813,7 @@ does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template is replaced by its
 denoted type prior to this determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(3.8)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -6798,23 +6824,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6848,7 +6874,7 @@ names<a href="#class.name-class-names" class="self-link"></a></h3>
 <p>Cover `$splice-type-specifier$s in paragraph 5.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">5</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>class-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6863,7 +6889,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6889,7 +6915,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">1</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.class.deduct]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6899,7 +6925,7 @@ When resolving a placeholder for a deduced class type
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -6908,7 +6934,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">3</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.simple]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
@@ -6929,7 +6955,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -6958,7 +6984,7 @@ form <code class="sourceCode cpp"><em>type-constraint</em></code>s.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">3+</a></span>
 A non-dependent
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
 forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
@@ -7011,7 +7037,7 @@ leverage splicers.</p>
 component name.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">2</a></span>
 The component name of a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>simple-template-id</em></code></span>,
 <span><code class="sourceCode default"><em>template-id</em></code></span>,
 or</del></span>
@@ -7029,31 +7055,31 @@ its <code class="sourceCode cpp"><em>simple-template-id</em></code>,
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows <span class="addu">either</span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(3.1)</a></span>
 a
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -7092,7 +7118,7 @@ containing
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or splicer</span> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a constrained non-function template or a
@@ -7108,7 +7134,7 @@ non-dependent ([temp.dep.temp]), the associated contraints
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">9</a></span>
 A <em>concept-id</em> is a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> where
 <span class="addu">either</span> the
@@ -7133,7 +7159,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">3</a></span>
 In a <code class="sourceCode cpp"><em>template-argument</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>, an
@@ -7166,7 +7192,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -7187,7 +7213,7 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
@@ -7196,11 +7222,11 @@ for the variable x in the invented declaration</p>
 <div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">2</a></span>
 The value of a non-type <em>template-parameter</em>
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">3</a></span>
 Otherwise, a temporary variable</p>
 <div class="sourceCode" id="cb130"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
@@ -7212,7 +7238,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be <span class="rm" style="color: #bf0303"><del>the name
@@ -7231,7 +7257,7 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 equivalence as defined by paragraph 1 to cover splicers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s are the
 same if</p>
 <ul>
@@ -7258,23 +7284,23 @@ are the same refer to the same class, function, or variable.</p>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7286,7 +7312,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -7302,7 +7328,7 @@ the class template are considered.</p>
 cannot themselves appear in deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">3</a></span>
 The same restrictions apply to the
 <code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
 of a deduction guide as in a function declaration ([dcl.fct]), except
@@ -7332,7 +7358,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -7354,7 +7380,7 @@ splicers can’t follow
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">3</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>typename-specifier</em></code> are its
 <code class="sourceCode cpp"><em>identifier</em></code> (if any) and
@@ -7364,6 +7390,60 @@ those of its
 any). <span class="addu">The
 <code class="sourceCode cpp"><em>simple-template-id</em></code> shall
 not contain a splicer.</span></p>
+</blockquote>
+</div>
+<p>Add a new case to the list of IFNDR conditions related to template
+instantiation.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">6</a></span>
+The validity of a templated entity may be checked prior to any
+instantiation.</p>
+<p><span class="note3"><span>[ <em>Note 3:</em> </span>Knowing which
+names are type names allows the syntax of every template to be checked
+in this way.<span> — <em>end note</em> ]</span></span></p>
+<p>The program is ill-formed, no diagnostic required, if</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(6.1)</a></span>
+no valid specialization, ignoring
+<code class="sourceCode cpp"><em>static_assert-declaration</em></code>s
+that fail ([dcl.pre]), can be generated for a templated entity or a
+substatement of a constexpr if statement ([stmt.if]) within a templaetd
+entity and the innermost enclosing template is not instantiated, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(6.2)</a></span>
+no valid specialization, ignoring
+<code class="sourceCode cpp"><em>static_assert-declaration</em></code>s
+that fail, can be generated for a default
+<code class="sourceCode cpp"><em>template-argument</em></code> and the
+default <code class="sourceCode cpp"><em>template-argument</em></code>
+is not used in any instantiation, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(6.3)</a></span>
+no specialization of an alias template ([temp.alias]) is valid and no
+specialization of the alias template is named in the program, or</li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(6.4)</a></span>
+any non-dependent plainly constant-evaluated expression within a
+templated entity produces an injected declaration ([expr.const]),
+or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(6.5)</a></span>
+any <code class="sourceCode cpp"><em>constraint-expression</em></code>
+in the program, introduced or otherwise, has (in its normal form) an
+atomic constraint <code class="sourceCode cpp"><em>A</em></code> where
+no satisfaction check of <code class="sourceCode cpp"><em>A</em></code>
+could be well-formed and no satisfaction check of
+<code class="sourceCode cpp"><em>A</em></code> is performed, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(6.6)</a></span>
+every valid specialization of a variadic template requires an empty
+template parameter pack, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(6.7)</a></span>
+a hypothetical instantiation of a templated entity immediately following
+its definition would be ill-formed due to a construct (other than a
+<code class="sourceCode cpp"><em>static_assert-declaration</em></code>
+that fails) that does not depend on a template parameter, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.8)</a></span>
+the interpretation of such a construct in the hypothetical instantiation
+is different from the interpretation of the corresponding construct in
+any actual instantiation of the templated entity.</li>
+</ul>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.dep.expr-type-dependent-expressions"><span>13.8.3.3 <a href="https://wg21.link/temp.dep.expr">[temp.dep.expr]</a></span>
@@ -7393,17 +7473,17 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is type-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(9.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(9.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7419,10 +7499,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -7446,17 +7526,17 @@ dependent name, names a dependent type, or contains a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is value-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(6.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(6.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7474,7 +7554,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -7492,19 +7572,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7517,7 +7597,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7525,7 +7605,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7534,14 +7614,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7987,17 +8067,18 @@ synopsis</strong></p>
 <span id="cb137-345"><a href="#cb137-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb137-346"><a href="#cb137-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb137-347"><a href="#cb137-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">2</a></span>
-Values of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-may represent implementation-defined constructs not otherwise specified
-by this document (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">2</a></span>
 The behavior of any function specified by this section is
-implementation-defined when a reflection representing such a construct
-is provided as an argument.</p>
+implementation-defined when a reflection of a construct not otherwise
+specified by this document is provided as an argument.</p>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>Values of type
+<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
+may represent implementation-defined constructs (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).<span>
+— <em>end note</em> ]</span></span></p>
 </div>
 </blockquote>
 </div>
@@ -8010,7 +8091,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -8263,10 +8344,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -8274,11 +8355,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -8293,33 +8374,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -8328,24 +8409,24 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8354,44 +8435,44 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
 identifier introduced by the declaration of what is represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8403,21 +8484,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -8435,7 +8516,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -8443,7 +8524,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -8451,7 +8532,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8459,7 +8540,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -8467,7 +8548,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8476,7 +8557,7 @@ defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8484,7 +8565,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8499,7 +8580,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8517,7 +8598,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8527,7 +8608,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -8535,7 +8616,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8544,7 +8625,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8553,7 +8634,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -8563,7 +8644,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -8574,7 +8655,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8583,13 +8664,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8599,13 +8680,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8614,20 +8695,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8635,7 +8716,7 @@ of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8647,7 +8728,7 @@ instantiation of an alias template is a
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8655,7 +8736,7 @@ instantiation of an alias template is a
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8670,7 +8751,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8680,14 +8761,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8704,7 +8785,7 @@ is
 <span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8713,7 +8794,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8722,14 +8803,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8740,7 +8821,7 @@ Otherwise,
 <span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8748,20 +8829,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8770,11 +8851,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8790,33 +8871,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8832,7 +8913,7 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or
@@ -8840,18 +8921,18 @@ member, bit-field, template, namespace or
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> <em>A</em>,
 then a reflection representing the entity named by <em>A</em>.
 Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8863,15 +8944,15 @@ Otherwise, <code class="sourceCode cpp">r</code>.</p>
 </div>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8893,11 +8974,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8916,7 +8997,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8927,11 +9008,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8945,14 +9026,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8962,92 +9043,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -9062,32 +9143,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9096,7 +9177,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -9109,7 +9190,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -9118,20 +9199,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -9139,7 +9220,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9148,7 +9229,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -9161,32 +9242,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -9194,7 +9275,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -9202,7 +9283,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -9210,52 +9291,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -9273,36 +9354,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb204-5"><a href="#cb204-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -9314,32 +9395,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -9347,37 +9428,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -9390,18 +9471,18 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9422,71 +9503,71 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -9496,7 +9577,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -9504,7 +9585,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9512,7 +9593,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -9529,18 +9610,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -9554,7 +9635,7 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9566,26 +9647,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -9598,29 +9679,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9632,18 +9713,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9653,10 +9734,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9677,7 +9758,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9699,7 +9780,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb217-13"><a href="#cb217-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb217-14"><a href="#cb217-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb217-15"><a href="#cb217-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb218"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9725,7 +9806,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9747,7 +9828,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9757,7 +9838,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9768,7 +9849,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9854,12 +9935,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9871,10 +9952,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9883,7 +9964,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9895,7 +9976,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9924,7 +10005,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb223-15"><a href="#cb223-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb223-16"><a href="#cb223-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9946,7 +10027,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9958,7 +10039,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9979,7 +10060,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9997,7 +10078,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -10014,7 +10095,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -10031,7 +10112,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -10058,7 +10139,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -10066,7 +10147,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -10076,7 +10157,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -10098,7 +10179,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -10120,7 +10201,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -10128,7 +10209,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -10152,7 +10233,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -10160,27 +10241,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -1215,7 +1215,7 @@ producing <em>reflection values</em> — <em>reflections</em> for short —
 of an opaque type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</li>
 <li>a <em>reflection operator</em> (prefix
 <code class="sourceCode cpp"><span class="op">^</span></code>) that
-produces a reflection value for its operand construct,</li>
+computes a reflection value for its operand construct,</li>
 <li>a number of
 <code class="sourceCode cpp"><span class="kw">consteval</span></code>
 <em>metafunctions</em> to work with reflections (including deriving
@@ -5413,10 +5413,10 @@ preceded by
 <span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> dependent<span class="op">()</span> <span class="op">{</span></span>
 <span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">[:</span>Var<span class="op">:]</span> <span class="op">*</span>var;                      <span class="co">// OK, multiplication of &#39;var * var&#39;</span></span>
 <span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>Cls<span class="op">:]</span> <span class="op">*</span>a;               <span class="co">// OK, declaration of &#39;cls *var&#39;</span></span>
+<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>Cls<span class="op">:]</span> <span class="op">*</span>a;               <span class="co">// OK, declaration of &#39;cls *a&#39;</span></span>
 <span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TVar<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// OK, multiplication of &#39;t_var&lt;0&gt; * var&#39;</span></span>
 <span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// error: cannot splice type as expression</span></span>
-<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>b;           <span class="co">// OK, declaration of &#39;t_cls&lt;0&gt; *var&#39;</span></span>
+<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>b;           <span class="co">// OK, declaration of &#39;t_cls&lt;0&gt; *b&#39;</span></span>
 <span id="cb106-15"><a href="#cb106-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>c;  <span class="co">// OK</span></span>
 <span id="cb106-16"><a href="#cb106-16" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb106-17"><a href="#cb106-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>Concept<span class="op">:]</span> <span class="kw">auto</span> <span class="op">*</span>d <span class="op">=</span> <span class="dv">0</span>;  <span class="co">// OK, deduced placeholder type</span></span>
@@ -5869,7 +5869,7 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><strong>The Reflection Operator [expr.reflect]</strong></p>
+<p><strong>The reflection operator [expr.reflect]</strong></p>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 following grammar avoids use of
 <code class="sourceCode default"><em>id-expression</em></code>, even
@@ -5918,22 +5918,22 @@ syntactically form a
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">4</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
 the form <code class="sourceCode cpp"><span class="op">^</span> <span class="op">::</span></code>
-produces a reflection of the global namespace.</p>
+computes a reflection of the global namespace.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">5</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
 the form <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>
 or <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>
 performs name lookup for the operand following
 <code class="sourceCode cpp"><span class="op">^</span></code> and
-produces a result as follows:</p>
+computes a result as follows:</p>
 <ul>
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(5.1)</a></span>
 If the lookup finds an overload set
-<code class="sourceCode cpp"><em>S</em></code> such that the assignment
-of
-<code class="sourceCode cpp"><span class="op">&amp;</span><em>S</em></code>
-to an invented variable of type <code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
+<code class="sourceCode cpp"><em>S</em></code> such that the
+initialization of an invented variable of type <code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
 (<span>9.2.9.7.2 <a href="https://wg21.link/dcl.type.auto.deduct">[dcl.type.auto.deduct]</a></span>)
+with
+<code class="sourceCode cpp"><span class="op">&amp;</span><em>S</em></code>
 would select a unique candidate function
 <code class="sourceCode cpp"><em>F</em></code> from
 <code class="sourceCode cpp"><em>S</em></code>, then the result is a
@@ -5956,7 +5956,7 @@ result is a reflection of the denoted entity.</p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(5.5)</a></span>
 Otherwise, if the lookup finds an implementation-defined construct not
 otherwise specified by this document, then the implementation may
-produce a reflection of the denoted construct.</p></li>
+compute a reflection of the denoted construct.</p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(5.6)</a></span>
 Otherwise, the program is ill-formed.</p></li>
 </ul>
@@ -5964,7 +5964,7 @@ Otherwise, the program is ill-formed.</p></li>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form
 <code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
-produces a reflection of the denoted type. A
+computes a reflection of the denoted type. A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> that
 could be validly interpreted as either <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>
 or
@@ -5978,7 +5978,7 @@ is interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>qua
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">7</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
 the form <code class="sourceCode cpp"><span class="op">^</span> <em>pack-index-expression</em></code>
-produces a reflection of the result computed by the
+computes a reflection of the result computed by the
 <code class="sourceCode cpp"><em>pack-index-expression</em></code>.</p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
@@ -7708,7 +7708,7 @@ template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
 entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 </span>For example, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>members_of</code>
-might not produce reflections of standard functions that an
+might not return reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">6b</a></span>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -5411,21 +5411,21 @@ preceded by
 <span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> Var, <span class="kw">auto</span> Cls, <span class="kw">auto</span> TVar, <span class="kw">auto</span> TCls, <span class="kw">auto</span> Concept<span class="op">&gt;</span></span>
 <span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> dependent<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">[:</span>Var<span class="op">:]</span> <span class="op">*</span>var;                      <span class="co">// ok: multiplication of &#39;var * var&#39;.</span></span>
+<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">[:</span>Var<span class="op">:]</span> <span class="op">*</span>var;                      <span class="co">// OK, multiplication of &#39;var * var&#39;</span></span>
 <span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>Cls<span class="op">:]</span> <span class="op">*</span>a;               <span class="co">// ok: declaration of &#39;cls *var&#39;</span></span>
-<span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TVar<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// ok: multiplication of &#39;t_var&lt;0&gt; * var&#39;.</span></span>
-<span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// error: cannot splice type as expression.</span></span>
-<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>b;           <span class="co">// ok: declaration of &#39;t_cls&lt;0&gt; *var&#39;.</span></span>
-<span id="cb106-15"><a href="#cb106-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>c;  <span class="co">// also ok.</span></span>
+<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>Cls<span class="op">:]</span> <span class="op">*</span>a;               <span class="co">// OK, declaration of &#39;cls *var&#39;</span></span>
+<span id="cb106-12"><a href="#cb106-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TVar<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// OK, multiplication of &#39;t_var&lt;0&gt; * var&#39;</span></span>
+<span id="cb106-13"><a href="#cb106-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;         <span class="co">// error: cannot splice type as expression</span></span>
+<span id="cb106-14"><a href="#cb106-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>b;           <span class="co">// OK, declaration of &#39;t_cls&lt;0&gt; *var&#39;</span></span>
+<span id="cb106-15"><a href="#cb106-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="kw">typename</span> <span class="op">[:</span>TCls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>c;  <span class="co">// OK</span></span>
 <span id="cb106-16"><a href="#cb106-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb106-17"><a href="#cb106-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>Concept<span class="op">:]</span> <span class="kw">auto</span> <span class="op">*</span>d <span class="op">=</span> <span class="dv">0</span>;  <span class="co">// ok: deduced placeholder type.</span></span>
+<span id="cb106-17"><a href="#cb106-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:</span>Concept<span class="op">:]</span> <span class="kw">auto</span> <span class="op">*</span>d <span class="op">=</span> <span class="dv">0</span>;  <span class="co">// OK, deduced placeholder type</span></span>
 <span id="cb106-18"><a href="#cb106-18" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb106-19"><a href="#cb106-19" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb106-20"><a href="#cb106-20" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> non_dependent<span class="op">()</span> <span class="op">{</span></span>
 <span id="cb106-21"><a href="#cb106-21" aria-hidden="true" tabindex="-1"></a>  dependent<span class="op">&lt;^</span>var, <span class="op">^</span>cls, <span class="op">^</span>t_var, <span class="op">^</span>t_cls, <span class="op">^</span>always_true<span class="op">&gt;()</span>;</span>
 <span id="cb106-22"><a href="#cb106-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb106-23"><a href="#cb106-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:^</span>t_cls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;  <span class="co">// ok in non-dependent context.</span></span>
+<span id="cb106-23"><a href="#cb106-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">[:^</span>t_cls<span class="op">:]&lt;</span><span class="dv">0</span><span class="op">&gt;</span> <span class="op">*</span>var;  <span class="co">// OK, non-dependent context</span></span>
 <span id="cb106-24"><a href="#cb106-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -6664,11 +6664,12 @@ follows:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">1</a></span>
-<span class="addu">A <code class="sourceCode cpp"><span class="kw">using</span><span class="op">-</span><span class="kw">enum</span><span class="op">-</span>declarator</code>
-of the form
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
-considered in a type-only context, and designates the same construct
-designated by the splicer. Any other</span> <span class="rm" style="color: #bf0303"><del>A</del></span>
+<span class="addu">A
+<code class="sourceCode cpp"><em>using-enum-declarator</em></code> of
+the form
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code> is a
+type-only context, and designates the same construct designated by the
+splicer. Any other</span> <span class="rm" style="color: #bf0303"><del>A</del></span>
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> names
 the set of declarations found by type-only lookup
 ([basic.lookup.general]) for the
@@ -6743,10 +6744,10 @@ renumber accordingly:</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
 any, designates a namespace or
-<code class="sourceCode cpp"><em>namespace-alias</em></code>. Neither
-the <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
-nor the <code class="sourceCode cpp"><em>splice-specifier</em></code>
-shall be dependent.</p>
+<code class="sourceCode cpp"><em>namespace-alias</em></code>. The
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> and
+the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+not be dependent.</p>
 </div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
@@ -6912,7 +6913,9 @@ not contain a splicer.</span> A
 </div>
 <h3 class="unnumbered" id="class.name-class-names">[class.name] Class
 names<a href="#class.name-class-names" class="self-link"></a></h3>
-<p>Cover `$splice-type-specifier$s in paragraph 5.</p>
+<p>Cover
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s in
+paragraph 5.</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">5</a></span>
@@ -7212,15 +7215,15 @@ form of the corresponding
 <div class="example2">
 <span>[ <em>Example 2:</em> </span>
 <div>
-<div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
-<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
+<div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f(); <span class="addu">  // #1</span></span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f(); <span class="addu">    // #2</span></span>
 <span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
-<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
+<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call<span class="addu">s (#1)</span> <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">the first f()</code></span></del></span></span>
 <span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
-<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-specifier: calls the first f()</span></span>
-<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-specifier: calls the second f()</span></span>
+<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-specifier: calls (#1)</span></span>
+<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-specifier: calls (#2)</span></span>
 <span id="cb129-10"><a href="#cb129-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
@@ -7433,11 +7436,64 @@ any). <span class="addu">The
 not contain a splicer.</span></p>
 </blockquote>
 </div>
+<p>Add a parargraph after the definition of <em>type-only context</em>
+to define what it means for a splicer to appear in a type-only
+context.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">4</a></span>
+A qualified or unqualified name is said to be in a
+<code class="sourceCode cpp"><em>type-only context</em></code> if it is
+the terminal name of</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(4.1)</a></span>
+a <code class="sourceCode cpp"><em>typename-specifier</em></code>,
+<code class="sourceCode cpp"><em>type-requirement</em></code>,
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
+<code class="sourceCode cpp"><em>elaborated-type-specifier</em></code>,
+<code class="sourceCode cpp"><em>class-or-decltype</em></code>, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(4.2)</a></span>
+[…]
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(4.4.6)</a></span>
+<code class="sourceCode cpp"><em>parameter-declaration</em></code> of a
+(non-type)
+<code class="sourceCode cpp"><em>template-parameter</em></code>.</li>
+</ul></li>
+</ul>
+<p><span class="addu">A splicer ([expr.prim.id.splice]) is said to be in
+a <em>type-only context</em> if a hypothetical qualified name appearing
+in the same position would be in a type-only context.</span></p>
+<div class="example5">
+<span>[ <em>Example 5:</em> </span>
+<div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> T<span class="op">::</span>R f<span class="op">()</span>;</span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="dt">void</span> f<span class="op">(</span>T<span class="op">::</span>R<span class="op">)</span>;   <span class="co">// ill-formed, no diagnostic required: attempt to</span></span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>                                  <span class="co">// declare a `void` variable template</span></span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">struct</span> S <span class="op">{</span></span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> Ptr <span class="op">=</span> PtrTraits<span class="op">&lt;</span>T<span class="op">&gt;::</span>Ptr;  <span class="co">// OK, in a <em>defining-type-id</em></span></span>
+<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>  <span class="addu"><code class="sourceCode cpp"><span class="kw">using</span> Alias <span class="op">=</span> <span class="op">[:^</span><span class="dt">int</span><span class="op">]</span>;          <span class="co">// OK, in a <em>defining-type-id</em></span></code></span></span>
+<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>  T<span class="op">::</span>R f<span class="op">(</span>T<span class="op">::</span>P p<span class="op">)</span> <span class="op">{</span>                <span class="co">// OK, class scope</span></span>
+<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> <span class="kw">static_cast</span><span class="op">&lt;</span>T<span class="op">::</span>R<span class="op">&gt;(</span>p<span class="op">)</span>;  <span class="co">// OK, <em>type-id</em> of a `static_cast`</span></span>
+<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> g<span class="op">()</span> <span class="op">-&gt;</span> S<span class="op">&lt;</span>T<span class="op">*&gt;::</span>Ptr;         <span class="co">// OK, <em>trailing-return-type</em></span></span>
+<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>  <span class="addu"><code class="sourceCode cpp"><span class="kw">auto</span> h<span class="op">()</span> <span class="op">-&gt;</span> <span class="op">[:^</span>S<span class="op">:]&lt;</span>T<span class="op">*&gt;</span>;         <span class="co">// OK, <em>trailing-return-type</em></span></code></span></span>
+<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> f<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb132-15"><a href="#cb132-15" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> <span class="op">(*</span>pf<span class="op">)(</span>T<span class="op">::</span>X<span class="op">)</span>;               <span class="co">// variable `pf` of type `void*` initialized</span></span>
+<span id="cb132-16"><a href="#cb132-16" aria-hidden="true" tabindex="-1"></a>                                  <span class="co">// with `T::X`</span></span>
+<span id="cb132-17"><a href="#cb132-17" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> g<span class="op">(</span>T<span class="op">::</span>X<span class="op">)</span>;                   <span class="co">// error: `T::X` at block scope does not denote</span></span>
+<span id="cb132-18"><a href="#cb132-18" aria-hidden="true" tabindex="-1"></a>                                  <span class="co">// a type (attempt to declare a `void` variable)</span></span>
+<span id="cb132-19"><a href="#cb132-19" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span> — <em>end example</em> ]</span>
+</div>
+</blockquote>
+</div>
 <p>Add a new case to the list of IFNDR conditions related to template
 instantiation.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">6</a></span>
 The validity of a templated entity may be checked prior to any
 instantiation.</p>
 <p><span class="note3"><span>[ <em>Note 3:</em> </span>Knowing which
@@ -7445,42 +7501,42 @@ names are type names allows the syntax of every template to be checked
 in this way.<span> — <em>end note</em> ]</span></span></p>
 <p>The program is ill-formed, no diagnostic required, if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(6.1)</a></span>
 no valid specialization, ignoring
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>s
 that fail ([dcl.pre]), can be generated for a templated entity or a
 substatement of a constexpr if statement ([stmt.if]) within a templaetd
 entity and the innermost enclosing template is not instantiated, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.2)</a></span>
 no valid specialization, ignoring
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>s
 that fail, can be generated for a default
 <code class="sourceCode cpp"><em>template-argument</em></code> and the
 default <code class="sourceCode cpp"><em>template-argument</em></code>
 is not used in any instantiation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(6.3)</a></span>
 no specialization of an alias template ([temp.alias]) is valid and no
 specialization of the alias template is named in the program, or</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(6.4)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(6.4)</a></span>
 any non-dependent plainly constant-evaluated expression within a
 templated entity produces an injected declaration ([expr.const]),
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(6.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(6.5)</a></span>
 any <code class="sourceCode cpp"><em>constraint-expression</em></code>
 in the program, introduced or otherwise, has (in its normal form) an
 atomic constraint <code class="sourceCode cpp"><em>A</em></code> where
 no satisfaction check of <code class="sourceCode cpp"><em>A</em></code>
 could be well-formed and no satisfaction check of
 <code class="sourceCode cpp"><em>A</em></code> is performed, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(6.6)</a></span>
 every valid specialization of a variadic template requires an empty
 template parameter pack, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(6.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(6.7)</a></span>
 a hypothetical instantiation of a templated entity immediately following
 its definition would be ill-formed due to a construct (other than a
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 that fails) that does not depend on a template parameter, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(6.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(6.8)</a></span>
 the interpretation of such a construct in the hypothetical instantiation
 is different from the interpretation of the corresponding construct in
 any actual instantiation of the templated entity.</li>
@@ -7494,19 +7550,19 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb132"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
-<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
-<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
-<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
-<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
-<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
-<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
-<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
-<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
-<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
-<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
-<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
+<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
+<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
+<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
+<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
+<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
+<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
+<span id="cb133-8"><a href="#cb133-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
+<span id="cb133-9"><a href="#cb133-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
+<span id="cb133-10"><a href="#cb133-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
+<span id="cb133-11"><a href="#cb133-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
+<span id="cb133-12"><a href="#cb133-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
+<span id="cb133-13"><a href="#cb133-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7514,17 +7570,17 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is type-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(9.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(9.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7540,21 +7596,21 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
 <em>unary-expression</em> or <em>expression</em> is type-dependent or
 the <em>type-id</em> is dependent:</p>
-<div class="sourceCode" id="cb133"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
-<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
-<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
-<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
-<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
-<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
+<div class="sourceCode" id="cb134"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
+<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
+<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
+<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
+<span id="cb134-5"><a href="#cb134-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
+<span id="cb134-6"><a href="#cb134-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
 <p><span class="addu">A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 value-dependent if the operand following
@@ -7567,17 +7623,17 @@ dependent name, names a dependent type, or contains a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is value-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(6.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
 is dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(6.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -7595,10 +7651,10 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">9</a></span>
 Preprocessing directives of the forms</p>
-<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
-<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
+<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
+<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
 <p>check whether the controlling constant expression evaluates to
 nonzero. <span class="addu">The program is ill-formed if a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> or
@@ -7613,19 +7669,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7638,7 +7694,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7646,7 +7702,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7655,14 +7711,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7677,20 +7733,20 @@ synopsis<a href="#meta.type.synop-header-type_traits-synopsis" class="self-link"
 synopsis</strong></p>
 <p>…</p>
 <div>
-<div class="sourceCode" id="cb135"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
-<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
-<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
-<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb135-7"><a href="#cb135-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb135-8"><a href="#cb135-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb135-9"><a href="#cb135-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
-<span id="cb135-10"><a href="#cb135-10" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb135-11"><a href="#cb135-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb135-12"><a href="#cb135-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
-<span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
-<span id="cb135-14"><a href="#cb135-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
+<div class="sourceCode" id="cb136"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
+<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
+<span id="cb136-5"><a href="#cb136-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
+<span id="cb136-6"><a href="#cb136-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb136-7"><a href="#cb136-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb136-8"><a href="#cb136-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb136-9"><a href="#cb136-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
+<span id="cb136-10"><a href="#cb136-10" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb136-11"><a href="#cb136-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb136-12"><a href="#cb136-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
+<span id="cb136-13"><a href="#cb136-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
+<span id="cb136-14"><a href="#cb136-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7712,8 +7768,8 @@ Comments
 </tr>
 <tr>
 <td>
-<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
+<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
 </td>
 <td style="text-align:center; vertical-align: middle">
 <code class="sourceCode cpp">T</code> is
@@ -7736,8 +7792,8 @@ Comments
 <tr>
 <td>
 <div class="addu">
-<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
+<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
 </div>
 </td>
 <td style="text-align:center; vertical-align: middle">
@@ -7761,358 +7817,358 @@ synopsis<a href="#meta.reflection.synop-header-meta-synopsis" class="self-link">
 <div class="addu">
 <p><strong>Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
 synopsis</strong></p>
-<div class="sourceCode" id="cb138"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
-<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
-<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
-<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
-<span id="cb138-5"><a href="#cb138-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-6"><a href="#cb138-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb138-7"><a href="#cb138-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
-<span id="cb138-8"><a href="#cb138-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-9"><a href="#cb138-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
-<span id="cb138-10"><a href="#cb138-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
-<span id="cb138-11"><a href="#cb138-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
-<span id="cb138-12"><a href="#cb138-12" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb138-13"><a href="#cb138-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
-<span id="cb138-14"><a href="#cb138-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
-<span id="cb138-15"><a href="#cb138-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
-<span id="cb138-16"><a href="#cb138-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
-<span id="cb138-17"><a href="#cb138-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-18"><a href="#cb138-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
-<span id="cb138-19"><a href="#cb138-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
-<span id="cb138-20"><a href="#cb138-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-21"><a href="#cb138-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
-<span id="cb138-22"><a href="#cb138-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
-<span id="cb138-23"><a href="#cb138-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-24"><a href="#cb138-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
-<span id="cb138-25"><a href="#cb138-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
-<span id="cb138-26"><a href="#cb138-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-27"><a href="#cb138-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
-<span id="cb138-28"><a href="#cb138-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-29"><a href="#cb138-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
-<span id="cb138-30"><a href="#cb138-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
-<span id="cb138-31"><a href="#cb138-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
-<span id="cb138-32"><a href="#cb138-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
-<span id="cb138-33"><a href="#cb138-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-34"><a href="#cb138-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
-<span id="cb138-35"><a href="#cb138-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
-<span id="cb138-36"><a href="#cb138-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
-<span id="cb138-37"><a href="#cb138-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
-<span id="cb138-38"><a href="#cb138-38" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-39"><a href="#cb138-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
-<span id="cb138-40"><a href="#cb138-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
-<span id="cb138-41"><a href="#cb138-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
-<span id="cb138-42"><a href="#cb138-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
-<span id="cb138-43"><a href="#cb138-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
-<span id="cb138-44"><a href="#cb138-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
-<span id="cb138-45"><a href="#cb138-45" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-46"><a href="#cb138-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
-<span id="cb138-47"><a href="#cb138-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
-<span id="cb138-48"><a href="#cb138-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-49"><a href="#cb138-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
-<span id="cb138-50"><a href="#cb138-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
-<span id="cb138-51"><a href="#cb138-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
-<span id="cb138-52"><a href="#cb138-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
-<span id="cb138-53"><a href="#cb138-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
-<span id="cb138-54"><a href="#cb138-54" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-55"><a href="#cb138-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
-<span id="cb138-56"><a href="#cb138-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
-<span id="cb138-57"><a href="#cb138-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
-<span id="cb138-58"><a href="#cb138-58" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-59"><a href="#cb138-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
-<span id="cb138-60"><a href="#cb138-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
-<span id="cb138-61"><a href="#cb138-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
-<span id="cb138-62"><a href="#cb138-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
-<span id="cb138-63"><a href="#cb138-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-64"><a href="#cb138-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
-<span id="cb138-65"><a href="#cb138-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
-<span id="cb138-66"><a href="#cb138-66" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-67"><a href="#cb138-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
-<span id="cb138-68"><a href="#cb138-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
-<span id="cb138-69"><a href="#cb138-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
-<span id="cb138-70"><a href="#cb138-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
-<span id="cb138-71"><a href="#cb138-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
-<span id="cb138-72"><a href="#cb138-72" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-73"><a href="#cb138-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
-<span id="cb138-74"><a href="#cb138-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
-<span id="cb138-75"><a href="#cb138-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
-<span id="cb138-76"><a href="#cb138-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
-<span id="cb138-77"><a href="#cb138-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
-<span id="cb138-78"><a href="#cb138-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
-<span id="cb138-79"><a href="#cb138-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
-<span id="cb138-80"><a href="#cb138-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
-<span id="cb138-81"><a href="#cb138-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
-<span id="cb138-82"><a href="#cb138-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
-<span id="cb138-83"><a href="#cb138-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
-<span id="cb138-84"><a href="#cb138-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
-<span id="cb138-85"><a href="#cb138-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
-<span id="cb138-86"><a href="#cb138-86" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-87"><a href="#cb138-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
-<span id="cb138-88"><a href="#cb138-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
-<span id="cb138-89"><a href="#cb138-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
-<span id="cb138-90"><a href="#cb138-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
-<span id="cb138-91"><a href="#cb138-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
-<span id="cb138-92"><a href="#cb138-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
-<span id="cb138-93"><a href="#cb138-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
-<span id="cb138-94"><a href="#cb138-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
-<span id="cb138-95"><a href="#cb138-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
-<span id="cb138-96"><a href="#cb138-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
-<span id="cb138-97"><a href="#cb138-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
-<span id="cb138-98"><a href="#cb138-98" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-99"><a href="#cb138-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
-<span id="cb138-100"><a href="#cb138-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
-<span id="cb138-101"><a href="#cb138-101" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-102"><a href="#cb138-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
-<span id="cb138-103"><a href="#cb138-103" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-104"><a href="#cb138-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
-<span id="cb138-105"><a href="#cb138-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
-<span id="cb138-106"><a href="#cb138-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
-<span id="cb138-107"><a href="#cb138-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
-<span id="cb138-108"><a href="#cb138-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
-<span id="cb138-109"><a href="#cb138-109" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-110"><a href="#cb138-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
-<span id="cb138-111"><a href="#cb138-111" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-112"><a href="#cb138-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
-<span id="cb138-113"><a href="#cb138-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
-<span id="cb138-114"><a href="#cb138-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
-<span id="cb138-115"><a href="#cb138-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
-<span id="cb138-116"><a href="#cb138-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
-<span id="cb138-117"><a href="#cb138-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
-<span id="cb138-118"><a href="#cb138-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
-<span id="cb138-119"><a href="#cb138-119" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-120"><a href="#cb138-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
-<span id="cb138-121"><a href="#cb138-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
-<span id="cb138-122"><a href="#cb138-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
-<span id="cb138-123"><a href="#cb138-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
-<span id="cb138-124"><a href="#cb138-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
-<span id="cb138-125"><a href="#cb138-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
-<span id="cb138-126"><a href="#cb138-126" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-127"><a href="#cb138-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
-<span id="cb138-128"><a href="#cb138-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
-<span id="cb138-129"><a href="#cb138-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
-<span id="cb138-130"><a href="#cb138-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
-<span id="cb138-131"><a href="#cb138-131" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-132"><a href="#cb138-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
-<span id="cb138-133"><a href="#cb138-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
-<span id="cb138-134"><a href="#cb138-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
-<span id="cb138-135"><a href="#cb138-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
-<span id="cb138-136"><a href="#cb138-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
-<span id="cb138-137"><a href="#cb138-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
-<span id="cb138-138"><a href="#cb138-138" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb138-139"><a href="#cb138-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
-<span id="cb138-140"><a href="#cb138-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
-<span id="cb138-141"><a href="#cb138-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
-<span id="cb138-142"><a href="#cb138-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
-<span id="cb138-143"><a href="#cb138-143" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-144"><a href="#cb138-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
-<span id="cb138-145"><a href="#cb138-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb138-146"><a href="#cb138-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
-<span id="cb138-147"><a href="#cb138-147" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-148"><a href="#cb138-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
-<span id="cb138-149"><a href="#cb138-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
-<span id="cb138-150"><a href="#cb138-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
-<span id="cb138-151"><a href="#cb138-151" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-152"><a href="#cb138-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-153"><a href="#cb138-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb138-154"><a href="#cb138-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-155"><a href="#cb138-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb138-156"><a href="#cb138-156" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-157"><a href="#cb138-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
-<span id="cb138-158"><a href="#cb138-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb138-159"><a href="#cb138-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
-<span id="cb138-160"><a href="#cb138-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb138-161"><a href="#cb138-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
-<span id="cb138-162"><a href="#cb138-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb138-163"><a href="#cb138-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
-<span id="cb138-164"><a href="#cb138-164" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-165"><a href="#cb138-165" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define.aggregate], class definition generation</span>
-<span id="cb138-166"><a href="#cb138-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options {</span>
-<span id="cb138-167"><a href="#cb138-167" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
-<span id="cb138-168"><a href="#cb138-168" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
-<span id="cb138-169"><a href="#cb138-169" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb138-170"><a href="#cb138-170" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-171"><a href="#cb138-171" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
-<span id="cb138-172"><a href="#cb138-172" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb138-173"><a href="#cb138-173" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-174"><a href="#cb138-174" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
-<span id="cb138-175"><a href="#cb138-175" aria-hidden="true" tabindex="-1"></a>    };</span>
-<span id="cb138-176"><a href="#cb138-176" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-177"><a href="#cb138-177" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
-<span id="cb138-178"><a href="#cb138-178" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
-<span id="cb138-179"><a href="#cb138-179" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; bit_width;</span>
-<span id="cb138-180"><a href="#cb138-180" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
-<span id="cb138-181"><a href="#cb138-181" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb138-182"><a href="#cb138-182" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
-<span id="cb138-183"><a href="#cb138-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options options = {});</span>
-<span id="cb138-184"><a href="#cb138-184" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
-<span id="cb138-185"><a href="#cb138-185" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-186"><a href="#cb138-186" aria-hidden="true" tabindex="-1"></a>  consteval info define_aggregate(info type_class, R&amp;&amp;);</span>
-<span id="cb138-187"><a href="#cb138-187" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-188"><a href="#cb138-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
-<span id="cb138-189"><a href="#cb138-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type);</span>
-<span id="cb138-190"><a href="#cb138-190" aria-hidden="true" tabindex="-1"></a>  consteval bool is_null_pointer_type(info type);</span>
-<span id="cb138-191"><a href="#cb138-191" aria-hidden="true" tabindex="-1"></a>  consteval bool is_integral_type(info type);</span>
-<span id="cb138-192"><a href="#cb138-192" aria-hidden="true" tabindex="-1"></a>  consteval bool is_floating_point_type(info type);</span>
-<span id="cb138-193"><a href="#cb138-193" aria-hidden="true" tabindex="-1"></a>  consteval bool is_array_type(info type);</span>
-<span id="cb138-194"><a href="#cb138-194" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_type(info type);</span>
-<span id="cb138-195"><a href="#cb138-195" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_type(info type);</span>
-<span id="cb138-196"><a href="#cb138-196" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_type(info type);</span>
-<span id="cb138-197"><a href="#cb138-197" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_object_pointer_type(info type);</span>
-<span id="cb138-198"><a href="#cb138-198" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_function_pointer_type(info type);</span>
-<span id="cb138-199"><a href="#cb138-199" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enum_type(info type);</span>
-<span id="cb138-200"><a href="#cb138-200" aria-hidden="true" tabindex="-1"></a>  consteval bool is_union_type(info type);</span>
-<span id="cb138-201"><a href="#cb138-201" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_type(info type);</span>
-<span id="cb138-202"><a href="#cb138-202" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_type(info type);</span>
-<span id="cb138-203"><a href="#cb138-203" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reflection_type(info type);</span>
-<span id="cb138-204"><a href="#cb138-204" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-205"><a href="#cb138-205" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
-<span id="cb138-206"><a href="#cb138-206" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reference_type(info type);</span>
-<span id="cb138-207"><a href="#cb138-207" aria-hidden="true" tabindex="-1"></a>  consteval bool is_arithmetic_type(info type);</span>
-<span id="cb138-208"><a href="#cb138-208" aria-hidden="true" tabindex="-1"></a>  consteval bool is_fundamental_type(info type);</span>
-<span id="cb138-209"><a href="#cb138-209" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object_type(info type);</span>
-<span id="cb138-210"><a href="#cb138-210" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scalar_type(info type);</span>
-<span id="cb138-211"><a href="#cb138-211" aria-hidden="true" tabindex="-1"></a>  consteval bool is_compound_type(info type);</span>
-<span id="cb138-212"><a href="#cb138-212" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_pointer_type(info type);</span>
-<span id="cb138-213"><a href="#cb138-213" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-214"><a href="#cb138-214" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
-<span id="cb138-215"><a href="#cb138-215" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const_type(info type);</span>
-<span id="cb138-216"><a href="#cb138-216" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile_type(info type);</span>
-<span id="cb138-217"><a href="#cb138-217" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivial_type(info type);</span>
-<span id="cb138-218"><a href="#cb138-218" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copyable_type(info type);</span>
-<span id="cb138-219"><a href="#cb138-219" aria-hidden="true" tabindex="-1"></a>  consteval bool is_standard_layout_type(info type);</span>
-<span id="cb138-220"><a href="#cb138-220" aria-hidden="true" tabindex="-1"></a>  consteval bool is_empty_type(info type);</span>
-<span id="cb138-221"><a href="#cb138-221" aria-hidden="true" tabindex="-1"></a>  consteval bool is_polymorphic_type(info type);</span>
-<span id="cb138-222"><a href="#cb138-222" aria-hidden="true" tabindex="-1"></a>  consteval bool is_abstract_type(info type);</span>
-<span id="cb138-223"><a href="#cb138-223" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final_type(info type);</span>
-<span id="cb138-224"><a href="#cb138-224" aria-hidden="true" tabindex="-1"></a>  consteval bool is_aggregate_type(info type);</span>
-<span id="cb138-225"><a href="#cb138-225" aria-hidden="true" tabindex="-1"></a>  consteval bool is_signed_type(info type);</span>
-<span id="cb138-226"><a href="#cb138-226" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unsigned_type(info type);</span>
-<span id="cb138-227"><a href="#cb138-227" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bounded_array_type(info type);</span>
-<span id="cb138-228"><a href="#cb138-228" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unbounded_array_type(info type);</span>
-<span id="cb138-229"><a href="#cb138-229" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scoped_enum_type(info type);</span>
-<span id="cb138-230"><a href="#cb138-230" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-231"><a href="#cb138-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-232"><a href="#cb138-232" aria-hidden="true" tabindex="-1"></a>    consteval bool is_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb138-233"><a href="#cb138-233" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructible_type(info type);</span>
-<span id="cb138-234"><a href="#cb138-234" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructible_type(info type);</span>
-<span id="cb138-235"><a href="#cb138-235" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructible_type(info type);</span>
-<span id="cb138-236"><a href="#cb138-236" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-237"><a href="#cb138-237" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignable_type(info type_dst, info type_src);</span>
-<span id="cb138-238"><a href="#cb138-238" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignable_type(info type);</span>
-<span id="cb138-239"><a href="#cb138-239" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignable_type(info type);</span>
-<span id="cb138-240"><a href="#cb138-240" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-241"><a href="#cb138-241" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_with_type(info type_dst, info type_src);</span>
-<span id="cb138-242"><a href="#cb138-242" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_type(info type);</span>
-<span id="cb138-243"><a href="#cb138-243" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-244"><a href="#cb138-244" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructible_type(info type);</span>
-<span id="cb138-245"><a href="#cb138-245" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-246"><a href="#cb138-246" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-247"><a href="#cb138-247" aria-hidden="true" tabindex="-1"></a>    consteval bool is_trivially_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb138-248"><a href="#cb138-248" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_default_constructible_type(info type);</span>
-<span id="cb138-249"><a href="#cb138-249" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_constructible_type(info type);</span>
-<span id="cb138-250"><a href="#cb138-250" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_constructible_type(info type);</span>
-<span id="cb138-251"><a href="#cb138-251" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-252"><a href="#cb138-252" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_assignable_type(info type_dst, info type_src);</span>
-<span id="cb138-253"><a href="#cb138-253" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_assignable_type(info type);</span>
-<span id="cb138-254"><a href="#cb138-254" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_assignable_type(info type);</span>
-<span id="cb138-255"><a href="#cb138-255" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_destructible_type(info type);</span>
-<span id="cb138-256"><a href="#cb138-256" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-257"><a href="#cb138-257" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-258"><a href="#cb138-258" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb138-259"><a href="#cb138-259" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_default_constructible_type(info type);</span>
-<span id="cb138-260"><a href="#cb138-260" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_constructible_type(info type);</span>
-<span id="cb138-261"><a href="#cb138-261" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_constructible_type(info type);</span>
-<span id="cb138-262"><a href="#cb138-262" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-263"><a href="#cb138-263" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_assignable_type(info type_dst, info type_src);</span>
-<span id="cb138-264"><a href="#cb138-264" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_assignable_type(info type);</span>
-<span id="cb138-265"><a href="#cb138-265" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_assignable_type(info type);</span>
-<span id="cb138-266"><a href="#cb138-266" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-267"><a href="#cb138-267" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_with_type(info type_dst, info type_src);</span>
-<span id="cb138-268"><a href="#cb138-268" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_type(info type);</span>
-<span id="cb138-269"><a href="#cb138-269" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-270"><a href="#cb138-270" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_destructible_type(info type);</span>
-<span id="cb138-271"><a href="#cb138-271" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-272"><a href="#cb138-272" aria-hidden="true" tabindex="-1"></a>  consteval bool is_implicit_lifetime_type(info type);</span>
-<span id="cb138-273"><a href="#cb138-273" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-274"><a href="#cb138-274" aria-hidden="true" tabindex="-1"></a>  consteval bool has_virtual_destructor(info type);</span>
-<span id="cb138-275"><a href="#cb138-275" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-276"><a href="#cb138-276" aria-hidden="true" tabindex="-1"></a>  consteval bool has_unique_object_representations(info type);</span>
-<span id="cb138-277"><a href="#cb138-277" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-278"><a href="#cb138-278" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_constructs_from_temporary(info type_dst, info type_src);</span>
-<span id="cb138-279"><a href="#cb138-279" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_converts_from_temporary(info type_dst, info type_src);</span>
-<span id="cb138-280"><a href="#cb138-280" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-281"><a href="#cb138-281" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
-<span id="cb138-282"><a href="#cb138-282" aria-hidden="true" tabindex="-1"></a>  consteval size_t rank(info type);</span>
-<span id="cb138-283"><a href="#cb138-283" aria-hidden="true" tabindex="-1"></a>  consteval size_t extent(info type, unsigned i = 0);</span>
-<span id="cb138-284"><a href="#cb138-284" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-285"><a href="#cb138-285" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
-<span id="cb138-286"><a href="#cb138-286" aria-hidden="true" tabindex="-1"></a>  consteval bool is_same_type(info type1, info type2);</span>
-<span id="cb138-287"><a href="#cb138-287" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base_of_type(info type_base, info type_derived);</span>
-<span id="cb138-288"><a href="#cb138-288" aria-hidden="true" tabindex="-1"></a>  consteval bool is_convertible_type(info type_src, info type_dst);</span>
-<span id="cb138-289"><a href="#cb138-289" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_convertible_type(info type_src, info type_dst);</span>
-<span id="cb138-290"><a href="#cb138-290" aria-hidden="true" tabindex="-1"></a>  consteval bool is_layout_compatible_type(info type1, info type2);</span>
-<span id="cb138-291"><a href="#cb138-291" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_interconvertible_base_of_type(info type_base, info type_derived);</span>
-<span id="cb138-292"><a href="#cb138-292" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-293"><a href="#cb138-293" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-294"><a href="#cb138-294" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb138-295"><a href="#cb138-295" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-296"><a href="#cb138-296" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb138-297"><a href="#cb138-297" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-298"><a href="#cb138-298" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-299"><a href="#cb138-299" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb138-300"><a href="#cb138-300" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-301"><a href="#cb138-301" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb138-302"><a href="#cb138-302" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-303"><a href="#cb138-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
-<span id="cb138-304"><a href="#cb138-304" aria-hidden="true" tabindex="-1"></a>  consteval info remove_const(info type);</span>
-<span id="cb138-305"><a href="#cb138-305" aria-hidden="true" tabindex="-1"></a>  consteval info remove_volatile(info type);</span>
-<span id="cb138-306"><a href="#cb138-306" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cv(info type);</span>
-<span id="cb138-307"><a href="#cb138-307" aria-hidden="true" tabindex="-1"></a>  consteval info add_const(info type);</span>
-<span id="cb138-308"><a href="#cb138-308" aria-hidden="true" tabindex="-1"></a>  consteval info add_volatile(info type);</span>
-<span id="cb138-309"><a href="#cb138-309" aria-hidden="true" tabindex="-1"></a>  consteval info add_cv(info type);</span>
-<span id="cb138-310"><a href="#cb138-310" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-311"><a href="#cb138-311" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
-<span id="cb138-312"><a href="#cb138-312" aria-hidden="true" tabindex="-1"></a>  consteval info remove_reference(info type);</span>
-<span id="cb138-313"><a href="#cb138-313" aria-hidden="true" tabindex="-1"></a>  consteval info add_lvalue_reference(info type);</span>
-<span id="cb138-314"><a href="#cb138-314" aria-hidden="true" tabindex="-1"></a>  consteval info add_rvalue_reference(info type);</span>
-<span id="cb138-315"><a href="#cb138-315" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-316"><a href="#cb138-316" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
-<span id="cb138-317"><a href="#cb138-317" aria-hidden="true" tabindex="-1"></a>  consteval info make_signed(info type);</span>
-<span id="cb138-318"><a href="#cb138-318" aria-hidden="true" tabindex="-1"></a>  consteval info make_unsigned(info type);</span>
-<span id="cb138-319"><a href="#cb138-319" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-320"><a href="#cb138-320" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
-<span id="cb138-321"><a href="#cb138-321" aria-hidden="true" tabindex="-1"></a>  consteval info remove_extent(info type);</span>
-<span id="cb138-322"><a href="#cb138-322" aria-hidden="true" tabindex="-1"></a>  consteval info remove_all_extents(info type);</span>
-<span id="cb138-323"><a href="#cb138-323" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-324"><a href="#cb138-324" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
-<span id="cb138-325"><a href="#cb138-325" aria-hidden="true" tabindex="-1"></a>  consteval info remove_pointer(info type);</span>
-<span id="cb138-326"><a href="#cb138-326" aria-hidden="true" tabindex="-1"></a>  consteval info add_pointer(info type);</span>
-<span id="cb138-327"><a href="#cb138-327" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-328"><a href="#cb138-328" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
-<span id="cb138-329"><a href="#cb138-329" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cvref(info type);</span>
-<span id="cb138-330"><a href="#cb138-330" aria-hidden="true" tabindex="-1"></a>  consteval info decay(info type);</span>
-<span id="cb138-331"><a href="#cb138-331" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-332"><a href="#cb138-332" aria-hidden="true" tabindex="-1"></a>    consteval info common_type(R&amp;&amp; type_args);</span>
-<span id="cb138-333"><a href="#cb138-333" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-334"><a href="#cb138-334" aria-hidden="true" tabindex="-1"></a>    consteval info common_reference(R&amp;&amp; type_args);</span>
-<span id="cb138-335"><a href="#cb138-335" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
-<span id="cb138-336"><a href="#cb138-336" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb138-337"><a href="#cb138-337" aria-hidden="true" tabindex="-1"></a>    `consteval info invoke_result(info type, R&amp;&amp; type_args);</span>
-<span id="cb138-338"><a href="#cb138-338" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_reference(info type);</span>
-<span id="cb138-339"><a href="#cb138-339" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_ref_decay(info type);</span>
-<span id="cb138-340"><a href="#cb138-340" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-341"><a href="#cb138-341" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
-<span id="cb138-342"><a href="#cb138-342" aria-hidden="true" tabindex="-1"></a>  consteval size_t tuple_size(info type);</span>
-<span id="cb138-343"><a href="#cb138-343" aria-hidden="true" tabindex="-1"></a>  consteval info tuple_element(size_t index, info type);</span>
-<span id="cb138-344"><a href="#cb138-344" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb138-345"><a href="#cb138-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
-<span id="cb138-346"><a href="#cb138-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
-<span id="cb138-347"><a href="#cb138-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">1</a></span>
+<div class="sourceCode" id="cb139"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
+<span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
+<span id="cb139-3"><a href="#cb139-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
+<span id="cb139-4"><a href="#cb139-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
+<span id="cb139-5"><a href="#cb139-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-6"><a href="#cb139-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb139-7"><a href="#cb139-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
+<span id="cb139-8"><a href="#cb139-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-9"><a href="#cb139-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
+<span id="cb139-10"><a href="#cb139-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
+<span id="cb139-11"><a href="#cb139-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
+<span id="cb139-12"><a href="#cb139-12" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb139-13"><a href="#cb139-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
+<span id="cb139-14"><a href="#cb139-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
+<span id="cb139-15"><a href="#cb139-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
+<span id="cb139-16"><a href="#cb139-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
+<span id="cb139-17"><a href="#cb139-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-18"><a href="#cb139-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
+<span id="cb139-19"><a href="#cb139-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
+<span id="cb139-20"><a href="#cb139-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-21"><a href="#cb139-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
+<span id="cb139-22"><a href="#cb139-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
+<span id="cb139-23"><a href="#cb139-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-24"><a href="#cb139-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
+<span id="cb139-25"><a href="#cb139-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
+<span id="cb139-26"><a href="#cb139-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-27"><a href="#cb139-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
+<span id="cb139-28"><a href="#cb139-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-29"><a href="#cb139-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
+<span id="cb139-30"><a href="#cb139-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
+<span id="cb139-31"><a href="#cb139-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
+<span id="cb139-32"><a href="#cb139-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
+<span id="cb139-33"><a href="#cb139-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-34"><a href="#cb139-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
+<span id="cb139-35"><a href="#cb139-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
+<span id="cb139-36"><a href="#cb139-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
+<span id="cb139-37"><a href="#cb139-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
+<span id="cb139-38"><a href="#cb139-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-39"><a href="#cb139-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
+<span id="cb139-40"><a href="#cb139-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
+<span id="cb139-41"><a href="#cb139-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
+<span id="cb139-42"><a href="#cb139-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
+<span id="cb139-43"><a href="#cb139-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
+<span id="cb139-44"><a href="#cb139-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
+<span id="cb139-45"><a href="#cb139-45" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-46"><a href="#cb139-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
+<span id="cb139-47"><a href="#cb139-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
+<span id="cb139-48"><a href="#cb139-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-49"><a href="#cb139-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
+<span id="cb139-50"><a href="#cb139-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
+<span id="cb139-51"><a href="#cb139-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
+<span id="cb139-52"><a href="#cb139-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
+<span id="cb139-53"><a href="#cb139-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
+<span id="cb139-54"><a href="#cb139-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-55"><a href="#cb139-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
+<span id="cb139-56"><a href="#cb139-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
+<span id="cb139-57"><a href="#cb139-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
+<span id="cb139-58"><a href="#cb139-58" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-59"><a href="#cb139-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
+<span id="cb139-60"><a href="#cb139-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
+<span id="cb139-61"><a href="#cb139-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
+<span id="cb139-62"><a href="#cb139-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
+<span id="cb139-63"><a href="#cb139-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-64"><a href="#cb139-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
+<span id="cb139-65"><a href="#cb139-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
+<span id="cb139-66"><a href="#cb139-66" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-67"><a href="#cb139-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
+<span id="cb139-68"><a href="#cb139-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
+<span id="cb139-69"><a href="#cb139-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
+<span id="cb139-70"><a href="#cb139-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
+<span id="cb139-71"><a href="#cb139-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
+<span id="cb139-72"><a href="#cb139-72" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-73"><a href="#cb139-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
+<span id="cb139-74"><a href="#cb139-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
+<span id="cb139-75"><a href="#cb139-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
+<span id="cb139-76"><a href="#cb139-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
+<span id="cb139-77"><a href="#cb139-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
+<span id="cb139-78"><a href="#cb139-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
+<span id="cb139-79"><a href="#cb139-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
+<span id="cb139-80"><a href="#cb139-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
+<span id="cb139-81"><a href="#cb139-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
+<span id="cb139-82"><a href="#cb139-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
+<span id="cb139-83"><a href="#cb139-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
+<span id="cb139-84"><a href="#cb139-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
+<span id="cb139-85"><a href="#cb139-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
+<span id="cb139-86"><a href="#cb139-86" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-87"><a href="#cb139-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
+<span id="cb139-88"><a href="#cb139-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
+<span id="cb139-89"><a href="#cb139-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
+<span id="cb139-90"><a href="#cb139-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
+<span id="cb139-91"><a href="#cb139-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
+<span id="cb139-92"><a href="#cb139-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
+<span id="cb139-93"><a href="#cb139-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
+<span id="cb139-94"><a href="#cb139-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
+<span id="cb139-95"><a href="#cb139-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
+<span id="cb139-96"><a href="#cb139-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
+<span id="cb139-97"><a href="#cb139-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
+<span id="cb139-98"><a href="#cb139-98" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-99"><a href="#cb139-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
+<span id="cb139-100"><a href="#cb139-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
+<span id="cb139-101"><a href="#cb139-101" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-102"><a href="#cb139-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
+<span id="cb139-103"><a href="#cb139-103" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-104"><a href="#cb139-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
+<span id="cb139-105"><a href="#cb139-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
+<span id="cb139-106"><a href="#cb139-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
+<span id="cb139-107"><a href="#cb139-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
+<span id="cb139-108"><a href="#cb139-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
+<span id="cb139-109"><a href="#cb139-109" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-110"><a href="#cb139-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
+<span id="cb139-111"><a href="#cb139-111" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-112"><a href="#cb139-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
+<span id="cb139-113"><a href="#cb139-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
+<span id="cb139-114"><a href="#cb139-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
+<span id="cb139-115"><a href="#cb139-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
+<span id="cb139-116"><a href="#cb139-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
+<span id="cb139-117"><a href="#cb139-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
+<span id="cb139-118"><a href="#cb139-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
+<span id="cb139-119"><a href="#cb139-119" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-120"><a href="#cb139-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
+<span id="cb139-121"><a href="#cb139-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
+<span id="cb139-122"><a href="#cb139-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
+<span id="cb139-123"><a href="#cb139-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
+<span id="cb139-124"><a href="#cb139-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
+<span id="cb139-125"><a href="#cb139-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
+<span id="cb139-126"><a href="#cb139-126" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-127"><a href="#cb139-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
+<span id="cb139-128"><a href="#cb139-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
+<span id="cb139-129"><a href="#cb139-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
+<span id="cb139-130"><a href="#cb139-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
+<span id="cb139-131"><a href="#cb139-131" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-132"><a href="#cb139-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
+<span id="cb139-133"><a href="#cb139-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
+<span id="cb139-134"><a href="#cb139-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
+<span id="cb139-135"><a href="#cb139-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
+<span id="cb139-136"><a href="#cb139-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
+<span id="cb139-137"><a href="#cb139-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
+<span id="cb139-138"><a href="#cb139-138" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb139-139"><a href="#cb139-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
+<span id="cb139-140"><a href="#cb139-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
+<span id="cb139-141"><a href="#cb139-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
+<span id="cb139-142"><a href="#cb139-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
+<span id="cb139-143"><a href="#cb139-143" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-144"><a href="#cb139-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
+<span id="cb139-145"><a href="#cb139-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb139-146"><a href="#cb139-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
+<span id="cb139-147"><a href="#cb139-147" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-148"><a href="#cb139-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
+<span id="cb139-149"><a href="#cb139-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
+<span id="cb139-150"><a href="#cb139-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
+<span id="cb139-151"><a href="#cb139-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-152"><a href="#cb139-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-153"><a href="#cb139-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb139-154"><a href="#cb139-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-155"><a href="#cb139-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb139-156"><a href="#cb139-156" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-157"><a href="#cb139-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
+<span id="cb139-158"><a href="#cb139-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb139-159"><a href="#cb139-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
+<span id="cb139-160"><a href="#cb139-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb139-161"><a href="#cb139-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
+<span id="cb139-162"><a href="#cb139-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb139-163"><a href="#cb139-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
+<span id="cb139-164"><a href="#cb139-164" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-165"><a href="#cb139-165" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define.aggregate], class definition generation</span>
+<span id="cb139-166"><a href="#cb139-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options {</span>
+<span id="cb139-167"><a href="#cb139-167" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
+<span id="cb139-168"><a href="#cb139-168" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
+<span id="cb139-169"><a href="#cb139-169" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb139-170"><a href="#cb139-170" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-171"><a href="#cb139-171" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
+<span id="cb139-172"><a href="#cb139-172" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb139-173"><a href="#cb139-173" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-174"><a href="#cb139-174" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
+<span id="cb139-175"><a href="#cb139-175" aria-hidden="true" tabindex="-1"></a>    };</span>
+<span id="cb139-176"><a href="#cb139-176" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-177"><a href="#cb139-177" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
+<span id="cb139-178"><a href="#cb139-178" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
+<span id="cb139-179"><a href="#cb139-179" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; bit_width;</span>
+<span id="cb139-180"><a href="#cb139-180" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
+<span id="cb139-181"><a href="#cb139-181" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb139-182"><a href="#cb139-182" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
+<span id="cb139-183"><a href="#cb139-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options options = {});</span>
+<span id="cb139-184"><a href="#cb139-184" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
+<span id="cb139-185"><a href="#cb139-185" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-186"><a href="#cb139-186" aria-hidden="true" tabindex="-1"></a>  consteval info define_aggregate(info type_class, R&amp;&amp;);</span>
+<span id="cb139-187"><a href="#cb139-187" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-188"><a href="#cb139-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
+<span id="cb139-189"><a href="#cb139-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type);</span>
+<span id="cb139-190"><a href="#cb139-190" aria-hidden="true" tabindex="-1"></a>  consteval bool is_null_pointer_type(info type);</span>
+<span id="cb139-191"><a href="#cb139-191" aria-hidden="true" tabindex="-1"></a>  consteval bool is_integral_type(info type);</span>
+<span id="cb139-192"><a href="#cb139-192" aria-hidden="true" tabindex="-1"></a>  consteval bool is_floating_point_type(info type);</span>
+<span id="cb139-193"><a href="#cb139-193" aria-hidden="true" tabindex="-1"></a>  consteval bool is_array_type(info type);</span>
+<span id="cb139-194"><a href="#cb139-194" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_type(info type);</span>
+<span id="cb139-195"><a href="#cb139-195" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_type(info type);</span>
+<span id="cb139-196"><a href="#cb139-196" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_type(info type);</span>
+<span id="cb139-197"><a href="#cb139-197" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_object_pointer_type(info type);</span>
+<span id="cb139-198"><a href="#cb139-198" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_function_pointer_type(info type);</span>
+<span id="cb139-199"><a href="#cb139-199" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enum_type(info type);</span>
+<span id="cb139-200"><a href="#cb139-200" aria-hidden="true" tabindex="-1"></a>  consteval bool is_union_type(info type);</span>
+<span id="cb139-201"><a href="#cb139-201" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_type(info type);</span>
+<span id="cb139-202"><a href="#cb139-202" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_type(info type);</span>
+<span id="cb139-203"><a href="#cb139-203" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reflection_type(info type);</span>
+<span id="cb139-204"><a href="#cb139-204" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-205"><a href="#cb139-205" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
+<span id="cb139-206"><a href="#cb139-206" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reference_type(info type);</span>
+<span id="cb139-207"><a href="#cb139-207" aria-hidden="true" tabindex="-1"></a>  consteval bool is_arithmetic_type(info type);</span>
+<span id="cb139-208"><a href="#cb139-208" aria-hidden="true" tabindex="-1"></a>  consteval bool is_fundamental_type(info type);</span>
+<span id="cb139-209"><a href="#cb139-209" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object_type(info type);</span>
+<span id="cb139-210"><a href="#cb139-210" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scalar_type(info type);</span>
+<span id="cb139-211"><a href="#cb139-211" aria-hidden="true" tabindex="-1"></a>  consteval bool is_compound_type(info type);</span>
+<span id="cb139-212"><a href="#cb139-212" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_pointer_type(info type);</span>
+<span id="cb139-213"><a href="#cb139-213" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-214"><a href="#cb139-214" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
+<span id="cb139-215"><a href="#cb139-215" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const_type(info type);</span>
+<span id="cb139-216"><a href="#cb139-216" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile_type(info type);</span>
+<span id="cb139-217"><a href="#cb139-217" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivial_type(info type);</span>
+<span id="cb139-218"><a href="#cb139-218" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copyable_type(info type);</span>
+<span id="cb139-219"><a href="#cb139-219" aria-hidden="true" tabindex="-1"></a>  consteval bool is_standard_layout_type(info type);</span>
+<span id="cb139-220"><a href="#cb139-220" aria-hidden="true" tabindex="-1"></a>  consteval bool is_empty_type(info type);</span>
+<span id="cb139-221"><a href="#cb139-221" aria-hidden="true" tabindex="-1"></a>  consteval bool is_polymorphic_type(info type);</span>
+<span id="cb139-222"><a href="#cb139-222" aria-hidden="true" tabindex="-1"></a>  consteval bool is_abstract_type(info type);</span>
+<span id="cb139-223"><a href="#cb139-223" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final_type(info type);</span>
+<span id="cb139-224"><a href="#cb139-224" aria-hidden="true" tabindex="-1"></a>  consteval bool is_aggregate_type(info type);</span>
+<span id="cb139-225"><a href="#cb139-225" aria-hidden="true" tabindex="-1"></a>  consteval bool is_signed_type(info type);</span>
+<span id="cb139-226"><a href="#cb139-226" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unsigned_type(info type);</span>
+<span id="cb139-227"><a href="#cb139-227" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bounded_array_type(info type);</span>
+<span id="cb139-228"><a href="#cb139-228" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unbounded_array_type(info type);</span>
+<span id="cb139-229"><a href="#cb139-229" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scoped_enum_type(info type);</span>
+<span id="cb139-230"><a href="#cb139-230" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-231"><a href="#cb139-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-232"><a href="#cb139-232" aria-hidden="true" tabindex="-1"></a>    consteval bool is_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb139-233"><a href="#cb139-233" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructible_type(info type);</span>
+<span id="cb139-234"><a href="#cb139-234" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructible_type(info type);</span>
+<span id="cb139-235"><a href="#cb139-235" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructible_type(info type);</span>
+<span id="cb139-236"><a href="#cb139-236" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-237"><a href="#cb139-237" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignable_type(info type_dst, info type_src);</span>
+<span id="cb139-238"><a href="#cb139-238" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignable_type(info type);</span>
+<span id="cb139-239"><a href="#cb139-239" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignable_type(info type);</span>
+<span id="cb139-240"><a href="#cb139-240" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-241"><a href="#cb139-241" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_with_type(info type_dst, info type_src);</span>
+<span id="cb139-242"><a href="#cb139-242" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_type(info type);</span>
+<span id="cb139-243"><a href="#cb139-243" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-244"><a href="#cb139-244" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructible_type(info type);</span>
+<span id="cb139-245"><a href="#cb139-245" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-246"><a href="#cb139-246" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-247"><a href="#cb139-247" aria-hidden="true" tabindex="-1"></a>    consteval bool is_trivially_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb139-248"><a href="#cb139-248" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_default_constructible_type(info type);</span>
+<span id="cb139-249"><a href="#cb139-249" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_constructible_type(info type);</span>
+<span id="cb139-250"><a href="#cb139-250" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_constructible_type(info type);</span>
+<span id="cb139-251"><a href="#cb139-251" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-252"><a href="#cb139-252" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_assignable_type(info type_dst, info type_src);</span>
+<span id="cb139-253"><a href="#cb139-253" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_assignable_type(info type);</span>
+<span id="cb139-254"><a href="#cb139-254" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_assignable_type(info type);</span>
+<span id="cb139-255"><a href="#cb139-255" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_destructible_type(info type);</span>
+<span id="cb139-256"><a href="#cb139-256" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-257"><a href="#cb139-257" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-258"><a href="#cb139-258" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb139-259"><a href="#cb139-259" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_default_constructible_type(info type);</span>
+<span id="cb139-260"><a href="#cb139-260" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_constructible_type(info type);</span>
+<span id="cb139-261"><a href="#cb139-261" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_constructible_type(info type);</span>
+<span id="cb139-262"><a href="#cb139-262" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-263"><a href="#cb139-263" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_assignable_type(info type_dst, info type_src);</span>
+<span id="cb139-264"><a href="#cb139-264" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_assignable_type(info type);</span>
+<span id="cb139-265"><a href="#cb139-265" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_assignable_type(info type);</span>
+<span id="cb139-266"><a href="#cb139-266" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-267"><a href="#cb139-267" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_with_type(info type_dst, info type_src);</span>
+<span id="cb139-268"><a href="#cb139-268" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_type(info type);</span>
+<span id="cb139-269"><a href="#cb139-269" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-270"><a href="#cb139-270" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_destructible_type(info type);</span>
+<span id="cb139-271"><a href="#cb139-271" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-272"><a href="#cb139-272" aria-hidden="true" tabindex="-1"></a>  consteval bool is_implicit_lifetime_type(info type);</span>
+<span id="cb139-273"><a href="#cb139-273" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-274"><a href="#cb139-274" aria-hidden="true" tabindex="-1"></a>  consteval bool has_virtual_destructor(info type);</span>
+<span id="cb139-275"><a href="#cb139-275" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-276"><a href="#cb139-276" aria-hidden="true" tabindex="-1"></a>  consteval bool has_unique_object_representations(info type);</span>
+<span id="cb139-277"><a href="#cb139-277" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-278"><a href="#cb139-278" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_constructs_from_temporary(info type_dst, info type_src);</span>
+<span id="cb139-279"><a href="#cb139-279" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_converts_from_temporary(info type_dst, info type_src);</span>
+<span id="cb139-280"><a href="#cb139-280" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-281"><a href="#cb139-281" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
+<span id="cb139-282"><a href="#cb139-282" aria-hidden="true" tabindex="-1"></a>  consteval size_t rank(info type);</span>
+<span id="cb139-283"><a href="#cb139-283" aria-hidden="true" tabindex="-1"></a>  consteval size_t extent(info type, unsigned i = 0);</span>
+<span id="cb139-284"><a href="#cb139-284" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-285"><a href="#cb139-285" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
+<span id="cb139-286"><a href="#cb139-286" aria-hidden="true" tabindex="-1"></a>  consteval bool is_same_type(info type1, info type2);</span>
+<span id="cb139-287"><a href="#cb139-287" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base_of_type(info type_base, info type_derived);</span>
+<span id="cb139-288"><a href="#cb139-288" aria-hidden="true" tabindex="-1"></a>  consteval bool is_convertible_type(info type_src, info type_dst);</span>
+<span id="cb139-289"><a href="#cb139-289" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_convertible_type(info type_src, info type_dst);</span>
+<span id="cb139-290"><a href="#cb139-290" aria-hidden="true" tabindex="-1"></a>  consteval bool is_layout_compatible_type(info type1, info type2);</span>
+<span id="cb139-291"><a href="#cb139-291" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_interconvertible_base_of_type(info type_base, info type_derived);</span>
+<span id="cb139-292"><a href="#cb139-292" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-293"><a href="#cb139-293" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-294"><a href="#cb139-294" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb139-295"><a href="#cb139-295" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-296"><a href="#cb139-296" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb139-297"><a href="#cb139-297" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-298"><a href="#cb139-298" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-299"><a href="#cb139-299" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb139-300"><a href="#cb139-300" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-301"><a href="#cb139-301" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb139-302"><a href="#cb139-302" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-303"><a href="#cb139-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
+<span id="cb139-304"><a href="#cb139-304" aria-hidden="true" tabindex="-1"></a>  consteval info remove_const(info type);</span>
+<span id="cb139-305"><a href="#cb139-305" aria-hidden="true" tabindex="-1"></a>  consteval info remove_volatile(info type);</span>
+<span id="cb139-306"><a href="#cb139-306" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cv(info type);</span>
+<span id="cb139-307"><a href="#cb139-307" aria-hidden="true" tabindex="-1"></a>  consteval info add_const(info type);</span>
+<span id="cb139-308"><a href="#cb139-308" aria-hidden="true" tabindex="-1"></a>  consteval info add_volatile(info type);</span>
+<span id="cb139-309"><a href="#cb139-309" aria-hidden="true" tabindex="-1"></a>  consteval info add_cv(info type);</span>
+<span id="cb139-310"><a href="#cb139-310" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-311"><a href="#cb139-311" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
+<span id="cb139-312"><a href="#cb139-312" aria-hidden="true" tabindex="-1"></a>  consteval info remove_reference(info type);</span>
+<span id="cb139-313"><a href="#cb139-313" aria-hidden="true" tabindex="-1"></a>  consteval info add_lvalue_reference(info type);</span>
+<span id="cb139-314"><a href="#cb139-314" aria-hidden="true" tabindex="-1"></a>  consteval info add_rvalue_reference(info type);</span>
+<span id="cb139-315"><a href="#cb139-315" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-316"><a href="#cb139-316" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
+<span id="cb139-317"><a href="#cb139-317" aria-hidden="true" tabindex="-1"></a>  consteval info make_signed(info type);</span>
+<span id="cb139-318"><a href="#cb139-318" aria-hidden="true" tabindex="-1"></a>  consteval info make_unsigned(info type);</span>
+<span id="cb139-319"><a href="#cb139-319" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-320"><a href="#cb139-320" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
+<span id="cb139-321"><a href="#cb139-321" aria-hidden="true" tabindex="-1"></a>  consteval info remove_extent(info type);</span>
+<span id="cb139-322"><a href="#cb139-322" aria-hidden="true" tabindex="-1"></a>  consteval info remove_all_extents(info type);</span>
+<span id="cb139-323"><a href="#cb139-323" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-324"><a href="#cb139-324" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
+<span id="cb139-325"><a href="#cb139-325" aria-hidden="true" tabindex="-1"></a>  consteval info remove_pointer(info type);</span>
+<span id="cb139-326"><a href="#cb139-326" aria-hidden="true" tabindex="-1"></a>  consteval info add_pointer(info type);</span>
+<span id="cb139-327"><a href="#cb139-327" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-328"><a href="#cb139-328" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
+<span id="cb139-329"><a href="#cb139-329" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cvref(info type);</span>
+<span id="cb139-330"><a href="#cb139-330" aria-hidden="true" tabindex="-1"></a>  consteval info decay(info type);</span>
+<span id="cb139-331"><a href="#cb139-331" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-332"><a href="#cb139-332" aria-hidden="true" tabindex="-1"></a>    consteval info common_type(R&amp;&amp; type_args);</span>
+<span id="cb139-333"><a href="#cb139-333" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-334"><a href="#cb139-334" aria-hidden="true" tabindex="-1"></a>    consteval info common_reference(R&amp;&amp; type_args);</span>
+<span id="cb139-335"><a href="#cb139-335" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
+<span id="cb139-336"><a href="#cb139-336" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb139-337"><a href="#cb139-337" aria-hidden="true" tabindex="-1"></a>    `consteval info invoke_result(info type, R&amp;&amp; type_args);</span>
+<span id="cb139-338"><a href="#cb139-338" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_reference(info type);</span>
+<span id="cb139-339"><a href="#cb139-339" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_ref_decay(info type);</span>
+<span id="cb139-340"><a href="#cb139-340" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-341"><a href="#cb139-341" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
+<span id="cb139-342"><a href="#cb139-342" aria-hidden="true" tabindex="-1"></a>  consteval size_t tuple_size(info type);</span>
+<span id="cb139-343"><a href="#cb139-343" aria-hidden="true" tabindex="-1"></a>  consteval info tuple_element(size_t index, info type);</span>
+<span id="cb139-344"><a href="#cb139-344" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb139-345"><a href="#cb139-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
+<span id="cb139-346"><a href="#cb139-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
+<span id="cb139-347"><a href="#cb139-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">2</a></span>
 The behavior of any function specified by this section is
 implementation-defined when a reflection of a construct not otherwise
 specified by this document is provided as an argument.</p>
@@ -8128,11 +8184,11 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
-<span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
-<span id="cb139-3"><a href="#cb139-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb139-4"><a href="#cb139-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">1</a></span>
+<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
+<span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
+<span id="cb140-3"><a href="#cb140-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb140-4"><a href="#cb140-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -8384,23 +8440,23 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tr>
 </tbody>
 </table>
-<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">2</a></span>
+<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
 unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
-<span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">4</a></span>
+<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
+<span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -8414,34 +8470,34 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">1</a></span>
+<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -8450,24 +8506,24 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8476,44 +8532,44 @@ description of a declaration of a non-static data member, then letting
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
-<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">2</a></span>
+<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
 identifier introduced by the declaration of what is represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8523,23 +8579,23 @@ then the <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> contents of <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
-<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">5</a></span>
+<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
-<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">7</a></span>
+<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -8554,59 +8610,59 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb146-3"><a href="#cb146-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">1</a></span>
+<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb147-3"><a href="#cb147-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
 class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">2</a></span>
+<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
 function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">3</a></span>
+<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
 is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">4</a></span>
+<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">5</a></span>
+<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 ([dcl.fct.def.default]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">6</a></span>
+<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb152-2"><a href="#cb152-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.def.default">[dcl.fct.def.default]</a></span>),
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">7</a></span>
+<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8620,8 +8676,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">8</a></span>
+<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8638,8 +8694,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">9</a></span>
+<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8648,16 +8704,16 @@ declaration of a non-static data member for which any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">10</a></span>
+<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">11</a></span>
+<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8665,38 +8721,38 @@ type (respectively), a const- or volatile-qualified function type
 (respectively), or an object, variable, non-static data member, or
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">12</a></span>
+<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><span class="kw">mutable</span></code>
 non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">13</a></span>
+<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
 rvalue-reference qualified function type (respectively), or a member
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">14</a></span>
+<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb160-3"><a href="#cb160-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
 that has static, thread, or automatic storage duration, respectively
 ([basic.stc]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb160-3"><a href="#cb160-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb160-4"><a href="#cb160-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">15</a></span>
+<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-3"><a href="#cb161-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb161-4"><a href="#cb161-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8704,14 +8760,14 @@ type, template, or namespace whose name has internal linkage, module
 linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">16</a></span>
+<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8720,14 +8776,14 @@ there is some point in the evaluation context from which the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">18</a></span>
+<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8735,29 +8791,29 @@ or enumeration type <code class="sourceCode cpp"><em>E</em></code>, such
 that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">20</a></span>
+<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 <code class="sourceCode cpp"><em>namespace-alias</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">21</a></span>
+<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">22</a></span>
+<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">23</a></span>
+<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8768,31 +8824,31 @@ instantiation of an alias template is a
 <code class="sourceCode cpp"><em>typedef-name</em></code><span>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">24</a></span>
+<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">25</a></span>
+<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
 operator function, or literal operator, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-4"><a href="#cb169-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-5"><a href="#cb169-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-6"><a href="#cb169-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-7"><a href="#cb169-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-8"><a href="#cb169-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb169-9"><a href="#cb169-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">26</a></span>
+<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-5"><a href="#cb170-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-6"><a href="#cb170-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-7"><a href="#cb170-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-8"><a href="#cb170-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-9"><a href="#cb170-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8801,15 +8857,15 @@ constructor, a move constructor, an assignment operator, a copy
 assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">27</a></span>
+<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8817,16 +8873,16 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code> but
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-2"><a href="#cb171-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-3"><a href="#cb171-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-4"><a href="#cb171-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-5"><a href="#cb171-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-6"><a href="#cb171-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-7"><a href="#cb171-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-8"><a href="#cb171-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb171-9"><a href="#cb171-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">29</a></span>
+<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-3"><a href="#cb172-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-4"><a href="#cb172-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-5"><a href="#cb172-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-6"><a href="#cb172-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-7"><a href="#cb172-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-8"><a href="#cb172-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-9"><a href="#cb172-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8834,56 +8890,56 @@ variable template, class template, alias template, conversion function
 template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">30</a></span>
+<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
 function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb173-2"><a href="#cb173-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">31</a></span>
+<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb174-2"><a href="#cb174-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">32</a></span>
+<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb175-2"><a href="#cb175-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb175-3"><a href="#cb175-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb175-4"><a href="#cb175-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb175-5"><a href="#cb175-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">33</a></span>
+<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb176-2"><a href="#cb176-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb176-3"><a href="#cb176-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb176-4"><a href="#cb176-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb176-5"><a href="#cb176-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
 namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">34</a></span>
+<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">35</a></span>
+<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8891,70 +8947,70 @@ entity, object, or value, then the type of what is represented by
 then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">37</a></span>
+<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
-<span id="cb179-2"><a href="#cb179-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
-<span id="cb179-3"><a href="#cb179-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb179-4"><a href="#cb179-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb179-5"><a href="#cb179-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
-<span id="cb179-6"><a href="#cb179-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
-<span id="cb179-7"><a href="#cb179-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
+<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
+<span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
+<span id="cb180-3"><a href="#cb180-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb180-4"><a href="#cb180-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb180-5"><a href="#cb180-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
+<span id="cb180-6"><a href="#cb180-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
+<span id="cb180-7"><a href="#cb180-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">39</a></span>
+<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb181"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb181-3"><a href="#cb181-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb181-4"><a href="#cb181-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb181-5"><a href="#cb181-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
-<span id="cb181-6"><a href="#cb181-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
-<span id="cb181-7"><a href="#cb181-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
-<span id="cb181-8"><a href="#cb181-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
+<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb182-3"><a href="#cb182-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb182-4"><a href="#cb182-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb182-5"><a href="#cb182-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
+<span id="cb182-6"><a href="#cb182-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
+<span id="cb182-7"><a href="#cb182-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
+<span id="cb182-8"><a href="#cb182-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">41</a></span>
+<div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or
@@ -8962,48 +9018,48 @@ member, bit-field, template, namespace or
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">43</a></span>
+<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> <em>A</em>,
 then a reflection representing the entity named by <em>A</em>.
 Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
-<div class="sourceCode" id="cb184"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
-<span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
-<span id="cb184-3"><a href="#cb184-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
-<span id="cb184-4"><a href="#cb184-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
-<span id="cb184-5"><a href="#cb184-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
+<div class="sourceCode" id="cb185"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
+<span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
+<span id="cb185-3"><a href="#cb185-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
+<span id="cb185-4"><a href="#cb185-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
+<span id="cb185-5"><a href="#cb185-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">45</a></span>
+<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
-<div class="sourceCode" id="cb186"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
-<span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
-<span id="cb186-3"><a href="#cb186-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb186-4"><a href="#cb186-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
-<span id="cb186-5"><a href="#cb186-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
-<span id="cb186-6"><a href="#cb186-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb186-7"><a href="#cb186-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
-<span id="cb186-8"><a href="#cb186-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
+<div class="sourceCode" id="cb187"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
+<span id="cb187-2"><a href="#cb187-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
+<span id="cb187-3"><a href="#cb187-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb187-4"><a href="#cb187-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
+<span id="cb187-5"><a href="#cb187-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
+<span id="cb187-6"><a href="#cb187-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb187-7"><a href="#cb187-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
+<span id="cb187-8"><a href="#cb187-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -9014,12 +9070,12 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">1</a></span>
+<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -9038,7 +9094,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -9049,11 +9105,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -9066,15 +9122,15 @@ declared within the member-specification of
 unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">6</a></span>
+<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -9083,93 +9139,93 @@ of all the direct base class specifiers, if any, of
 indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
-<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">9</a></span>
+<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">12</a></span>
+<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">15</a></span>
+<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">17</a></span>
+<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">20</a></span>
+<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">23</a></span>
+<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">26</a></span>
+<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -9183,33 +9239,33 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">1</a></span>
+<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">2</a></span>
+<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
-<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">5</a></span>
+<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9218,7 +9274,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -9230,8 +9286,8 @@ Otherwise, <code class="sourceCode cpp">size_of<span class="op">(</span>type_of<
 corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">7</a></span>
+<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -9240,28 +9296,28 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
 data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">9</a></span>
+<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9270,7 +9326,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -9283,32 +9339,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
-<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">3</a></span>
+<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">6</a></span>
+<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -9316,7 +9372,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -9324,7 +9380,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -9332,52 +9388,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">8</a></span>
+<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">11</a></span>
+<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -9388,43 +9444,43 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
-<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
-<span id="cb205-3"><a href="#cb205-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb205-4"><a href="#cb205-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb205-5"><a href="#cb205-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">1</a></span>
+<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
+<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
+<span id="cb206-3"><a href="#cb206-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb206-4"><a href="#cb206-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb206-5"><a href="#cb206-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
-<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">5</a></span>
+<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -9434,72 +9490,72 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">1</a></span>
+<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
 value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">4</a></span>
+<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">7</a></span>
+<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -9512,19 +9568,19 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">name_type</code> are consteval-only types
 ([basic.types.general]), and are not a structural types
 ([temp.param]).</p>
-<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">2</a></span>
+<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">3</a></span>
+<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9539,77 +9595,77 @@ ordinary string literal (or
 <code class="sourceCode cpp">string</code>, etc) or a UTF-8 string
 literal (or <code class="sourceCode cpp">u8string_view</code>,
 <code class="sourceCode cpp">u8string</code>, etc) equally well.</p>
-<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
-<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
+<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
 <span> — <em>end note</em> ]</span>
 </div>
-<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">1</a></span>
+<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
+<span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -9618,16 +9674,16 @@ Certain other functions in
 <code class="sourceCode cpp">identifier_of</code>) can also be used to
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
-<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">4</a></span>
+<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
 declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">5</a></span>
+<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9635,7 +9691,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -9652,18 +9708,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -9677,37 +9733,37 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
 {<code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub>k</sub></code>}
 be a sequence of <code class="sourceCode cpp">data_member_options</code>
 values such that</p>
-<div class="sourceCode" id="cb217"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
+<div class="sourceCode" id="cb218"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -9720,29 +9776,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9754,18 +9810,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9775,10 +9831,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9799,44 +9855,44 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.unary.cat]</a></span>.</p>
-<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-4"><a href="#cb218-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-5"><a href="#cb218-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-6"><a href="#cb218-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-9"><a href="#cb218-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-10"><a href="#cb218-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-11"><a href="#cb218-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-12"><a href="#cb218-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-14"><a href="#cb218-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb218-15"><a href="#cb218-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">2</a></span></p>
+<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-10"><a href="#cb219-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-11"><a href="#cb219-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-12"><a href="#cb219-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-13"><a href="#cb219-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-14"><a href="#cb219-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb219-15"><a href="#cb219-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb219"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
-<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
-<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
-<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
-<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
-<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
-<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
-<span id="cb219-10"><a href="#cb219-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
-<span id="cb219-11"><a href="#cb219-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
-<span id="cb219-12"><a href="#cb219-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb219-13"><a href="#cb219-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb220"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
+<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
+<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
+<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
+<span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
+<span id="cb220-8"><a href="#cb220-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
+<span id="cb220-9"><a href="#cb220-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
+<span id="cb220-10"><a href="#cb220-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
+<span id="cb220-11"><a href="#cb220-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
+<span id="cb220-12"><a href="#cb220-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb220-13"><a href="#cb220-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -9847,20 +9903,20 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.3 <a href="https://wg21.link/meta.unary.comp">[meta.unary.comp]</a></span>.</p>
-<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-4"><a href="#cb221-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-5"><a href="#cb221-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-6"><a href="#cb221-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9869,7 +9925,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9879,7 +9935,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9890,7 +9946,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9902,71 +9958,71 @@ each function template <code class="sourceCode cpp">std<span class="op">::</span
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-TRAIT</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivial_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-4"><a href="#cb221-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-5"><a href="#cb221-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-6"><a href="#cb221-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-8"><a href="#cb221-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-9"><a href="#cb221-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-10"><a href="#cb221-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-11"><a href="#cb221-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-12"><a href="#cb221-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-13"><a href="#cb221-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-14"><a href="#cb221-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-15"><a href="#cb221-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-17"><a href="#cb221-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb221-18"><a href="#cb221-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb221-19"><a href="#cb221-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-20"><a href="#cb221-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-21"><a href="#cb221-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-22"><a href="#cb221-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-23"><a href="#cb221-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb221-24"><a href="#cb221-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-25"><a href="#cb221-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-26"><a href="#cb221-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-27"><a href="#cb221-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb221-28"><a href="#cb221-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-29"><a href="#cb221-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-30"><a href="#cb221-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-31"><a href="#cb221-31" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-32"><a href="#cb221-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb221-33"><a href="#cb221-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb221-34"><a href="#cb221-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-35"><a href="#cb221-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-36"><a href="#cb221-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-37"><a href="#cb221-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-38"><a href="#cb221-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb221-39"><a href="#cb221-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-40"><a href="#cb221-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-41"><a href="#cb221-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-42"><a href="#cb221-42" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-43"><a href="#cb221-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb221-44"><a href="#cb221-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb221-45"><a href="#cb221-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-46"><a href="#cb221-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-47"><a href="#cb221-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-48"><a href="#cb221-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-49"><a href="#cb221-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb221-50"><a href="#cb221-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-51"><a href="#cb221-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-52"><a href="#cb221-52" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-53"><a href="#cb221-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb221-54"><a href="#cb221-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-55"><a href="#cb221-55" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-56"><a href="#cb221-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-57"><a href="#cb221-57" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-58"><a href="#cb221-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-59"><a href="#cb221-59" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-60"><a href="#cb221-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-61"><a href="#cb221-61" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-62"><a href="#cb221-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-63"><a href="#cb221-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-64"><a href="#cb221-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb221-65"><a href="#cb221-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-3"><a href="#cb222-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivial_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-4"><a href="#cb222-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-5"><a href="#cb222-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-6"><a href="#cb222-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-7"><a href="#cb222-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-8"><a href="#cb222-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-9"><a href="#cb222-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-10"><a href="#cb222-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-11"><a href="#cb222-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-12"><a href="#cb222-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-13"><a href="#cb222-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-14"><a href="#cb222-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-15"><a href="#cb222-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-16"><a href="#cb222-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-17"><a href="#cb222-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb222-18"><a href="#cb222-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb222-19"><a href="#cb222-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-20"><a href="#cb222-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-21"><a href="#cb222-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-22"><a href="#cb222-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-23"><a href="#cb222-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb222-24"><a href="#cb222-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-25"><a href="#cb222-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-26"><a href="#cb222-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-27"><a href="#cb222-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb222-28"><a href="#cb222-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-29"><a href="#cb222-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-30"><a href="#cb222-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-31"><a href="#cb222-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-32"><a href="#cb222-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb222-33"><a href="#cb222-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb222-34"><a href="#cb222-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-35"><a href="#cb222-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-36"><a href="#cb222-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-37"><a href="#cb222-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-38"><a href="#cb222-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb222-39"><a href="#cb222-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-40"><a href="#cb222-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-41"><a href="#cb222-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-42"><a href="#cb222-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-43"><a href="#cb222-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb222-44"><a href="#cb222-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb222-45"><a href="#cb222-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-46"><a href="#cb222-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-47"><a href="#cb222-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-48"><a href="#cb222-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-49"><a href="#cb222-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb222-50"><a href="#cb222-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-51"><a href="#cb222-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-52"><a href="#cb222-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-53"><a href="#cb222-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb222-54"><a href="#cb222-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-55"><a href="#cb222-55" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-56"><a href="#cb222-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-57"><a href="#cb222-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-58"><a href="#cb222-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-59"><a href="#cb222-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-60"><a href="#cb222-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-61"><a href="#cb222-61" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-62"><a href="#cb222-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-63"><a href="#cb222-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb222-64"><a href="#cb222-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb222-65"><a href="#cb222-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9975,13 +10031,13 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
+<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
-<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">2</a></span>
+<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9993,10 +10049,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -10005,7 +10061,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -10017,7 +10073,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -10030,23 +10086,23 @@ each ternary function template <code class="sourceCode cpp">std<span class="op">
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL-R</em><span class="op">(^</span>R, <span class="op">^</span>T, r<span class="op">)</span>_type</code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL-R</em>_v<span class="op">&lt;</span>R, T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb224-3"><a href="#cb224-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb224-4"><a href="#cb224-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb224-5"><a href="#cb224-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb224-6"><a href="#cb224-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb224-7"><a href="#cb224-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb224-8"><a href="#cb224-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb224-9"><a href="#cb224-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb224-10"><a href="#cb224-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb224-11"><a href="#cb224-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb224-12"><a href="#cb224-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb224-13"><a href="#cb224-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb224-14"><a href="#cb224-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb224-15"><a href="#cb224-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb224-16"><a href="#cb224-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">5</a></span>
+<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb225-4"><a href="#cb225-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb225-5"><a href="#cb225-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb225-6"><a href="#cb225-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb225-7"><a href="#cb225-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb225-8"><a href="#cb225-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb225-9"><a href="#cb225-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb225-10"><a href="#cb225-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb225-11"><a href="#cb225-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb225-12"><a href="#cb225-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb225-13"><a href="#cb225-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb225-14"><a href="#cb225-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb225-15"><a href="#cb225-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb225-16"><a href="#cb225-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -10068,7 +10124,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -10080,19 +10136,19 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
-<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-4"><a href="#cb225-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-5"><a href="#cb225-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-6"><a href="#cb225-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-3"><a href="#cb226-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-4"><a href="#cb226-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-5"><a href="#cb226-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-6"><a href="#cb226-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10101,16 +10157,16 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
-<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb226-3"><a href="#cb226-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-3"><a href="#cb227-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10119,15 +10175,15 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
-<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10136,15 +10192,15 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
-<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10153,15 +10209,15 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.6 <a href="https://wg21.link/meta.trans.ptr">[meta.trans.ptr]</a></span>.</p>
-<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10180,7 +10236,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -10188,7 +10244,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -10198,7 +10254,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -10209,29 +10265,29 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>invoke_result<span class="op">(^</span>T, r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span>invoke_result_t<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 (<span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>).</p>
-<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-3"><a href="#cb230-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb230-4"><a href="#cb230-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb230-5"><a href="#cb230-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb230-6"><a href="#cb230-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb230-7"><a href="#cb230-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-8"><a href="#cb230-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb230-9"><a href="#cb230-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb230-10"><a href="#cb230-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb230-11"><a href="#cb230-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">4</a></span></p>
+<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb231-2"><a href="#cb231-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb231-3"><a href="#cb231-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb231-4"><a href="#cb231-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb231-5"><a href="#cb231-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb231-6"><a href="#cb231-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb231-7"><a href="#cb231-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb231-8"><a href="#cb231-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb231-9"><a href="#cb231-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb231-10"><a href="#cb231-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb231-11"><a href="#cb231-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
-<span id="cb231-2"><a href="#cb231-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb231-3"><a href="#cb231-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb231-4"><a href="#cb231-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb231-5"><a href="#cb231-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb231-6"><a href="#cb231-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb231-7"><a href="#cb231-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
-<span id="cb231-8"><a href="#cb231-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb231-9"><a href="#cb231-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb232"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
+<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb232-3"><a href="#cb232-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
+<span id="cb232-4"><a href="#cb232-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb232-5"><a href="#cb232-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb232-6"><a href="#cb232-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb232-7"><a href="#cb232-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
+<span id="cb232-8"><a href="#cb232-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb232-9"><a href="#cb232-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -10242,7 +10298,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -10250,7 +10306,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -10259,11 +10315,11 @@ defined in this clause with the signature <code class="sourceCode cpp">info<span
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^</span>T<span class="op">)</span></code>
 returns a reflection representing the type <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<div class="sourceCode" id="cb232"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb232-3"><a href="#cb232-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb232-4"><a href="#cb232-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb232-5"><a href="#cb232-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb233"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb233-2"><a href="#cb233-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb233-3"><a href="#cb233-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb233-4"><a href="#cb233-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb233-5"><a href="#cb233-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10274,7 +10330,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -10282,27 +10338,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -10320,10 +10376,10 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb233"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
-<span id="cb233-2"><a href="#cb233-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
-<span id="cb233-3"><a href="#cb233-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
-<span id="cb233-4"><a href="#cb233-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
+<div class="sourceCode" id="cb234"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
+<span id="cb234-2"><a href="#cb234-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
+<span id="cb234-3"><a href="#cb234-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
+<span id="cb234-4"><a href="#cb234-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -10331,7 +10387,7 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb234"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb235"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb235-1"><a href="#cb235-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-11-08" />
+  <meta name="dcterms.date" content="2024-11-09" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-11-08</td>
+    <td>2024-11-09</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -797,6 +797,10 @@ The reflection operator<span></span></a></li>
 <li><a href="#expr.const-constant-expressions" id="toc-expr.const-constant-expressions"><span>7.7
 <span>[expr.const]</span></span> Constant
 Expressions<span></span></a></li>
+<li><a href="#dcl.typedef-the-typedef-specifier" id="toc-dcl.typedef-the-typedef-specifier"><span>9.2.4
+<span>[dcl.typedef]</span></span> The
+<code class="sourceCode cpp"><span class="kw">typedef</span></code>
+specifier<span></span></a></li>
 <li><a href="#dcl.type.simple-simple-type-specifiers" id="toc-dcl.type.simple-simple-type-specifiers"><span>9.2.9.3
 <span>[dcl.type.simple]</span></span> Simple type
 specifiers<span></span></a></li>
@@ -822,10 +826,18 @@ directive<span></span></a></li>
 <li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1
 <span>[dcl.attr.grammar]</span></span> Attribute syntax and
 semantics<span></span></a></li>
+<li><a href="#module.global.frag-global-module-fragment" id="toc-module.global.frag-global-module-fragment">[module.global.frag]
+Global module fragment<span></span></a></li>
 <li><a href="#module.reach-reachability" id="toc-module.reach-reachability"><span>10.7
 <span>[module.reach]</span></span> Reachability<span></span></a></li>
+<li><a href="#class.pre-preamble" id="toc-class.pre-preamble">[class.pre] Preamble<span></span></a></li>
+<li><a href="#class.name-class-names" id="toc-class.name-class-names">[class.name] Class
+names<span></span></a></li>
 <li><a href="#class.mem.general-general" id="toc-class.mem.general-general"><span>11.4.1
 <span>[class.mem.general]</span></span> General<span></span></a></li>
+<li><a href="#over.match.class.deduct-class-template-argument-deduction" id="toc-over.match.class.deduct-class-template-argument-deduction"><span>12.2.2.9
+<span>[over.match.class.deduct]</span></span> Class template argument
+deduction<span></span></a></li>
 <li><a href="#over.built-built-in-operators" id="toc-over.built-built-in-operators"><span>12.5
 <span>[over.built]</span></span> Built-in
 operators<span></span></a></li>
@@ -848,11 +860,16 @@ arguments<span></span></a></li>
 arguments<span></span></a></li>
 <li><a href="#temp.type-type-equivalence" id="toc-temp.type-type-equivalence"><span>13.6
 <span>[temp.type]</span></span> Type equivalence<span></span></a></li>
+<li><a href="#temp.deduct.guide-deduction-guides" id="toc-temp.deduct.guide-deduction-guides"><span>13.7.2.3
+<span>[temp.deduct.guide]</span></span> Deduction
+guides<span></span></a></li>
 <li><a href="#temp.alias-alias-templates" id="toc-temp.alias-alias-templates"><span>13.7.8
 <span>[temp.alias]</span></span> Alias templates<span></span></a></li>
 <li><a href="#temp.concept-concept-definitions" id="toc-temp.concept-concept-definitions"><span>13.7.9
 <span>[temp.concept]</span></span> Concept
 definitions<span></span></a></li>
+<li><a href="#temp.res.general-general" id="toc-temp.res.general-general"><span>13.8.1
+<span>[temp.res.general]</span></span> General<span></span></a></li>
 <li><a href="#temp.dep.expr-type-dependent-expressions" id="toc-temp.dep.expr-type-dependent-expressions"><span>13.8.3.3
 <span>[temp.dep.expr]</span></span> Type-dependent
 expressions<span></span></a></li>
@@ -6188,19 +6205,152 @@ the injected points corresponding to any injected declarations
 </div>
 </blockquote>
 </div>
+<h3 class="unnumbered" id="dcl.typedef-the-typedef-specifier"><span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.typedef]</a></span> The
+<code class="sourceCode cpp"><span class="kw">typedef</span></code>
+specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3>
+<p>Account for
+<code class="sourceCode cpp"><em>splice-template-speciifer</em></code>s
+in paragraph 3.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">3</a></span>
+A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
+only a <code class="sourceCode cpp"><em>typedef-name</em></code> if its
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+designate</span> <span class="rm" style="color: #bf0303"><del>names</del></span> an alias template or a
+template
+<code class="sourceCode cpp"><em>template-parameter</em></code>.</p>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="dcl.type.simple-simple-type-specifiers"><span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>
 Simple type specifiers<a href="#dcl.type.simple-simple-type-specifiers" class="self-link"></a></h3>
 <p>Extend the grammar for
+<code class="sourceCode cpp"><em>simple-type-specifier</em></code> and
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code> as
 follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb115"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
-<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
-<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
-<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb115"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-type-specifier</em>:</span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>    <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>type-name</em></span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>    <em>nested-name-specifier</em> template <em>simple-template-id</em></span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>    <em>computed-type-specifier</em></span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a>    <em>placeholder-type-specifier</em></span>
+<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a>    <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></span>
+<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-specifier</em></span></span>
+<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
+<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
+<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
+<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
+</blockquote>
+</div>
+<p>Modify paragraph 3 to indicate that a
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+can be deduced.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">3</a></span>
+A
+<code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
+is a placeholder for a type to be deduced ([dcl.spec.auto]). <span class="addu">The
+<code class="sourceCode cpp"><em>simple-template-id</em></code> in a
+<code class="sourceCode cpp"><em>type-specifier</em></code> of the form
+<code class="sourceCode cpp"><em>nested-name-specifier</em> <span class="kw">template</span> <em>simple-template-id</em></code>
+shall not contain a
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</span>
+A <code class="sourceCode cpp"><em>type-specifier</em></code> of the
+form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>
+<span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+is a placeholder for a deduced class type ([dcl.type.class.deduct]). The
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>, if
+any, shall be non-dependent and the
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+shall <span class="rm" style="color: #bf0303"><del>name</del></span>
+<span class="addu">designate</span> a deducible template. A
+<em>deducible template</em> is either a class template or is an alias
+template whose
+<code class="sourceCode cpp"><em>defining-type-id</em></code> is of the
+form</p>
+<div class="sourceCode" id="cb116"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
+<p>where the
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> (if
+any) is non-dependent and the
+<code class="sourceCode cpp"><em>template-name</em></code> of the
+<code class="sourceCode cpp"><em>simple-template-id</em></code> names a
+deducible template.</p>
+</blockquote>
+</div>
+<p>Add a row to [tab:dcl.type.simple] to cover the
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+production.</p>
+<div class="std">
+<blockquote>
+<center>
+Table 17:
+<code class="sourceCode cpp"><em>simple-type-specifier</em></code>s and
+the types they specify [tab:dcl.type.simple]
+</center>
+<table>
+<colgroup>
+<col style="width: 50%" />
+<col style="width: 50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th style="text-align: left;"><div style="text-align:center">
+<strong>Specifier(s)</strong>
+</div></th>
+<th style="text-align: left;"><div style="text-align:center">
+<strong>Type</strong>
+</div></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;"><code class="sourceCode cpp"><em>type-name</em></code></td>
+<td style="text-align: left;">the type named</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"><code class="sourceCode cpp"><em>simple-template-id</em></code></td>
+<td style="text-align: left;">the type as defined in [temp.names]</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;"><code class="sourceCode cpp"><em>decltype-specifier</em></code></td>
+<td style="text-align: left;">the type as defined in
+[dcl.type.decltype]</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"><code class="sourceCode cpp"><em>pack-index-specifier</em></code></td>
+<td style="text-align: left;">the type as defined in
+[dcl.type.pack.index]</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;"><code class="sourceCode cpp"><em>placeholder-type-specifier</em></code></td>
+<td style="text-align: left;">the type as defined in
+[dcl.spec.auto]</td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"><code class="sourceCode cpp"><em>template-name</em></code></td>
+<td style="text-align: left;">the type as defined in
+[dcl.type.class.deduct]</td>
+</tr>
+<tr class="odd">
+<td style="text-align: left;"><span class="addu"><code class="sourceCode cpp"><em>splice-template-specifier</em></code></span></td>
+<td style="text-align: left;"><span class="addu">the type as defined in
+[dcl.type.class.deduct]</span></td>
+</tr>
+<tr class="even">
+<td style="text-align: left;"><code class="sourceCode cpp"><span class="op">...</span></code></td>
+<td style="text-align: left;">…</td>
+</tr>
+</tbody>
+</table>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.type.splice-type-splicing">9.2.9*
@@ -6211,13 +6361,13 @@ follows:</p>
 <blockquote>
 <div class="addu">
 <div>
-<div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
-<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">1</a></span>
 The <code class="sourceCode cpp"><span class="kw">typename</span></code>
 may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">2</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 designate a type. The type designated by the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
@@ -6234,45 +6384,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6280,7 +6430,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6289,22 +6439,22 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">9</a></span>
 A function type with a <em>cv-qualifier-seq</em> or a
 <em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(9.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(9.5)</a></span>
 the <em>type-id</em> of a <em>template-argument</em> for a
 <em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(9.6)</a></span>
 the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
 </ul>
 </div>
@@ -6316,7 +6466,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 the reflection operator</span>, is ill-formed.</p>
@@ -6330,13 +6480,13 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
-<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
-<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
-<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
-<span id="cb117-6"><a href="#cb117-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
-<span id="cb117-7"><a href="#cb117-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb118"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declaration</em>:</span>
+<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>     using enum <em>using-enum-declarator</em> ;</span>
+<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
+<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
+<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
+<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6344,7 +6494,7 @@ follows:</p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">1</a></span>
 A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
 <span class="addu">that is not a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>
@@ -6366,15 +6516,15 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb118"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias</em>:</span>
-<span id="cb118-2"><a href="#cb118-2" aria-hidden="true" tabindex="-1"></a>      <em>identifier</em></span>
-<span id="cb118-3"><a href="#cb118-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
-<span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
-<span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a>  <em>qualified-namespace-specifier</em>:</span>
-<span id="cb118-8"><a href="#cb118-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
-<span id="cb118-9"><a href="#cb118-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias</em>:</span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>      <em>identifier</em></span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
+<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
+<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a>  <em>qualified-namespace-specifier</em>:</span>
+<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6382,7 +6532,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">0</a></span>
 If a
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 is a <code class="sourceCode cpp"><em>splice-specifier</em></code>, the
@@ -6403,7 +6553,7 @@ designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link
 in the paragraph that immediately follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -6420,9 +6570,9 @@ in the grammar for
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>qualified-namespace-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>qualified-namespace-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6431,7 +6581,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">0</a></span>
 The
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 shall neither contain a dependent
@@ -6439,7 +6589,7 @@ shall neither contain a dependent
 dependent
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6478,10 +6628,10 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
-<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
-<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
-<span id="cb120-4"><a href="#cb120-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
+<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>attribute-specifier</em>:</span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>     [ [ <em>attribute-using-prefix</em><sub><em>opt</em></sub> <em>attribute-list</em> ] ]</span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    [ [ using <em>attribute-namespace</em> :] ]</span></span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>     <em>alignment-specifier</em></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6489,13 +6639,13 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb121"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
-<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
-<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
-<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
+<div class="sourceCode" id="cb122"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a>  <em>balanced-token</em> :</span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>      ( <em>balanced-token-seq</em><sub><em>opt</em></sub> )</span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>      [ <em>balanced-token-seq</em><sub><em>opt</em></sub> ]</span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a>      { <em>balanced-token-seq</em><sub><em>opt</em></sub> }</span>
+<span id="cb122-5"><a href="#cb122-5" aria-hidden="true" tabindex="-1"></a><span class="st">-     any token other than a parenthesis, a bracket, or a brace</span></span>
+<span id="cb122-6"><a href="#cb122-6" aria-hidden="true" tabindex="-1"></a><span class="va">+     [: <em>balanced-token-seq</em><sub><em>opt</em></sub> :]</span></span>
+<span id="cb122-7"><a href="#cb122-7" aria-hidden="true" tabindex="-1"></a><span class="va">+     any token other than (, ), [, ], {, }, [:, or :]</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6503,7 +6653,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6520,34 +6670,101 @@ the two-token sequence
 — <em>end note</em> ]</span></span></span> …</p>
 </blockquote>
 </div>
+<h3 class="unnumbered" id="module.global.frag-global-module-fragment">[module.global.frag]
+Global module fragment<a href="#module.global.frag-global-module-fragment" class="self-link"></a></h3>
+<p>Extend the caveat in paragraph 3.7 to also apply to
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<div class="std">
+<blockquote>
+<p>In this determination, it is unspecified</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(3.6)</a></span>
+whether a reference to an
+<code class="sourceCode cpp"><em>alias-declaration</em></code>,
+<code class="sourceCode cpp"><span class="kw">typedef</span></code>
+declaration,
+<code class="sourceCode cpp"><em>using-declaration</em></code>, or
+<code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
+is replaced by the declarations they name prior to this
+determination,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(3.7)</a></span>
+whether a
+<code class="sourceCode cpp"><em>simple-template-id</em></code> that
+does denote a dependent type and whose
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template is replaced by its
+denoted type prior to this determination,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(3.8)</a></span>
+…</li>
+</ul>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="module.reach-reachability"><span>10.7 <a href="https://wg21.link/module.reach">[module.reach]</a></span>
 Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 <p>Modify the definition of reachability to account for injected
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
 within a <em>private-module-framgent</em>.</li>
 </ul>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="class.pre-preamble">[class.pre] Preamble<a href="#class.pre-preamble" class="self-link"></a></h3>
+<p>Disallow a
+<code class="sourceCode cpp"><em>slice-template-specifier</em></code>
+from appearing in a declaration of a
+<code class="sourceCode cpp"><em>class-name</em></code> in paragraph
+1.</p>
+<div class="std">
+<blockquote>
+<p>…</p>
+<p>A class declaration where the
+<code class="sourceCode cpp"><em>class-name</em></code> in the
+<code class="sourceCode cpp"><em>class-head-name</em></code> is a
+<code class="sourceCode cpp"><em>simple-template-id</em></code> shall be
+an explicit specialization ([temp.expl.spec]) or a partial
+specialization ([temp.spec.partial]). <span class="addu">The
+<code class="sourceCode cpp"><em>simple-template-id</em></code> shall
+not contain a
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</span>
+A <code class="sourceCode cpp"><em>class-specifier</em></code> whose
+<code class="sourceCode cpp"><em>class-head</em></code> omits the
+<code class="sourceCode cpp"><em>class-head-name</em></code> defines an
+<em>unnamed class</em>.</p>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="class.name-class-names">[class.name] Class
+names<a href="#class.name-class-names" class="self-link"></a></h3>
+<p>Cover `$splice-template-specifier$s in paragraph 5.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">5</a></span>
+A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
+only a <code class="sourceCode cpp"><em>class-name</em></code> if its
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a class template.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="class.mem.general-general"><span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>
@@ -6557,7 +6774,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6571,9 +6788,50 @@ non-static data member of reference type, there is a unique member
 subobject whose size and alignment is the same as if the data member
 were declared with the corresponding pointer type.</span></p>
 <p><span class="note3"><span>[ <em>Note 3:</em> </span><span class="rm" style="color: #bf0303"><del>A non-static data member of non-reference
-type is a member subobject of a class object.</del></span> An object of
-class type has a member subobject corresponding to each non-static data
-member of its class<span> — <em>end note</em> ]</span></span></p>
+type is a member subobject of a class object.</del></span> <span class="addu">An object of class type has a member subobject
+corresponding to each non-static data member of its class</span><span>
+— <em>end note</em> ]</span></span></p>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="over.match.class.deduct-class-template-argument-deduction"><span>12.2.2.9
+<a href="https://wg21.link/over.match.class.deduct">[over.match.class.deduct]</a></span>
+Class template argument deduction<a href="#over.match.class.deduct-class-template-argument-deduction" class="self-link"></a></h3>
+<p>Extend paragraph 1 to work with
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">1</a></span>
+When resolving a placeholder for a deduced class type
+([dcl.type.class.deduct]) where the
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a primary class template
+<code class="sourceCode cpp">C</code>, a set of functions and function
+templates, called the guides of <code class="sourceCode cpp">C</code>,
+is formed comprising:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(1.1)</a></span>
+…</li>
+</ul>
+</blockquote>
+</div>
+<p>Extend paragraph 3 to also cover
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">3</a></span>
+When resolving a placeholder for a deduced class type
+([dcl.type.simple]) where the
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template
+<code class="sourceCode cpp">A</code>, the
+<code class="sourceCode cpp"><em>defining-type-id</em></code> of
+<code class="sourceCode cpp">A</code> must be of the form</p>
+<div class="sourceCode" id="cb123"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
+<p>as specified in [dcl.type.simple]. The guides of
+<code class="sourceCode cpp">A</code> are the set of functions or
+function templates formed as follows. …</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="over.built-built-in-operators"><span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span> Built-in
@@ -6582,13 +6840,13 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
 there exist candidate operator functions of the form</p>
-<div class="sourceCode" id="cb122"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
-<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb124"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.param-template-parameters"><span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span> Template
@@ -6597,126 +6855,187 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 in template parameter declarations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">4</a></span>
 … The concept designated by a type-constraint shall be a type concept
 ([temp.concept]) <span class="addu">that is not a
-<code class="sourceCode cpp"><em>splice-template-name</em></code></span>.</p>
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.names-names-of-template-specializations"><span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span> Names of
 template specializations<a href="#temp.names-names-of-template-specializations" class="self-link"></a></h3>
-<p>Modify the grammars for
-<code class="sourceCode cpp"><em>template-id</em></code> and
-<code class="sourceCode cpp"><em>template-argument</em></code> as
-follows:</p>
+<p>Introduce
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+and
+<code class="sourceCode cpp"><em>splice-template-argument</em></code>
+nonterminals. Extend
+<code class="sourceCode cpp"><em>simple-template-id</em></code> and
+<code class="sourceCode cpp"><em>template-argument</em></code> to
+leverage these.</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb123"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-name</em>:</span></span>
-<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a><span class="va">+     template <em>splice-specifier</em></span></span>
-<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
-<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span>
-<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
-<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a>      identifier</span>
-<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-name</em></span></span>
-<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
-<span id="cb123-12"><a href="#cb123-12" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
-<span id="cb123-13"><a href="#cb123-13" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
-<span id="cb123-14"><a href="#cb123-14" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
-<span id="cb123-15"><a href="#cb123-15" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
-<span id="cb123-16"><a href="#cb123-16" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-template-id</em>:</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>      <em>template-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
+<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>  <em>template-id</em>:</span>
+<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a>      <em>simple-template-id</em></span>
+<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a>      $operator-function-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a>      $literal-operator-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
+<span id="cb125-11"><a href="#cb125-11" aria-hidden="true" tabindex="-1"></a>      identifier</span>
+<span id="cb125-12"><a href="#cb125-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb125-13"><a href="#cb125-13" aria-hidden="true" tabindex="-1"></a>  <em>template-argument-list</em>:</span>
+<span id="cb125-14"><a href="#cb125-14" aria-hidden="true" tabindex="-1"></a>      <em>template-argument</em> ...<sub><em>opt</em></sub></span>
+<span id="cb125-15"><a href="#cb125-15" aria-hidden="true" tabindex="-1"></a>      <em>template-argument-list</em> , <em>template-argument</em> ...<sub><em>opt</em></sub></span>
+<span id="cb125-16"><a href="#cb125-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb125-17"><a href="#cb125-17" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
+<span id="cb125-18"><a href="#cb125-18" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
+<span id="cb125-19"><a href="#cb125-19" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
+<span id="cb125-20"><a href="#cb125-20" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
+<span id="cb125-21"><a href="#cb125-21" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
+<span id="cb125-22"><a href="#cb125-22" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span>
+<span id="cb125-23"><a href="#cb125-23" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb125-24"><a href="#cb125-24" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-specifier</em>:</span></span>
+<span id="cb125-25"><a href="#cb125-25" aria-hidden="true" tabindex="-1"></a><span class="va">+     template <em>splice-specifier</em></span></span>
+<span id="cb125-26"><a href="#cb125-26" aria-hidden="true" tabindex="-1"></a><span class="va">+     typename template<sub><em>opt</em></sub> <em>splice-specifier</em></span></span>
+<span id="cb125-27"><a href="#cb125-27" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
+<span id="cb125-28"><a href="#cb125-28" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
+<span id="cb125-29"><a href="#cb125-29" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Extend paragraph 1 to cover template splicers:</p>
+<p>Extend paragraph 2 to cover
+<code class="sourceCode cpp"><em>simple-template-id</em></code>s and
+<code class="sourceCode cpp"><em>template-id</em></code>s that have no
+component name.</p>
 <div class="std">
 <blockquote>
-<p>The component name of a
-<code class="sourceCode cpp"><em>simple-template-id</em></code>,
-<code class="sourceCode cpp"><em>template-id</em></code>, or
-<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">that is an
-<code class="sourceCode cpp"><em>identifier</em></code></span> is the
-first name in it. <span class="addu">If the
-<code class="sourceCode cpp"><em>template-name</em></code> is a
-<code class="sourceCode cpp"><em>splice-template-name</em></code>, the
-<code class="sourceCode cpp"><em>splice-specifier</em></code> shall
-designate a concept, variable template, class template, alias template,
-or function template that is not a constructor template or destructor
-template; the
-<code class="sourceCode cpp"><em>splice-template-name</em></code>
-designates the entity designated by the
-<code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">2</a></span>
+The component name of a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>simple-template-id</em></code></span>,
+<span><code class="sourceCode default"><em>template-id</em></code></span>,
+or</del></span>
+<code class="sourceCode cpp"><em>template-name</em></code> is its
+<code class="sourceCode cpp"><em>identifier</em></code> <span class="rm" style="color: #bf0303"><del>the first name in it</del></span>. <span class="addu">The component names of a
+<code class="sourceCode cpp"><em>simple-template-id</em></code> are
+those of its <code class="sourceCode cpp"><em>template-name</em></code>
+(if any). The component names of a
+<code class="sourceCode cpp"><em>template-id</em></code> are those of
+its <code class="sourceCode cpp"><em>simple-template-id</em></code>,
+<code class="sourceCode cpp"><em>operator-function-id</em></code>, or
+<code class="sourceCode cpp"><em>literal-operator-id</em></code>.</span></p>
 </blockquote>
 </div>
-<p>Extend paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
+<p>Add a paragraph following paragraph 2 defining the semantics of a
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">3</a></span>
+<div class="addu">
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">2+</a></span>
+A <code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+designates the same entity designated by its
+<code class="sourceCode cpp"><em>splice-specifier</em></code>. A
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+shall designate a concept, variable template, class template, alias
+template, or function template. A
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+shall not designate a constructor template or destructor template.</p>
+</div>
+</blockquote>
+</div>
+<p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
-interpreted as the delimiter of a <em>template-argument-list</em> if it
-follows a name that is not a <em>conversion-function-id</em> and</p>
+interpreted as the delimiter of a
+<code class="sourceCode cpp"><em>template-argument-list</em></code> if
+it follows <span class="addu">either</span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(3.1)</a></span>
+a
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>,
+or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.2)</a></span>
+a name that is not a
+<code class="sourceCode cpp"><em>conversion-function-id</em></code> and
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
+</ul></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>If the name is an
 identifier, it is then interpreted as a <em>template-name</em>. The
 keyword template is used to indicate that a dependent qualified name
 ([temp.dep.type]) denotes a template where an expression might
 appear.<span> — <em>end note</em> ]</span></span></p>
-<div class="addu">
-<p>A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
-also interpreted as the delimiter of a
-<code class="sourceCode cpp"><em>template-argument-list</em></code> if
-it follows a
-<code class="sourceCode cpp"><em>splice-template-name</em></code>.</p>
-</div>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div>
-<div class="sourceCode" id="cb124"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
-<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
-<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
-<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a>};</span>
-<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
-<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
-<span id="cb124-7"><a href="#cb124-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
-<span id="cb124-8"><a href="#cb124-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
-<span id="cb124-9"><a href="#cb124-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
-<span id="cb124-10"><a href="#cb124-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb124-11"><a href="#cb124-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
-<span id="cb124-12"><a href="#cb124-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
-<span id="cb124-13"><a href="#cb124-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
-<span id="cb124-14"><a href="#cb124-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
+<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
+<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>};</span>
+<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
+<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
+<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
+<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
+<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
+<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
+<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
+<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
+<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
 </blockquote>
 </div>
+<p>Extend paragraph 8 to also cover
+<code class="sourceCode cpp"><em>simple-template-id</em></code>s
+containing
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">8</a></span>
+When the <code class="sourceCode cpp"><em>template-name</em></code>
+<span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+of a <code class="sourceCode cpp"><em>simple-template-id</em></code>
+<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a constrained non-function template or a
+constrained template
+<code class="sourceCode cpp"><em>template-parameter</em></code>, and all
+<code class="sourceCode cpp"><em>template-arguments</em></code> in the
+<code class="sourceCode cpp"><em>simple-template-id</em></code> are
+non-dependent ([temp.dep.temp]), the associated contraints
+([temp.constr.decl]) of the constrained template shall be satisfied
+([temp.constr.constr]).</p>
+</blockquote>
+</div>
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">9</a></span>
-A <em>concept-id</em> is a <em>simple-template-id</em> where the
-<em>template-name</em> is <span class="addu">either</span> a
-<em>concept-name</em> <span class="addu">or a
-<em>splice-template-name</em> whose <em>splice-specifier</em> designates
-a concept</span>. A concept-id is a prvalue of type bool, and does not
-name a template specialization.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">9</a></span>
+A <em>concept-id</em> is a
+<code class="sourceCode cpp"><em>simple-template-id</em></code> where
+<span class="addu">either</span> the
+<code class="sourceCode cpp"><em>template-name</em></code> is a
+<code class="sourceCode cpp"><em>concept-name</em></code> <span class="addu">or the
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+designates a concept</span>. A concept-id is a prvalue of type bool, and
+does not name a template specialization.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.arg.general-general"><span>13.4.1 <a href="https://wg21.link/temp.arg.general">[temp.arg.general]</a></span>
@@ -6725,7 +7044,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -6742,16 +7061,16 @@ regardless of the form of the corresponding
 <div class="example2">
 <span>[ <em>Example 2:</em> </span>
 <div>
-<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
-<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
-<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
-<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-template-argument: calls the first f()</span></span>
-<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-template-argument: calls the second f()</span></span>
-<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
+<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
+<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
+<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
+<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
+<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-template-argument: calls the first f()</span></span>
+<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-template-argument: calls the second f()</span></span>
+<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -6763,7 +7082,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -6782,7 +7101,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be the name of a class template or an alias template, expressed as
@@ -6794,28 +7113,103 @@ designates a template</span>.</p>
 </div>
 <h3 class="unnumbered" id="temp.type-type-equivalence"><span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span> Type
 equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
+<p>Extend <code class="sourceCode cpp"><em>template-id</em></code>
+equivalence as defined by paragraph 1 to cover
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">1</a></span>
+Two <code class="sourceCode cpp"><em>template-id</em></code>s are the
+same if</p>
+<ul>
+<li>their <code class="sourceCode cpp"><em>template-name</em></code>s,
+<span class="addu"><code class="sourceCode cpp"><em>splice-template-specifier</em></code>s,</span>
+<code class="sourceCode cpp"><em>operator-function-id</em></code>s, or
+<code class="sourceCode cpp"><em>literal-operator-id</em></code>s refer
+to the same template, and</li>
+<li>their corresponding type
+<code class="sourceCode cpp"><em>template-argument</em></code>s are the
+same type, and</li>
+<li>the template parameter values determined by their corresponding
+non-type template arguments ([temp.arg.nontype]) are
+template-argument-equivalent (see below), and</li>
+<li>their corresponding template
+<code class="sourceCode cpp"><em>template-argument</em></code>s refer to
+the same template.</li>
+</ul>
+<p>Two <code class="sourceCode cpp"><em>template-id</em></code>s that
+are the same refer to the same class, function, or variable.</p>
+</blockquote>
+</div>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(2.3)</a></span>
-they are of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(2.3)</a></span>
+they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and they compare equal, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(2.5)</a></span>
 […]</li>
 </ul>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="temp.deduct.guide-deduction-guides"><span>13.7.2.3 <a href="https://wg21.link/temp.deduct.guide">[temp.deduct.guide]</a></span>
+Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link"></a></h3>
+<p>Extend paragraph 1 to clarify that
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s
+can also leverage deduction guides.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">1</a></span>
+Deduction guides are used when a
+<code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+appears as a type specifier for a deduced class type
+([dcl.type.class.deduct]). Deduction guides are not found by name
+lookup. Instead, when performing class template argument deduction
+([over.match.class.deduct]), all reachable deduction guides declared for
+the class template are considered.</p>
+</blockquote>
+</div>
+<p>Notwithstanding the above, extend paragraph 3 to clarify that
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s
+cannot themselves appear in deduction guides.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">3</a></span>
+The same restrictions apply to the
+<code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
+of a deduction guide as in a function declaration ([dcl.fct]), except
+that a generic parameter type placeholder ([dcl.spec.auto]) shall not
+appear in the
+<code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
+of a deduction guide. The
+<code class="sourceCode cpp"><em>simple-template-id</em></code> shall
+name a class template specialization <span class="addu">and shall
+contain a
+<code class="sourceCode cpp"><em>template-name</em></code></span>. The
+<code class="sourceCode cpp"><em>template-name</em></code> shall be the
+same <code class="sourceCode cpp"><em>identifier</em></code> as the
+<code class="sourceCode cpp"><em>template-name</em></code> of the
+<code class="sourceCode cpp"><em>simple-template-id</em></code>. A
+<code class="sourceCode cpp"><em>deduction-guide</em></code> shall
+inhabit the scope to which the corresponding class template belongs and,
+for a member class template, have the same access. Two deduction guide
+declarations for the same class template shall not have equivalent
+<code class="sourceCode cpp"><em>parameter-declaration-clauses</em></code>
+if either is reachable from the other.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.alias-alias-templates"><span>13.7.8 <a href="https://wg21.link/temp.alias">[temp.alias]</a></span> Alias
@@ -6824,7 +7218,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -6844,9 +7238,9 @@ splicing reflections of concepts:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-name</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6863,6 +7257,23 @@ scope. The optional <em>attribute-specifier-seq</em> appertains to the
 concept.</p>
 </blockquote>
 </div>
+<h3 class="unnumbered" id="temp.res.general-general"><span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>
+General<a href="#temp.res.general-general" class="self-link"></a></h3>
+<p>Disallow
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s
+from appearing in
+<code class="sourceCode cpp"><em>typename-specifier</em></code>s.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">3</a></span>
+The component names of a
+<code class="sourceCode cpp"><em>typename-specifier</em></code> are its
+<code class="sourceCode cpp"><em>identifier</em></code> (if any) and
+those of its
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> and
+<code class="sourceCode cpp"><em>simple-template-id</em></code> (if
+any). The
+<code class="sourceCode cpp"><em>simple-template-id</em></code> shall
+not contain a
+<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</p>
 <h3 class="unnumbered" id="temp.dep.expr-type-dependent-expressions"><span>13.8.3.3 <a href="https://wg21.link/temp.dep.expr">[temp.dep.expr]</a></span>
 Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" class="self-link"></a></h3>
 <p>Add to the list of never-type-dependent expression forms in
@@ -6870,19 +7281,19 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
-<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
-<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
-<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
-<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
-<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
-<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
-<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
-<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
-<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
-<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>     <em>literal</em></span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>     sizeof <em>unary-expression</em></span>
+<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a>     sizeof ( <em>type-id</em> )</span>
+<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a>     sizeof ... ( <em>identifier</em> )</span>
+<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a>     alignof ( <em>type-id</em> )</span>
+<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>expression</em> )</span>
+<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a>     typeid ( <em>type-id</em> )</span>
+<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete <em>cast-expression</em></span>
+<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a>     ::<sub><em>opt</em></sub> delete [ ] <em>cast-expression</em></span>
+<span id="cb129-10"><a href="#cb129-10" aria-hidden="true" tabindex="-1"></a>     throw <em>assignment-expression</em><sub><em>opt</em></sub></span>
+<span id="cb129-11"><a href="#cb129-11" aria-hidden="true" tabindex="-1"></a>     noexcept ( <em>expression</em> )</span>
+<span id="cb129-12"><a href="#cb129-12" aria-hidden="true" tabindex="-1"></a>     <em>requires-expression</em></span>
+<span id="cb129-13"><a href="#cb129-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6890,7 +7301,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6909,21 +7320,21 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
 <em>unary-expression</em> or <em>expression</em> is type-dependent or
 the <em>type-id</em> is dependent:</p>
-<div class="sourceCode" id="cb128"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
-<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
-<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
-<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
-<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
+<div class="sourceCode" id="cb130"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a>sizeof unary-expression</span>
+<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>sizeof ( type-id )</span>
+<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>typeid ( expression )</span>
+<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>typeid ( type-id )</span>
+<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a>alignof ( type-id )</span>
+<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
 <p><span class="addu">A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 value-dependent if the operand of the reflection operator is a
@@ -6938,7 +7349,7 @@ or a dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
@@ -6959,10 +7370,10 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">9</a></span>
 Preprocessing directives of the forms</p>
-<div class="sourceCode" id="cb129"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
-<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
+<div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
+<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
 <p>check whether the controlling constant expression evaluates to
 nonzero. <span class="addu">The program is ill-formed if a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> or
@@ -6977,19 +7388,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7002,7 +7413,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7010,7 +7421,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7019,14 +7430,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7041,20 +7452,20 @@ synopsis<a href="#meta.type.synop-header-type_traits-synopsis" class="self-link"
 synopsis</strong></p>
 <p>…</p>
 <div>
-<div class="sourceCode" id="cb130"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
-<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
-<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
-<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
-<span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
-<span id="cb130-10"><a href="#cb130-10" aria-hidden="true" tabindex="-1"></a>...</span>
-<span id="cb130-11"><a href="#cb130-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
-<span id="cb130-12"><a href="#cb130-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
-<span id="cb130-13"><a href="#cb130-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
-<span id="cb130-14"><a href="#cb130-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
+<div class="sourceCode" id="cb132"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_void;</span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt; struct is_function;</span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt; struct is_reflection;</span></span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>    // [meta.unary.cat], primary type categories</span>
+<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_void_v = is_void&lt;T&gt;::value;</span>
+<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>...</span>
+<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>    template&lt;class T&gt;</span>
+<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>      constexpr bool is_function_v = is_function&lt;T&gt;::value;</span>
+<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a><span class="va">+   template&lt;class T&gt;</span></span>
+<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a><span class="va">+     constexpr bool is_reflection_v = is_reflection&lt;T&gt;::value;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -7076,8 +7487,8 @@ Comments
 </tr>
 <tr>
 <td>
-<div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_void;</span></code></pre></div>
 </td>
 <td style="text-align:center; vertical-align: middle">
 <code class="sourceCode cpp">T</code> is
@@ -7100,8 +7511,8 @@ Comments
 <tr>
 <td>
 <div class="addu">
-<div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
+<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> is_reflection;</span></code></pre></div>
 </div>
 </td>
 <td style="text-align:center; vertical-align: middle">
@@ -7125,354 +7536,354 @@ synopsis<a href="#meta.synop-header-meta-synopsis" class="self-link"></a></h3>
 <div class="addu">
 <p><strong>Header <code class="sourceCode cpp"><span class="op">&lt;</span>meta<span class="op">&gt;</span></code>
 synopsis</strong></p>
-<div class="sourceCode" id="cb133"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
-<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
-<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
-<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
-<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
-<span id="cb133-8"><a href="#cb133-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-9"><a href="#cb133-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
-<span id="cb133-10"><a href="#cb133-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
-<span id="cb133-11"><a href="#cb133-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
-<span id="cb133-12"><a href="#cb133-12" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb133-13"><a href="#cb133-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
-<span id="cb133-14"><a href="#cb133-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
-<span id="cb133-15"><a href="#cb133-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
-<span id="cb133-16"><a href="#cb133-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
-<span id="cb133-17"><a href="#cb133-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-18"><a href="#cb133-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
-<span id="cb133-19"><a href="#cb133-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
-<span id="cb133-20"><a href="#cb133-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-21"><a href="#cb133-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
-<span id="cb133-22"><a href="#cb133-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
-<span id="cb133-23"><a href="#cb133-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-24"><a href="#cb133-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
-<span id="cb133-25"><a href="#cb133-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
-<span id="cb133-26"><a href="#cb133-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-27"><a href="#cb133-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
-<span id="cb133-28"><a href="#cb133-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-29"><a href="#cb133-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
-<span id="cb133-30"><a href="#cb133-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
-<span id="cb133-31"><a href="#cb133-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
-<span id="cb133-32"><a href="#cb133-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
-<span id="cb133-33"><a href="#cb133-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-34"><a href="#cb133-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
-<span id="cb133-35"><a href="#cb133-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
-<span id="cb133-36"><a href="#cb133-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
-<span id="cb133-37"><a href="#cb133-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
-<span id="cb133-38"><a href="#cb133-38" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-39"><a href="#cb133-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
-<span id="cb133-40"><a href="#cb133-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
-<span id="cb133-41"><a href="#cb133-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
-<span id="cb133-42"><a href="#cb133-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
-<span id="cb133-43"><a href="#cb133-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
-<span id="cb133-44"><a href="#cb133-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
-<span id="cb133-45"><a href="#cb133-45" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-46"><a href="#cb133-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
-<span id="cb133-47"><a href="#cb133-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
-<span id="cb133-48"><a href="#cb133-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-49"><a href="#cb133-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
-<span id="cb133-50"><a href="#cb133-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
-<span id="cb133-51"><a href="#cb133-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
-<span id="cb133-52"><a href="#cb133-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
-<span id="cb133-53"><a href="#cb133-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
-<span id="cb133-54"><a href="#cb133-54" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-55"><a href="#cb133-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
-<span id="cb133-56"><a href="#cb133-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
-<span id="cb133-57"><a href="#cb133-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
-<span id="cb133-58"><a href="#cb133-58" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-59"><a href="#cb133-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
-<span id="cb133-60"><a href="#cb133-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
-<span id="cb133-61"><a href="#cb133-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
-<span id="cb133-62"><a href="#cb133-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
-<span id="cb133-63"><a href="#cb133-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-64"><a href="#cb133-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
-<span id="cb133-65"><a href="#cb133-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
-<span id="cb133-66"><a href="#cb133-66" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-67"><a href="#cb133-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
-<span id="cb133-68"><a href="#cb133-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
-<span id="cb133-69"><a href="#cb133-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
-<span id="cb133-70"><a href="#cb133-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
-<span id="cb133-71"><a href="#cb133-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
-<span id="cb133-72"><a href="#cb133-72" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-73"><a href="#cb133-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
-<span id="cb133-74"><a href="#cb133-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
-<span id="cb133-75"><a href="#cb133-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
-<span id="cb133-76"><a href="#cb133-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
-<span id="cb133-77"><a href="#cb133-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
-<span id="cb133-78"><a href="#cb133-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
-<span id="cb133-79"><a href="#cb133-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
-<span id="cb133-80"><a href="#cb133-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
-<span id="cb133-81"><a href="#cb133-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
-<span id="cb133-82"><a href="#cb133-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
-<span id="cb133-83"><a href="#cb133-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
-<span id="cb133-84"><a href="#cb133-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
-<span id="cb133-85"><a href="#cb133-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
-<span id="cb133-86"><a href="#cb133-86" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-87"><a href="#cb133-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
-<span id="cb133-88"><a href="#cb133-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
-<span id="cb133-89"><a href="#cb133-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
-<span id="cb133-90"><a href="#cb133-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
-<span id="cb133-91"><a href="#cb133-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
-<span id="cb133-92"><a href="#cb133-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
-<span id="cb133-93"><a href="#cb133-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
-<span id="cb133-94"><a href="#cb133-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
-<span id="cb133-95"><a href="#cb133-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
-<span id="cb133-96"><a href="#cb133-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
-<span id="cb133-97"><a href="#cb133-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
-<span id="cb133-98"><a href="#cb133-98" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-99"><a href="#cb133-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
-<span id="cb133-100"><a href="#cb133-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
-<span id="cb133-101"><a href="#cb133-101" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-102"><a href="#cb133-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
-<span id="cb133-103"><a href="#cb133-103" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-104"><a href="#cb133-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
-<span id="cb133-105"><a href="#cb133-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
-<span id="cb133-106"><a href="#cb133-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
-<span id="cb133-107"><a href="#cb133-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
-<span id="cb133-108"><a href="#cb133-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
-<span id="cb133-109"><a href="#cb133-109" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-110"><a href="#cb133-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
-<span id="cb133-111"><a href="#cb133-111" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-112"><a href="#cb133-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
-<span id="cb133-113"><a href="#cb133-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
-<span id="cb133-114"><a href="#cb133-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
-<span id="cb133-115"><a href="#cb133-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
-<span id="cb133-116"><a href="#cb133-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
-<span id="cb133-117"><a href="#cb133-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
-<span id="cb133-118"><a href="#cb133-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
-<span id="cb133-119"><a href="#cb133-119" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-120"><a href="#cb133-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
-<span id="cb133-121"><a href="#cb133-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
-<span id="cb133-122"><a href="#cb133-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
-<span id="cb133-123"><a href="#cb133-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
-<span id="cb133-124"><a href="#cb133-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
-<span id="cb133-125"><a href="#cb133-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
-<span id="cb133-126"><a href="#cb133-126" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-127"><a href="#cb133-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
-<span id="cb133-128"><a href="#cb133-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
-<span id="cb133-129"><a href="#cb133-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
-<span id="cb133-130"><a href="#cb133-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
-<span id="cb133-131"><a href="#cb133-131" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-132"><a href="#cb133-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
-<span id="cb133-133"><a href="#cb133-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
-<span id="cb133-134"><a href="#cb133-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
-<span id="cb133-135"><a href="#cb133-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
-<span id="cb133-136"><a href="#cb133-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
-<span id="cb133-137"><a href="#cb133-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
-<span id="cb133-138"><a href="#cb133-138" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb133-139"><a href="#cb133-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
-<span id="cb133-140"><a href="#cb133-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
-<span id="cb133-141"><a href="#cb133-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
-<span id="cb133-142"><a href="#cb133-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
-<span id="cb133-143"><a href="#cb133-143" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-144"><a href="#cb133-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
-<span id="cb133-145"><a href="#cb133-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb133-146"><a href="#cb133-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
-<span id="cb133-147"><a href="#cb133-147" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-148"><a href="#cb133-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
-<span id="cb133-149"><a href="#cb133-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
-<span id="cb133-150"><a href="#cb133-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
-<span id="cb133-151"><a href="#cb133-151" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-152"><a href="#cb133-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-153"><a href="#cb133-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb133-154"><a href="#cb133-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-155"><a href="#cb133-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
-<span id="cb133-156"><a href="#cb133-156" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-157"><a href="#cb133-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
-<span id="cb133-158"><a href="#cb133-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb133-159"><a href="#cb133-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
-<span id="cb133-160"><a href="#cb133-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb133-161"><a href="#cb133-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
-<span id="cb133-162"><a href="#cb133-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
-<span id="cb133-163"><a href="#cb133-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
-<span id="cb133-164"><a href="#cb133-164" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-165"><a href="#cb133-165" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define.aggregate], class definition generation</span>
-<span id="cb133-166"><a href="#cb133-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
-<span id="cb133-167"><a href="#cb133-167" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
-<span id="cb133-168"><a href="#cb133-168" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
-<span id="cb133-169"><a href="#cb133-169" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb133-170"><a href="#cb133-170" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-171"><a href="#cb133-171" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
-<span id="cb133-172"><a href="#cb133-172" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
-<span id="cb133-173"><a href="#cb133-173" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-174"><a href="#cb133-174" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
-<span id="cb133-175"><a href="#cb133-175" aria-hidden="true" tabindex="-1"></a>    };</span>
-<span id="cb133-176"><a href="#cb133-176" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-177"><a href="#cb133-177" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
-<span id="cb133-178"><a href="#cb133-178" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
-<span id="cb133-179"><a href="#cb133-179" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; bit_width;</span>
-<span id="cb133-180"><a href="#cb133-180" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
-<span id="cb133-181"><a href="#cb133-181" aria-hidden="true" tabindex="-1"></a>  };</span>
-<span id="cb133-182"><a href="#cb133-182" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
-<span id="cb133-183"><a href="#cb133-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
-<span id="cb133-184"><a href="#cb133-184" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
-<span id="cb133-185"><a href="#cb133-185" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-186"><a href="#cb133-186" aria-hidden="true" tabindex="-1"></a>  consteval info define_aggregate(info type_class, R&amp;&amp;);</span>
-<span id="cb133-187"><a href="#cb133-187" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-188"><a href="#cb133-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
-<span id="cb133-189"><a href="#cb133-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type);</span>
-<span id="cb133-190"><a href="#cb133-190" aria-hidden="true" tabindex="-1"></a>  consteval bool is_null_pointer_type(info type);</span>
-<span id="cb133-191"><a href="#cb133-191" aria-hidden="true" tabindex="-1"></a>  consteval bool is_integral_type(info type);</span>
-<span id="cb133-192"><a href="#cb133-192" aria-hidden="true" tabindex="-1"></a>  consteval bool is_floating_point_type(info type);</span>
-<span id="cb133-193"><a href="#cb133-193" aria-hidden="true" tabindex="-1"></a>  consteval bool is_array_type(info type);</span>
-<span id="cb133-194"><a href="#cb133-194" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_type(info type);</span>
-<span id="cb133-195"><a href="#cb133-195" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_type(info type);</span>
-<span id="cb133-196"><a href="#cb133-196" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_type(info type);</span>
-<span id="cb133-197"><a href="#cb133-197" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_object_pointer_type(info type);</span>
-<span id="cb133-198"><a href="#cb133-198" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_function_pointer_type(info type);</span>
-<span id="cb133-199"><a href="#cb133-199" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enum_type(info type);</span>
-<span id="cb133-200"><a href="#cb133-200" aria-hidden="true" tabindex="-1"></a>  consteval bool is_union_type(info type);</span>
-<span id="cb133-201"><a href="#cb133-201" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_type(info type);</span>
-<span id="cb133-202"><a href="#cb133-202" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_type(info type);</span>
-<span id="cb133-203"><a href="#cb133-203" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reflection_type(info type);</span>
-<span id="cb133-204"><a href="#cb133-204" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-205"><a href="#cb133-205" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
-<span id="cb133-206"><a href="#cb133-206" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reference_type(info type);</span>
-<span id="cb133-207"><a href="#cb133-207" aria-hidden="true" tabindex="-1"></a>  consteval bool is_arithmetic_type(info type);</span>
-<span id="cb133-208"><a href="#cb133-208" aria-hidden="true" tabindex="-1"></a>  consteval bool is_fundamental_type(info type);</span>
-<span id="cb133-209"><a href="#cb133-209" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object_type(info type);</span>
-<span id="cb133-210"><a href="#cb133-210" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scalar_type(info type);</span>
-<span id="cb133-211"><a href="#cb133-211" aria-hidden="true" tabindex="-1"></a>  consteval bool is_compound_type(info type);</span>
-<span id="cb133-212"><a href="#cb133-212" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_pointer_type(info type);</span>
-<span id="cb133-213"><a href="#cb133-213" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-214"><a href="#cb133-214" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
-<span id="cb133-215"><a href="#cb133-215" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const_type(info type);</span>
-<span id="cb133-216"><a href="#cb133-216" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile_type(info type);</span>
-<span id="cb133-217"><a href="#cb133-217" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivial_type(info type);</span>
-<span id="cb133-218"><a href="#cb133-218" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copyable_type(info type);</span>
-<span id="cb133-219"><a href="#cb133-219" aria-hidden="true" tabindex="-1"></a>  consteval bool is_standard_layout_type(info type);</span>
-<span id="cb133-220"><a href="#cb133-220" aria-hidden="true" tabindex="-1"></a>  consteval bool is_empty_type(info type);</span>
-<span id="cb133-221"><a href="#cb133-221" aria-hidden="true" tabindex="-1"></a>  consteval bool is_polymorphic_type(info type);</span>
-<span id="cb133-222"><a href="#cb133-222" aria-hidden="true" tabindex="-1"></a>  consteval bool is_abstract_type(info type);</span>
-<span id="cb133-223"><a href="#cb133-223" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final_type(info type);</span>
-<span id="cb133-224"><a href="#cb133-224" aria-hidden="true" tabindex="-1"></a>  consteval bool is_aggregate_type(info type);</span>
-<span id="cb133-225"><a href="#cb133-225" aria-hidden="true" tabindex="-1"></a>  consteval bool is_signed_type(info type);</span>
-<span id="cb133-226"><a href="#cb133-226" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unsigned_type(info type);</span>
-<span id="cb133-227"><a href="#cb133-227" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bounded_array_type(info type);</span>
-<span id="cb133-228"><a href="#cb133-228" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unbounded_array_type(info type);</span>
-<span id="cb133-229"><a href="#cb133-229" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scoped_enum_type(info type);</span>
-<span id="cb133-230"><a href="#cb133-230" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-231"><a href="#cb133-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-232"><a href="#cb133-232" aria-hidden="true" tabindex="-1"></a>    consteval bool is_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb133-233"><a href="#cb133-233" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructible_type(info type);</span>
-<span id="cb133-234"><a href="#cb133-234" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructible_type(info type);</span>
-<span id="cb133-235"><a href="#cb133-235" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructible_type(info type);</span>
-<span id="cb133-236"><a href="#cb133-236" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-237"><a href="#cb133-237" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignable_type(info type_dst, info type_src);</span>
-<span id="cb133-238"><a href="#cb133-238" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignable_type(info type);</span>
-<span id="cb133-239"><a href="#cb133-239" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignable_type(info type);</span>
-<span id="cb133-240"><a href="#cb133-240" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-241"><a href="#cb133-241" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_with_type(info type_dst, info type_src);</span>
-<span id="cb133-242"><a href="#cb133-242" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_type(info type);</span>
-<span id="cb133-243"><a href="#cb133-243" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-244"><a href="#cb133-244" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructible_type(info type);</span>
-<span id="cb133-245"><a href="#cb133-245" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-246"><a href="#cb133-246" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-247"><a href="#cb133-247" aria-hidden="true" tabindex="-1"></a>    consteval bool is_trivially_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb133-248"><a href="#cb133-248" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_default_constructible_type(info type);</span>
-<span id="cb133-249"><a href="#cb133-249" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_constructible_type(info type);</span>
-<span id="cb133-250"><a href="#cb133-250" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_constructible_type(info type);</span>
-<span id="cb133-251"><a href="#cb133-251" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-252"><a href="#cb133-252" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_assignable_type(info type_dst, info type_src);</span>
-<span id="cb133-253"><a href="#cb133-253" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_assignable_type(info type);</span>
-<span id="cb133-254"><a href="#cb133-254" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_assignable_type(info type);</span>
-<span id="cb133-255"><a href="#cb133-255" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_destructible_type(info type);</span>
-<span id="cb133-256"><a href="#cb133-256" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-257"><a href="#cb133-257" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-258"><a href="#cb133-258" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_constructible_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb133-259"><a href="#cb133-259" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_default_constructible_type(info type);</span>
-<span id="cb133-260"><a href="#cb133-260" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_constructible_type(info type);</span>
-<span id="cb133-261"><a href="#cb133-261" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_constructible_type(info type);</span>
-<span id="cb133-262"><a href="#cb133-262" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-263"><a href="#cb133-263" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_assignable_type(info type_dst, info type_src);</span>
-<span id="cb133-264"><a href="#cb133-264" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_assignable_type(info type);</span>
-<span id="cb133-265"><a href="#cb133-265" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_assignable_type(info type);</span>
-<span id="cb133-266"><a href="#cb133-266" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-267"><a href="#cb133-267" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_with_type(info type_dst, info type_src);</span>
-<span id="cb133-268"><a href="#cb133-268" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_type(info type);</span>
-<span id="cb133-269"><a href="#cb133-269" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-270"><a href="#cb133-270" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_destructible_type(info type);</span>
-<span id="cb133-271"><a href="#cb133-271" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-272"><a href="#cb133-272" aria-hidden="true" tabindex="-1"></a>  consteval bool is_implicit_lifetime_type(info type);</span>
-<span id="cb133-273"><a href="#cb133-273" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-274"><a href="#cb133-274" aria-hidden="true" tabindex="-1"></a>  consteval bool has_virtual_destructor(info type);</span>
-<span id="cb133-275"><a href="#cb133-275" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-276"><a href="#cb133-276" aria-hidden="true" tabindex="-1"></a>  consteval bool has_unique_object_representations(info type);</span>
-<span id="cb133-277"><a href="#cb133-277" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-278"><a href="#cb133-278" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_constructs_from_temporary(info type_dst, info type_src);</span>
-<span id="cb133-279"><a href="#cb133-279" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_converts_from_temporary(info type_dst, info type_src);</span>
-<span id="cb133-280"><a href="#cb133-280" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-281"><a href="#cb133-281" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
-<span id="cb133-282"><a href="#cb133-282" aria-hidden="true" tabindex="-1"></a>  consteval size_t rank(info type);</span>
-<span id="cb133-283"><a href="#cb133-283" aria-hidden="true" tabindex="-1"></a>  consteval size_t extent(info type, unsigned i = 0);</span>
-<span id="cb133-284"><a href="#cb133-284" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-285"><a href="#cb133-285" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
-<span id="cb133-286"><a href="#cb133-286" aria-hidden="true" tabindex="-1"></a>  consteval bool is_same_type(info type1, info type2);</span>
-<span id="cb133-287"><a href="#cb133-287" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base_of_type(info type_base, info type_derived);</span>
-<span id="cb133-288"><a href="#cb133-288" aria-hidden="true" tabindex="-1"></a>  consteval bool is_convertible_type(info type_src, info type_dst);</span>
-<span id="cb133-289"><a href="#cb133-289" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_convertible_type(info type_src, info type_dst);</span>
-<span id="cb133-290"><a href="#cb133-290" aria-hidden="true" tabindex="-1"></a>  consteval bool is_layout_compatible_type(info type1, info type2);</span>
-<span id="cb133-291"><a href="#cb133-291" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_interconvertible_base_of_type(info type_base, info type_derived);</span>
-<span id="cb133-292"><a href="#cb133-292" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-293"><a href="#cb133-293" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-294"><a href="#cb133-294" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb133-295"><a href="#cb133-295" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-296"><a href="#cb133-296" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb133-297"><a href="#cb133-297" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-298"><a href="#cb133-298" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-299"><a href="#cb133-299" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_type(info type, R&amp;&amp; type_args);</span>
-<span id="cb133-300"><a href="#cb133-300" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-301"><a href="#cb133-301" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
-<span id="cb133-302"><a href="#cb133-302" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-303"><a href="#cb133-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
-<span id="cb133-304"><a href="#cb133-304" aria-hidden="true" tabindex="-1"></a>  consteval info remove_const(info type);</span>
-<span id="cb133-305"><a href="#cb133-305" aria-hidden="true" tabindex="-1"></a>  consteval info remove_volatile(info type);</span>
-<span id="cb133-306"><a href="#cb133-306" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cv(info type);</span>
-<span id="cb133-307"><a href="#cb133-307" aria-hidden="true" tabindex="-1"></a>  consteval info add_const(info type);</span>
-<span id="cb133-308"><a href="#cb133-308" aria-hidden="true" tabindex="-1"></a>  consteval info add_volatile(info type);</span>
-<span id="cb133-309"><a href="#cb133-309" aria-hidden="true" tabindex="-1"></a>  consteval info add_cv(info type);</span>
-<span id="cb133-310"><a href="#cb133-310" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-311"><a href="#cb133-311" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
-<span id="cb133-312"><a href="#cb133-312" aria-hidden="true" tabindex="-1"></a>  consteval info remove_reference(info type);</span>
-<span id="cb133-313"><a href="#cb133-313" aria-hidden="true" tabindex="-1"></a>  consteval info add_lvalue_reference(info type);</span>
-<span id="cb133-314"><a href="#cb133-314" aria-hidden="true" tabindex="-1"></a>  consteval info add_rvalue_reference(info type);</span>
-<span id="cb133-315"><a href="#cb133-315" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-316"><a href="#cb133-316" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
-<span id="cb133-317"><a href="#cb133-317" aria-hidden="true" tabindex="-1"></a>  consteval info make_signed(info type);</span>
-<span id="cb133-318"><a href="#cb133-318" aria-hidden="true" tabindex="-1"></a>  consteval info make_unsigned(info type);</span>
-<span id="cb133-319"><a href="#cb133-319" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-320"><a href="#cb133-320" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
-<span id="cb133-321"><a href="#cb133-321" aria-hidden="true" tabindex="-1"></a>  consteval info remove_extent(info type);</span>
-<span id="cb133-322"><a href="#cb133-322" aria-hidden="true" tabindex="-1"></a>  consteval info remove_all_extents(info type);</span>
-<span id="cb133-323"><a href="#cb133-323" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-324"><a href="#cb133-324" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
-<span id="cb133-325"><a href="#cb133-325" aria-hidden="true" tabindex="-1"></a>  consteval info remove_pointer(info type);</span>
-<span id="cb133-326"><a href="#cb133-326" aria-hidden="true" tabindex="-1"></a>  consteval info add_pointer(info type);</span>
-<span id="cb133-327"><a href="#cb133-327" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-328"><a href="#cb133-328" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
-<span id="cb133-329"><a href="#cb133-329" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cvref(info type);</span>
-<span id="cb133-330"><a href="#cb133-330" aria-hidden="true" tabindex="-1"></a>  consteval info decay(info type);</span>
-<span id="cb133-331"><a href="#cb133-331" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-332"><a href="#cb133-332" aria-hidden="true" tabindex="-1"></a>    consteval info common_type(R&amp;&amp; type_args);</span>
-<span id="cb133-333"><a href="#cb133-333" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-334"><a href="#cb133-334" aria-hidden="true" tabindex="-1"></a>    consteval info common_reference(R&amp;&amp; type_args);</span>
-<span id="cb133-335"><a href="#cb133-335" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
-<span id="cb133-336"><a href="#cb133-336" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
-<span id="cb133-337"><a href="#cb133-337" aria-hidden="true" tabindex="-1"></a>    `consteval info invoke_result(info type, R&amp;&amp; type_args);</span>
-<span id="cb133-338"><a href="#cb133-338" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_reference(info type);</span>
-<span id="cb133-339"><a href="#cb133-339" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_ref_decay(info type);</span>
-<span id="cb133-340"><a href="#cb133-340" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-341"><a href="#cb133-341" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
-<span id="cb133-342"><a href="#cb133-342" aria-hidden="true" tabindex="-1"></a>  consteval size_t tuple_size(info type);</span>
-<span id="cb133-343"><a href="#cb133-343" aria-hidden="true" tabindex="-1"></a>  consteval info tuple_element(size_t index, info type);</span>
-<span id="cb133-344"><a href="#cb133-344" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb133-345"><a href="#cb133-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
-<span id="cb133-346"><a href="#cb133-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
-<span id="cb133-347"><a href="#cb133-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">1</a></span>
+<div class="sourceCode" id="cb135"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a>#include &lt;initializer_list&gt;</span>
+<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>#include &lt;ranges&gt;</span>
+<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a>#include &lt;string_view&gt;</span>
+<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>#include &lt;vector&gt;</span>
+<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb135-7"><a href="#cb135-7" aria-hidden="true" tabindex="-1"></a>  using info = decltype(^::);</span>
+<span id="cb135-8"><a href="#cb135-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-9"><a href="#cb135-9" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.operators], operator representations</span>
+<span id="cb135-10"><a href="#cb135-10" aria-hidden="true" tabindex="-1"></a>  enum class operators {</span>
+<span id="cb135-11"><a href="#cb135-11" aria-hidden="true" tabindex="-1"></a>    <em>see below</em>;</span>
+<span id="cb135-12"><a href="#cb135-12" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a>  using enum operators;</span>
+<span id="cb135-14"><a href="#cb135-14" aria-hidden="true" tabindex="-1"></a>  consteval operators operator_of(info r);</span>
+<span id="cb135-15"><a href="#cb135-15" aria-hidden="true" tabindex="-1"></a>  consteval string_view symbol_of(operators op);</span>
+<span id="cb135-16"><a href="#cb135-16" aria-hidden="true" tabindex="-1"></a>  consteval u8string_view u8symbol_of(operators op);</span>
+<span id="cb135-17"><a href="#cb135-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-18"><a href="#cb135-18" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.names], reflection names and locations</span>
+<span id="cb135-19"><a href="#cb135-19" aria-hidden="true" tabindex="-1"></a>  consteval bool has_identifier(info r);</span>
+<span id="cb135-20"><a href="#cb135-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-21"><a href="#cb135-21" aria-hidden="true" tabindex="-1"></a>  consteval string_view identifier_of(info r);</span>
+<span id="cb135-22"><a href="#cb135-22" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8identifier_of(info r);</span>
+<span id="cb135-23"><a href="#cb135-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-24"><a href="#cb135-24" aria-hidden="true" tabindex="-1"></a>  consteval string_view display_string_of(info r);</span>
+<span id="cb135-25"><a href="#cb135-25" aria-hidden="true" tabindex="-1"></a>  consteval string_view u8display_string_of(info r);</span>
+<span id="cb135-26"><a href="#cb135-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-27"><a href="#cb135-27" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
+<span id="cb135-28"><a href="#cb135-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-29"><a href="#cb135-29" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
+<span id="cb135-30"><a href="#cb135-30" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
+<span id="cb135-31"><a href="#cb135-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
+<span id="cb135-32"><a href="#cb135-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
+<span id="cb135-33"><a href="#cb135-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-34"><a href="#cb135-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
+<span id="cb135-35"><a href="#cb135-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
+<span id="cb135-36"><a href="#cb135-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
+<span id="cb135-37"><a href="#cb135-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
+<span id="cb135-38"><a href="#cb135-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-39"><a href="#cb135-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
+<span id="cb135-40"><a href="#cb135-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
+<span id="cb135-41"><a href="#cb135-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
+<span id="cb135-42"><a href="#cb135-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
+<span id="cb135-43"><a href="#cb135-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
+<span id="cb135-44"><a href="#cb135-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
+<span id="cb135-45"><a href="#cb135-45" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-46"><a href="#cb135-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
+<span id="cb135-47"><a href="#cb135-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
+<span id="cb135-48"><a href="#cb135-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-49"><a href="#cb135-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
+<span id="cb135-50"><a href="#cb135-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
+<span id="cb135-51"><a href="#cb135-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
+<span id="cb135-52"><a href="#cb135-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
+<span id="cb135-53"><a href="#cb135-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
+<span id="cb135-54"><a href="#cb135-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-55"><a href="#cb135-55" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
+<span id="cb135-56"><a href="#cb135-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
+<span id="cb135-57"><a href="#cb135-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
+<span id="cb135-58"><a href="#cb135-58" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-59"><a href="#cb135-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
+<span id="cb135-60"><a href="#cb135-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
+<span id="cb135-61"><a href="#cb135-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
+<span id="cb135-62"><a href="#cb135-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
+<span id="cb135-63"><a href="#cb135-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-64"><a href="#cb135-64" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
+<span id="cb135-65"><a href="#cb135-65" aria-hidden="true" tabindex="-1"></a>  consteval bool has_complete_definition(info r);</span>
+<span id="cb135-66"><a href="#cb135-66" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-67"><a href="#cb135-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
+<span id="cb135-68"><a href="#cb135-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
+<span id="cb135-69"><a href="#cb135-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
+<span id="cb135-70"><a href="#cb135-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
+<span id="cb135-71"><a href="#cb135-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
+<span id="cb135-72"><a href="#cb135-72" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-73"><a href="#cb135-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
+<span id="cb135-74"><a href="#cb135-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
+<span id="cb135-75"><a href="#cb135-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
+<span id="cb135-76"><a href="#cb135-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
+<span id="cb135-77"><a href="#cb135-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
+<span id="cb135-78"><a href="#cb135-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
+<span id="cb135-79"><a href="#cb135-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
+<span id="cb135-80"><a href="#cb135-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
+<span id="cb135-81"><a href="#cb135-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
+<span id="cb135-82"><a href="#cb135-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
+<span id="cb135-83"><a href="#cb135-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
+<span id="cb135-84"><a href="#cb135-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
+<span id="cb135-85"><a href="#cb135-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
+<span id="cb135-86"><a href="#cb135-86" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-87"><a href="#cb135-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
+<span id="cb135-88"><a href="#cb135-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
+<span id="cb135-89"><a href="#cb135-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
+<span id="cb135-90"><a href="#cb135-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
+<span id="cb135-91"><a href="#cb135-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
+<span id="cb135-92"><a href="#cb135-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
+<span id="cb135-93"><a href="#cb135-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
+<span id="cb135-94"><a href="#cb135-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
+<span id="cb135-95"><a href="#cb135-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
+<span id="cb135-96"><a href="#cb135-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
+<span id="cb135-97"><a href="#cb135-97" aria-hidden="true" tabindex="-1"></a>  consteval bool has_template_arguments(info r);</span>
+<span id="cb135-98"><a href="#cb135-98" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-99"><a href="#cb135-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
+<span id="cb135-100"><a href="#cb135-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
+<span id="cb135-101"><a href="#cb135-101" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-102"><a href="#cb135-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
+<span id="cb135-103"><a href="#cb135-103" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-104"><a href="#cb135-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
+<span id="cb135-105"><a href="#cb135-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
+<span id="cb135-106"><a href="#cb135-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
+<span id="cb135-107"><a href="#cb135-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
+<span id="cb135-108"><a href="#cb135-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
+<span id="cb135-109"><a href="#cb135-109" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-110"><a href="#cb135-110" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
+<span id="cb135-111"><a href="#cb135-111" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-112"><a href="#cb135-112" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
+<span id="cb135-113"><a href="#cb135-113" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
+<span id="cb135-114"><a href="#cb135-114" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
+<span id="cb135-115"><a href="#cb135-115" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
+<span id="cb135-116"><a href="#cb135-116" aria-hidden="true" tabindex="-1"></a>  consteval info dealias(info r);</span>
+<span id="cb135-117"><a href="#cb135-117" aria-hidden="true" tabindex="-1"></a>  consteval info template_of(info r);</span>
+<span id="cb135-118"><a href="#cb135-118" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; template_arguments_of(info r);</span>
+<span id="cb135-119"><a href="#cb135-119" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-120"><a href="#cb135-120" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.member.queries], reflection member queries</span>
+<span id="cb135-121"><a href="#cb135-121" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; members_of(info r);</span>
+<span id="cb135-122"><a href="#cb135-122" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; bases_of(info type);</span>
+<span id="cb135-123"><a href="#cb135-123" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; static_data_members_of(info type);</span>
+<span id="cb135-124"><a href="#cb135-124" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; nonstatic_data_members_of(info type);</span>
+<span id="cb135-125"><a href="#cb135-125" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; enumerators_of(info type_enum);</span>
+<span id="cb135-126"><a href="#cb135-126" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-127"><a href="#cb135-127" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_members(info type);</span>
+<span id="cb135-128"><a href="#cb135-128" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_static_data_members(info type);</span>
+<span id="cb135-129"><a href="#cb135-129" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_nonstatic_data_members(info type);</span>
+<span id="cb135-130"><a href="#cb135-130" aria-hidden="true" tabindex="-1"></a>  consteval vector&lt;info&gt; get_public_bases(info type);</span>
+<span id="cb135-131"><a href="#cb135-131" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-132"><a href="#cb135-132" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.layout], reflection layout queries</span>
+<span id="cb135-133"><a href="#cb135-133" aria-hidden="true" tabindex="-1"></a>  struct member_offset {</span>
+<span id="cb135-134"><a href="#cb135-134" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bytes;</span>
+<span id="cb135-135"><a href="#cb135-135" aria-hidden="true" tabindex="-1"></a>    ptrdiff_t bits;</span>
+<span id="cb135-136"><a href="#cb135-136" aria-hidden="true" tabindex="-1"></a>    constexpr ptrdiff_t total_bits() const;</span>
+<span id="cb135-137"><a href="#cb135-137" aria-hidden="true" tabindex="-1"></a>    auto operator&lt;=&gt;(member_offset const&amp;) const = default;</span>
+<span id="cb135-138"><a href="#cb135-138" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb135-139"><a href="#cb135-139" aria-hidden="true" tabindex="-1"></a>  consteval member_offset offset_of(info r);</span>
+<span id="cb135-140"><a href="#cb135-140" aria-hidden="true" tabindex="-1"></a>  consteval size_t size_of(info r);</span>
+<span id="cb135-141"><a href="#cb135-141" aria-hidden="true" tabindex="-1"></a>  consteval size_t alignment_of(info r);</span>
+<span id="cb135-142"><a href="#cb135-142" aria-hidden="true" tabindex="-1"></a>  consteval size_t bit_size_of(info r);</span>
+<span id="cb135-143"><a href="#cb135-143" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-144"><a href="#cb135-144" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.extract], value extraction</span>
+<span id="cb135-145"><a href="#cb135-145" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb135-146"><a href="#cb135-146" aria-hidden="true" tabindex="-1"></a>    consteval T extract(info);</span>
+<span id="cb135-147"><a href="#cb135-147" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-148"><a href="#cb135-148" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.substitute], reflection substitution</span>
+<span id="cb135-149"><a href="#cb135-149" aria-hidden="true" tabindex="-1"></a>  template &lt;class R&gt;</span>
+<span id="cb135-150"><a href="#cb135-150" aria-hidden="true" tabindex="-1"></a>    concept reflection_range = <em>see below</em>;</span>
+<span id="cb135-151"><a href="#cb135-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-152"><a href="#cb135-152" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-153"><a href="#cb135-153" aria-hidden="true" tabindex="-1"></a>    consteval bool can_substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb135-154"><a href="#cb135-154" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-155"><a href="#cb135-155" aria-hidden="true" tabindex="-1"></a>    consteval info substitute(info templ, R&amp;&amp; arguments);</span>
+<span id="cb135-156"><a href="#cb135-156" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-157"><a href="#cb135-157" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.result], expression result reflection</span>
+<span id="cb135-158"><a href="#cb135-158" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb135-159"><a href="#cb135-159" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_value(T value);</span>
+<span id="cb135-160"><a href="#cb135-160" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb135-161"><a href="#cb135-161" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_object(T&amp; object);</span>
+<span id="cb135-162"><a href="#cb135-162" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt;</span>
+<span id="cb135-163"><a href="#cb135-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
+<span id="cb135-164"><a href="#cb135-164" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-165"><a href="#cb135-165" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define.aggregate], class definition generation</span>
+<span id="cb135-166"><a href="#cb135-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
+<span id="cb135-167"><a href="#cb135-167" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
+<span id="cb135-168"><a href="#cb135-168" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
+<span id="cb135-169"><a href="#cb135-169" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb135-170"><a href="#cb135-170" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-171"><a href="#cb135-171" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;string, T&gt;</span>
+<span id="cb135-172"><a href="#cb135-172" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
+<span id="cb135-173"><a href="#cb135-173" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-174"><a href="#cb135-174" aria-hidden="true" tabindex="-1"></a>      variant&lt;u8string, string&gt; <em>contents</em>;    // <em>exposition only</em></span>
+<span id="cb135-175"><a href="#cb135-175" aria-hidden="true" tabindex="-1"></a>    };</span>
+<span id="cb135-176"><a href="#cb135-176" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-177"><a href="#cb135-177" aria-hidden="true" tabindex="-1"></a>    optional&lt;name_type&gt; name;</span>
+<span id="cb135-178"><a href="#cb135-178" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; alignment;</span>
+<span id="cb135-179"><a href="#cb135-179" aria-hidden="true" tabindex="-1"></a>    optional&lt;int&gt; bit_width;</span>
+<span id="cb135-180"><a href="#cb135-180" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
+<span id="cb135-181"><a href="#cb135-181" aria-hidden="true" tabindex="-1"></a>  };</span>
+<span id="cb135-182"><a href="#cb135-182" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
+<span id="cb135-183"><a href="#cb135-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
+<span id="cb135-184"><a href="#cb135-184" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
+<span id="cb135-185"><a href="#cb135-185" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-186"><a href="#cb135-186" aria-hidden="true" tabindex="-1"></a>  consteval info define_aggregate(info type_class, R&amp;&amp;);</span>
+<span id="cb135-187"><a href="#cb135-187" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-188"><a href="#cb135-188" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.cat], primary type categories</span>
+<span id="cb135-189"><a href="#cb135-189" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type);</span>
+<span id="cb135-190"><a href="#cb135-190" aria-hidden="true" tabindex="-1"></a>  consteval bool is_null_pointer_type(info type);</span>
+<span id="cb135-191"><a href="#cb135-191" aria-hidden="true" tabindex="-1"></a>  consteval bool is_integral_type(info type);</span>
+<span id="cb135-192"><a href="#cb135-192" aria-hidden="true" tabindex="-1"></a>  consteval bool is_floating_point_type(info type);</span>
+<span id="cb135-193"><a href="#cb135-193" aria-hidden="true" tabindex="-1"></a>  consteval bool is_array_type(info type);</span>
+<span id="cb135-194"><a href="#cb135-194" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_type(info type);</span>
+<span id="cb135-195"><a href="#cb135-195" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_type(info type);</span>
+<span id="cb135-196"><a href="#cb135-196" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_type(info type);</span>
+<span id="cb135-197"><a href="#cb135-197" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_object_pointer_type(info type);</span>
+<span id="cb135-198"><a href="#cb135-198" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_function_pointer_type(info type);</span>
+<span id="cb135-199"><a href="#cb135-199" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enum_type(info type);</span>
+<span id="cb135-200"><a href="#cb135-200" aria-hidden="true" tabindex="-1"></a>  consteval bool is_union_type(info type);</span>
+<span id="cb135-201"><a href="#cb135-201" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_type(info type);</span>
+<span id="cb135-202"><a href="#cb135-202" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_type(info type);</span>
+<span id="cb135-203"><a href="#cb135-203" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reflection_type(info type);</span>
+<span id="cb135-204"><a href="#cb135-204" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-205"><a href="#cb135-205" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.comp], composite type categories</span>
+<span id="cb135-206"><a href="#cb135-206" aria-hidden="true" tabindex="-1"></a>  consteval bool is_reference_type(info type);</span>
+<span id="cb135-207"><a href="#cb135-207" aria-hidden="true" tabindex="-1"></a>  consteval bool is_arithmetic_type(info type);</span>
+<span id="cb135-208"><a href="#cb135-208" aria-hidden="true" tabindex="-1"></a>  consteval bool is_fundamental_type(info type);</span>
+<span id="cb135-209"><a href="#cb135-209" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object_type(info type);</span>
+<span id="cb135-210"><a href="#cb135-210" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scalar_type(info type);</span>
+<span id="cb135-211"><a href="#cb135-211" aria-hidden="true" tabindex="-1"></a>  consteval bool is_compound_type(info type);</span>
+<span id="cb135-212"><a href="#cb135-212" aria-hidden="true" tabindex="-1"></a>  consteval bool is_member_pointer_type(info type);</span>
+<span id="cb135-213"><a href="#cb135-213" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-214"><a href="#cb135-214" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection unary.prop], type properties</span>
+<span id="cb135-215"><a href="#cb135-215" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const_type(info type);</span>
+<span id="cb135-216"><a href="#cb135-216" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile_type(info type);</span>
+<span id="cb135-217"><a href="#cb135-217" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivial_type(info type);</span>
+<span id="cb135-218"><a href="#cb135-218" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copyable_type(info type);</span>
+<span id="cb135-219"><a href="#cb135-219" aria-hidden="true" tabindex="-1"></a>  consteval bool is_standard_layout_type(info type);</span>
+<span id="cb135-220"><a href="#cb135-220" aria-hidden="true" tabindex="-1"></a>  consteval bool is_empty_type(info type);</span>
+<span id="cb135-221"><a href="#cb135-221" aria-hidden="true" tabindex="-1"></a>  consteval bool is_polymorphic_type(info type);</span>
+<span id="cb135-222"><a href="#cb135-222" aria-hidden="true" tabindex="-1"></a>  consteval bool is_abstract_type(info type);</span>
+<span id="cb135-223"><a href="#cb135-223" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final_type(info type);</span>
+<span id="cb135-224"><a href="#cb135-224" aria-hidden="true" tabindex="-1"></a>  consteval bool is_aggregate_type(info type);</span>
+<span id="cb135-225"><a href="#cb135-225" aria-hidden="true" tabindex="-1"></a>  consteval bool is_signed_type(info type);</span>
+<span id="cb135-226"><a href="#cb135-226" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unsigned_type(info type);</span>
+<span id="cb135-227"><a href="#cb135-227" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bounded_array_type(info type);</span>
+<span id="cb135-228"><a href="#cb135-228" aria-hidden="true" tabindex="-1"></a>  consteval bool is_unbounded_array_type(info type);</span>
+<span id="cb135-229"><a href="#cb135-229" aria-hidden="true" tabindex="-1"></a>  consteval bool is_scoped_enum_type(info type);</span>
+<span id="cb135-230"><a href="#cb135-230" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-231"><a href="#cb135-231" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-232"><a href="#cb135-232" aria-hidden="true" tabindex="-1"></a>    consteval bool is_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb135-233"><a href="#cb135-233" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructible_type(info type);</span>
+<span id="cb135-234"><a href="#cb135-234" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructible_type(info type);</span>
+<span id="cb135-235"><a href="#cb135-235" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructible_type(info type);</span>
+<span id="cb135-236"><a href="#cb135-236" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-237"><a href="#cb135-237" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignable_type(info type_dst, info type_src);</span>
+<span id="cb135-238"><a href="#cb135-238" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignable_type(info type);</span>
+<span id="cb135-239"><a href="#cb135-239" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignable_type(info type);</span>
+<span id="cb135-240"><a href="#cb135-240" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-241"><a href="#cb135-241" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_with_type(info type_dst, info type_src);</span>
+<span id="cb135-242"><a href="#cb135-242" aria-hidden="true" tabindex="-1"></a>  consteval bool is_swappable_type(info type);</span>
+<span id="cb135-243"><a href="#cb135-243" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-244"><a href="#cb135-244" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructible_type(info type);</span>
+<span id="cb135-245"><a href="#cb135-245" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-246"><a href="#cb135-246" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-247"><a href="#cb135-247" aria-hidden="true" tabindex="-1"></a>    consteval bool is_trivially_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb135-248"><a href="#cb135-248" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_default_constructible_type(info type);</span>
+<span id="cb135-249"><a href="#cb135-249" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_constructible_type(info type);</span>
+<span id="cb135-250"><a href="#cb135-250" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_constructible_type(info type);</span>
+<span id="cb135-251"><a href="#cb135-251" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-252"><a href="#cb135-252" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_assignable_type(info type_dst, info type_src);</span>
+<span id="cb135-253"><a href="#cb135-253" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_copy_assignable_type(info type);</span>
+<span id="cb135-254"><a href="#cb135-254" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_move_assignable_type(info type);</span>
+<span id="cb135-255"><a href="#cb135-255" aria-hidden="true" tabindex="-1"></a>  consteval bool is_trivially_destructible_type(info type);</span>
+<span id="cb135-256"><a href="#cb135-256" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-257"><a href="#cb135-257" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-258"><a href="#cb135-258" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_constructible_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb135-259"><a href="#cb135-259" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_default_constructible_type(info type);</span>
+<span id="cb135-260"><a href="#cb135-260" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_constructible_type(info type);</span>
+<span id="cb135-261"><a href="#cb135-261" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_constructible_type(info type);</span>
+<span id="cb135-262"><a href="#cb135-262" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-263"><a href="#cb135-263" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_assignable_type(info type_dst, info type_src);</span>
+<span id="cb135-264"><a href="#cb135-264" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_copy_assignable_type(info type);</span>
+<span id="cb135-265"><a href="#cb135-265" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_move_assignable_type(info type);</span>
+<span id="cb135-266"><a href="#cb135-266" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-267"><a href="#cb135-267" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_with_type(info type_dst, info type_src);</span>
+<span id="cb135-268"><a href="#cb135-268" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_swappable_type(info type);</span>
+<span id="cb135-269"><a href="#cb135-269" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-270"><a href="#cb135-270" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_destructible_type(info type);</span>
+<span id="cb135-271"><a href="#cb135-271" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-272"><a href="#cb135-272" aria-hidden="true" tabindex="-1"></a>  consteval bool is_implicit_lifetime_type(info type);</span>
+<span id="cb135-273"><a href="#cb135-273" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-274"><a href="#cb135-274" aria-hidden="true" tabindex="-1"></a>  consteval bool has_virtual_destructor(info type);</span>
+<span id="cb135-275"><a href="#cb135-275" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-276"><a href="#cb135-276" aria-hidden="true" tabindex="-1"></a>  consteval bool has_unique_object_representations(info type);</span>
+<span id="cb135-277"><a href="#cb135-277" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-278"><a href="#cb135-278" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_constructs_from_temporary(info type_dst, info type_src);</span>
+<span id="cb135-279"><a href="#cb135-279" aria-hidden="true" tabindex="-1"></a>  consteval bool reference_converts_from_temporary(info type_dst, info type_src);</span>
+<span id="cb135-280"><a href="#cb135-280" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-281"><a href="#cb135-281" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.unary.prop.query], type property queries</span>
+<span id="cb135-282"><a href="#cb135-282" aria-hidden="true" tabindex="-1"></a>  consteval size_t rank(info type);</span>
+<span id="cb135-283"><a href="#cb135-283" aria-hidden="true" tabindex="-1"></a>  consteval size_t extent(info type, unsigned i = 0);</span>
+<span id="cb135-284"><a href="#cb135-284" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-285"><a href="#cb135-285" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.rel], type relations</span>
+<span id="cb135-286"><a href="#cb135-286" aria-hidden="true" tabindex="-1"></a>  consteval bool is_same_type(info type1, info type2);</span>
+<span id="cb135-287"><a href="#cb135-287" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base_of_type(info type_base, info type_derived);</span>
+<span id="cb135-288"><a href="#cb135-288" aria-hidden="true" tabindex="-1"></a>  consteval bool is_convertible_type(info type_src, info type_dst);</span>
+<span id="cb135-289"><a href="#cb135-289" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nothrow_convertible_type(info type_src, info type_dst);</span>
+<span id="cb135-290"><a href="#cb135-290" aria-hidden="true" tabindex="-1"></a>  consteval bool is_layout_compatible_type(info type1, info type2);</span>
+<span id="cb135-291"><a href="#cb135-291" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pointer_interconvertible_base_of_type(info type_base, info type_derived);</span>
+<span id="cb135-292"><a href="#cb135-292" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-293"><a href="#cb135-293" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-294"><a href="#cb135-294" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb135-295"><a href="#cb135-295" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-296"><a href="#cb135-296" aria-hidden="true" tabindex="-1"></a>    consteval bool is_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb135-297"><a href="#cb135-297" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-298"><a href="#cb135-298" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-299"><a href="#cb135-299" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_type(info type, R&amp;&amp; type_args);</span>
+<span id="cb135-300"><a href="#cb135-300" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-301"><a href="#cb135-301" aria-hidden="true" tabindex="-1"></a>    consteval bool is_nothrow_invocable_r_type(info type_result, info type, R&amp;&amp; type_args);</span>
+<span id="cb135-302"><a href="#cb135-302" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-303"><a href="#cb135-303" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.cv], const-volatile modifications</span>
+<span id="cb135-304"><a href="#cb135-304" aria-hidden="true" tabindex="-1"></a>  consteval info remove_const(info type);</span>
+<span id="cb135-305"><a href="#cb135-305" aria-hidden="true" tabindex="-1"></a>  consteval info remove_volatile(info type);</span>
+<span id="cb135-306"><a href="#cb135-306" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cv(info type);</span>
+<span id="cb135-307"><a href="#cb135-307" aria-hidden="true" tabindex="-1"></a>  consteval info add_const(info type);</span>
+<span id="cb135-308"><a href="#cb135-308" aria-hidden="true" tabindex="-1"></a>  consteval info add_volatile(info type);</span>
+<span id="cb135-309"><a href="#cb135-309" aria-hidden="true" tabindex="-1"></a>  consteval info add_cv(info type);</span>
+<span id="cb135-310"><a href="#cb135-310" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-311"><a href="#cb135-311" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ref], reference modifications</span>
+<span id="cb135-312"><a href="#cb135-312" aria-hidden="true" tabindex="-1"></a>  consteval info remove_reference(info type);</span>
+<span id="cb135-313"><a href="#cb135-313" aria-hidden="true" tabindex="-1"></a>  consteval info add_lvalue_reference(info type);</span>
+<span id="cb135-314"><a href="#cb135-314" aria-hidden="true" tabindex="-1"></a>  consteval info add_rvalue_reference(info type);</span>
+<span id="cb135-315"><a href="#cb135-315" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-316"><a href="#cb135-316" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.sign], sign modifications</span>
+<span id="cb135-317"><a href="#cb135-317" aria-hidden="true" tabindex="-1"></a>  consteval info make_signed(info type);</span>
+<span id="cb135-318"><a href="#cb135-318" aria-hidden="true" tabindex="-1"></a>  consteval info make_unsigned(info type);</span>
+<span id="cb135-319"><a href="#cb135-319" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-320"><a href="#cb135-320" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.arr], array modifications</span>
+<span id="cb135-321"><a href="#cb135-321" aria-hidden="true" tabindex="-1"></a>  consteval info remove_extent(info type);</span>
+<span id="cb135-322"><a href="#cb135-322" aria-hidden="true" tabindex="-1"></a>  consteval info remove_all_extents(info type);</span>
+<span id="cb135-323"><a href="#cb135-323" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-324"><a href="#cb135-324" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.ptr], pointer modifications</span>
+<span id="cb135-325"><a href="#cb135-325" aria-hidden="true" tabindex="-1"></a>  consteval info remove_pointer(info type);</span>
+<span id="cb135-326"><a href="#cb135-326" aria-hidden="true" tabindex="-1"></a>  consteval info add_pointer(info type);</span>
+<span id="cb135-327"><a href="#cb135-327" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-328"><a href="#cb135-328" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.trans.other], other transformations</span>
+<span id="cb135-329"><a href="#cb135-329" aria-hidden="true" tabindex="-1"></a>  consteval info remove_cvref(info type);</span>
+<span id="cb135-330"><a href="#cb135-330" aria-hidden="true" tabindex="-1"></a>  consteval info decay(info type);</span>
+<span id="cb135-331"><a href="#cb135-331" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-332"><a href="#cb135-332" aria-hidden="true" tabindex="-1"></a>    consteval info common_type(R&amp;&amp; type_args);</span>
+<span id="cb135-333"><a href="#cb135-333" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-334"><a href="#cb135-334" aria-hidden="true" tabindex="-1"></a>    consteval info common_reference(R&amp;&amp; type_args);</span>
+<span id="cb135-335"><a href="#cb135-335" aria-hidden="true" tabindex="-1"></a>  consteval info type_underlying_type(info type);</span>
+<span id="cb135-336"><a href="#cb135-336" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
+<span id="cb135-337"><a href="#cb135-337" aria-hidden="true" tabindex="-1"></a>    `consteval info invoke_result(info type, R&amp;&amp; type_args);</span>
+<span id="cb135-338"><a href="#cb135-338" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_reference(info type);</span>
+<span id="cb135-339"><a href="#cb135-339" aria-hidden="true" tabindex="-1"></a>  consteval info unwrap_ref_decay(info type);</span>
+<span id="cb135-340"><a href="#cb135-340" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-341"><a href="#cb135-341" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.tuple.variant], tuple and variant queries</span>
+<span id="cb135-342"><a href="#cb135-342" aria-hidden="true" tabindex="-1"></a>  consteval size_t tuple_size(info type);</span>
+<span id="cb135-343"><a href="#cb135-343" aria-hidden="true" tabindex="-1"></a>  consteval info tuple_element(size_t index, info type);</span>
+<span id="cb135-344"><a href="#cb135-344" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb135-345"><a href="#cb135-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
+<span id="cb135-346"><a href="#cb135-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
+<span id="cb135-347"><a href="#cb135-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
@@ -7484,11 +7895,11 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb134"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
-<span id="cb134-2"><a href="#cb134-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
-<span id="cb134-3"><a href="#cb134-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb134-4"><a href="#cb134-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">1</a></span>
+<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> operators <span class="op">{</span></span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
+<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -7740,23 +8151,23 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tr>
 </tbody>
 </table>
-<div class="sourceCode" id="cb135"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">2</a></span>
+<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
 unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
-<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">4</a></span>
+<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -7770,34 +8181,34 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">1</a></span>
+<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -7806,23 +8217,23 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7831,43 +8242,43 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
-<div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">2</a></span>
+<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
 namespace alias, then the identifier introduced by the declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -7877,23 +8288,23 @@ then the <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> contents of <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
-<div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">5</a></span>
+<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
-<div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">7</a></span>
+<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -7908,59 +8319,59 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb141-3"><a href="#cb141-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">1</a></span>
+<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb143-3"><a href="#cb143-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
 class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">2</a></span>
+<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
 function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">3</a></span>
+<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
 is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">4</a></span>
+<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">5</a></span>
+<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 ([dcl.fct.def.default]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb146-2"><a href="#cb146-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">6</a></span>
+<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.def.default">[dcl.fct.def.default]</a></span>),
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">7</a></span>
+<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -7974,8 +8385,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">8</a></span>
+<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -7992,8 +8403,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">9</a></span>
+<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8002,16 +8413,16 @@ declaration of a non-static data member for which any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">10</a></span>
+<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">11</a></span>
+<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8019,38 +8430,38 @@ type (respectively), a const- or volatile-qualified function type
 (respectively), or an object, variable, non-static data member, or
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">12</a></span>
+<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><span class="kw">mutable</span></code>
 non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">13</a></span>
+<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
 rvalue-reference qualified function type (respectively), or a member
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb154-3"><a href="#cb154-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">14</a></span>
+<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
 that has static, thread, or automatic storage duration, respectively
 ([basic.stc]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb155-3"><a href="#cb155-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb155-4"><a href="#cb155-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">15</a></span>
+<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb157-3"><a href="#cb157-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb157-4"><a href="#cb157-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8058,14 +8469,14 @@ type, template, or namespace whose name has internal linkage, module
 linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">16</a></span>
+<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8074,14 +8485,14 @@ there is some point in the evaluation context from which the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">18</a></span>
+<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8089,29 +8500,29 @@ or enumeration type <code class="sourceCode cpp"><em>E</em></code>, such
 that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">20</a></span>
+<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">21</a></span>
+<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">22</a></span>
+<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">23</a></span>
+<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8121,31 +8532,31 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 <code class="sourceCode cpp"><em>typedef-name</em></code><span>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">24</a></span>
+<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb163-3"><a href="#cb163-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">25</a></span>
+<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb165-3"><a href="#cb165-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
 operator function, or literal operator, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-2"><a href="#cb164-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-3"><a href="#cb164-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-4"><a href="#cb164-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-5"><a href="#cb164-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-6"><a href="#cb164-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-7"><a href="#cb164-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-8"><a href="#cb164-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb164-9"><a href="#cb164-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">26</a></span>
+<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-3"><a href="#cb166-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-4"><a href="#cb166-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-5"><a href="#cb166-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-6"><a href="#cb166-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-7"><a href="#cb166-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-8"><a href="#cb166-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb166-9"><a href="#cb166-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8154,15 +8565,15 @@ constructor, a move constructor, an assignment operator, a copy
 assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">27</a></span>
+<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8170,16 +8581,16 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code> but
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-3"><a href="#cb166-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-4"><a href="#cb166-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-5"><a href="#cb166-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-6"><a href="#cb166-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-7"><a href="#cb166-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-8"><a href="#cb166-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb166-9"><a href="#cb166-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">29</a></span>
+<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-4"><a href="#cb168-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-5"><a href="#cb168-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-6"><a href="#cb168-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8187,56 +8598,56 @@ variable template, class template, alias template, conversion function
 template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">30</a></span>
+<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
 function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">31</a></span>
+<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">32</a></span>
+<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb170-5"><a href="#cb170-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">33</a></span>
+<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-3"><a href="#cb172-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-4"><a href="#cb172-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb172-5"><a href="#cb172-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
 namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">34</a></span>
+<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">35</a></span>
+<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8244,117 +8655,117 @@ entity, object, or value, then the type of what is represented by
 then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">37</a></span>
+<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
-<span id="cb174-2"><a href="#cb174-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
-<span id="cb174-3"><a href="#cb174-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb174-4"><a href="#cb174-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb174-5"><a href="#cb174-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
-<span id="cb174-6"><a href="#cb174-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
-<span id="cb174-7"><a href="#cb174-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
+<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
+<span id="cb176-2"><a href="#cb176-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
+<span id="cb176-3"><a href="#cb176-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb176-4"><a href="#cb176-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb176-5"><a href="#cb176-5" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// reflections compare different</span></span>
+<span id="cb176-6"><a href="#cb176-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
+<span id="cb176-7"><a href="#cb176-7" aria-hidden="true" tabindex="-1"></a>                                               <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">39</a></span>
+<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb176-2"><a href="#cb176-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb176-3"><a href="#cb176-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb176-4"><a href="#cb176-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb176-5"><a href="#cb176-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
-<span id="cb176-6"><a href="#cb176-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
-<span id="cb176-7"><a href="#cb176-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
-<span id="cb176-8"><a href="#cb176-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
+<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-4"><a href="#cb178-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^</span>x <span class="op">!=</span> <span class="op">^</span>y<span class="op">)</span>;                         <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb178-5"><a href="#cb178-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
+<span id="cb178-6"><a href="#cb178-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^</span>y<span class="op">))</span>;     <span class="co">// OK, both value_of(^x) and value_of(^y) represent</span></span>
+<span id="cb178-7"><a href="#cb178-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// the value 0</span></span>
+<span id="cb178-8"><a href="#cb178-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">41</a></span>
+<div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">43</a></span>
+<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
 alias <em>A</em>, then a reflection representing the entity named by
 <em>A</em>. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">44</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
-<div class="sourceCode" id="cb179"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
-<span id="cb179-2"><a href="#cb179-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
-<span id="cb179-3"><a href="#cb179-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
-<span id="cb179-4"><a href="#cb179-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
-<span id="cb179-5"><a href="#cb179-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
+<div class="sourceCode" id="cb181"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
+<span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
+<span id="cb181-3"><a href="#cb181-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^int) == ^int);</span>
+<span id="cb181-4"><a href="#cb181-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^X) == ^int);</span>
+<span id="cb181-5"><a href="#cb181-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^Y) == ^int);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">45</a></span>
+<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
-<div class="sourceCode" id="cb181"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
-<span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
-<span id="cb181-3"><a href="#cb181-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb181-4"><a href="#cb181-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
-<span id="cb181-5"><a href="#cb181-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
-<span id="cb181-6"><a href="#cb181-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb181-7"><a href="#cb181-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
-<span id="cb181-8"><a href="#cb181-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
+<div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
+<span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
+<span id="cb183-3"><a href="#cb183-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb183-4"><a href="#cb183-4" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^Pair&lt;int&gt;) == ^Pair);</span>
+<span id="cb183-5"><a href="#cb183-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^Pair&lt;int&gt;).size() == 2);</span>
+<span id="cb183-6"><a href="#cb183-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb183-7"><a href="#cb183-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^PairPtr&lt;int&gt;) == ^PairPtr);</span>
+<span id="cb183-8"><a href="#cb183-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^PairPtr&lt;int&gt;).size() == 1);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -8365,12 +8776,12 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
+<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8389,7 +8800,7 @@ template, alias template, or concept,</li>
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8400,11 +8811,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8417,15 +8828,15 @@ declared within the member-specification of
 unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">6</a></span>
+<div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8434,93 +8845,93 @@ of all the direct base class specifiers, if any, of
 indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
-<div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">9</a></span>
+<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">12</a></span>
+<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">15</a></span>
+<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
-<div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">17</a></span>
+<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">20</a></span>
+<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">23</a></span>
+<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
-<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">26</a></span>
+<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -8534,33 +8945,33 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">1</a></span>
+<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
-<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">2</a></span>
+<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
-<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">5</a></span>
+<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8569,7 +8980,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -8581,8 +8992,8 @@ Otherwise, <code class="sourceCode cpp">size_of<span class="op">(</span>type_of<
 corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">7</a></span>
+<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -8591,28 +9002,28 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
 data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">9</a></span>
+<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8621,7 +9032,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -8634,32 +9045,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
-<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">3</a></span>
+<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb197-2"><a href="#cb197-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">6</a></span>
+<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -8667,7 +9078,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -8675,7 +9086,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -8683,52 +9094,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">8</a></span>
+<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">11</a></span>
+<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -8739,43 +9150,43 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
-<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
-<span id="cb200-3"><a href="#cb200-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb200-4"><a href="#cb200-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb200-5"><a href="#cb200-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">1</a></span>
+<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
+<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
+<span id="cb202-3"><a href="#cb202-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb202-4"><a href="#cb202-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb202-5"><a href="#cb202-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
-<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">5</a></span>
+<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -8785,72 +9196,72 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">1</a></span>
+<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
 value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">4</a></span>
+<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">7</a></span>
+<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -8863,18 +9274,18 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
-<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">2</a></span>
+<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">3</a></span>
+<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -8889,77 +9300,77 @@ ordinary string literal (or
 <code class="sourceCode cpp">string</code>, etc) or a UTF-8 string
 literal (or <code class="sourceCode cpp">u8string_view</code>,
 <code class="sourceCode cpp">u8string</code>, etc) equally well.</p>
-<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
-<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
+<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
 <span> — <em>end note</em> ]</span>
 </div>
-<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">1</a></span>
+<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -8968,16 +9379,16 @@ Certain other functions in
 <code class="sourceCode cpp">identifier_of</code>) can also be used to
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
-<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">4</a></span>
+<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
 declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">5</a></span>
+<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -8985,7 +9396,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -9002,18 +9413,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -9027,7 +9438,7 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9035,30 +9446,30 @@ be a sequence of reflections and
 be a sequence of
 <code class="sourceCode cpp">data_member_options_t</code> values such
 that</p>
-<div class="sourceCode" id="cb212"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
+<div class="sourceCode" id="cb214"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -9071,29 +9482,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9105,18 +9516,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9126,10 +9537,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9150,44 +9561,44 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.unary.cat]</a></span>.</p>
-<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-3"><a href="#cb213-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-4"><a href="#cb213-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-5"><a href="#cb213-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-6"><a href="#cb213-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-7"><a href="#cb213-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-8"><a href="#cb213-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-9"><a href="#cb213-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-10"><a href="#cb213-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-11"><a href="#cb213-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-12"><a href="#cb213-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-13"><a href="#cb213-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-14"><a href="#cb213-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb213-15"><a href="#cb213-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">2</a></span></p>
+<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-3"><a href="#cb215-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-4"><a href="#cb215-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-5"><a href="#cb215-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-6"><a href="#cb215-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-7"><a href="#cb215-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-8"><a href="#cb215-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-9"><a href="#cb215-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-10"><a href="#cb215-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-11"><a href="#cb215-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-12"><a href="#cb215-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-13"><a href="#cb215-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-14"><a href="#cb215-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb215-15"><a href="#cb215-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb214"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
-<span id="cb214-3"><a href="#cb214-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
-<span id="cb214-4"><a href="#cb214-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
-<span id="cb214-5"><a href="#cb214-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb214-6"><a href="#cb214-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
-<span id="cb214-7"><a href="#cb214-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
-<span id="cb214-8"><a href="#cb214-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
-<span id="cb214-9"><a href="#cb214-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
-<span id="cb214-10"><a href="#cb214-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
-<span id="cb214-11"><a href="#cb214-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
-<span id="cb214-12"><a href="#cb214-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb214-13"><a href="#cb214-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb216"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
+<span id="cb216-3"><a href="#cb216-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
+<span id="cb216-4"><a href="#cb216-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^is_void_v, {type}));</span>
+<span id="cb216-5"><a href="#cb216-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb216-6"><a href="#cb216-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
+<span id="cb216-7"><a href="#cb216-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
+<span id="cb216-8"><a href="#cb216-8" aria-hidden="true" tabindex="-1"></a>    return type == ^void</span>
+<span id="cb216-9"><a href="#cb216-9" aria-hidden="true" tabindex="-1"></a>        || type == ^const void</span>
+<span id="cb216-10"><a href="#cb216-10" aria-hidden="true" tabindex="-1"></a>        || type == ^volatile void</span>
+<span id="cb216-11"><a href="#cb216-11" aria-hidden="true" tabindex="-1"></a>        || type == ^const volatile void;</span>
+<span id="cb216-12"><a href="#cb216-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb216-13"><a href="#cb216-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -9198,20 +9609,20 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp">std<span class="op">::</span><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.3 <a href="https://wg21.link/meta.unary.comp">[meta.unary.comp]</a></span>.</p>
-<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb215-3"><a href="#cb215-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb215-4"><a href="#cb215-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb215-5"><a href="#cb215-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb215-6"><a href="#cb215-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb215-7"><a href="#cb215-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb217-3"><a href="#cb217-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb217-4"><a href="#cb217-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb217-5"><a href="#cb217-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb217-6"><a href="#cb217-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb217-7"><a href="#cb217-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9220,7 +9631,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9230,7 +9641,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9241,7 +9652,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9253,71 +9664,71 @@ each function template <code class="sourceCode cpp">std<span class="op">::</span
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-TRAIT</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-3"><a href="#cb216-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivial_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-4"><a href="#cb216-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-5"><a href="#cb216-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-6"><a href="#cb216-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-7"><a href="#cb216-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-8"><a href="#cb216-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-9"><a href="#cb216-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-10"><a href="#cb216-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-11"><a href="#cb216-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-12"><a href="#cb216-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-13"><a href="#cb216-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-14"><a href="#cb216-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-15"><a href="#cb216-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-16"><a href="#cb216-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-17"><a href="#cb216-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb216-18"><a href="#cb216-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb216-19"><a href="#cb216-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-20"><a href="#cb216-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-21"><a href="#cb216-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-22"><a href="#cb216-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-23"><a href="#cb216-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb216-24"><a href="#cb216-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-25"><a href="#cb216-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-26"><a href="#cb216-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-27"><a href="#cb216-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb216-28"><a href="#cb216-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-29"><a href="#cb216-29" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-30"><a href="#cb216-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-31"><a href="#cb216-31" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-32"><a href="#cb216-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb216-33"><a href="#cb216-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb216-34"><a href="#cb216-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-35"><a href="#cb216-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-36"><a href="#cb216-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-37"><a href="#cb216-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-38"><a href="#cb216-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb216-39"><a href="#cb216-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-40"><a href="#cb216-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-41"><a href="#cb216-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-42"><a href="#cb216-42" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-43"><a href="#cb216-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb216-44"><a href="#cb216-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb216-45"><a href="#cb216-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-46"><a href="#cb216-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-47"><a href="#cb216-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-48"><a href="#cb216-48" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-49"><a href="#cb216-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb216-50"><a href="#cb216-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-51"><a href="#cb216-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-52"><a href="#cb216-52" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-53"><a href="#cb216-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb216-54"><a href="#cb216-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-55"><a href="#cb216-55" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-56"><a href="#cb216-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-57"><a href="#cb216-57" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-58"><a href="#cb216-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-59"><a href="#cb216-59" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-60"><a href="#cb216-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-61"><a href="#cb216-61" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-62"><a href="#cb216-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb216-63"><a href="#cb216-63" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb216-64"><a href="#cb216-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb216-65"><a href="#cb216-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivial_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-4"><a href="#cb218-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-5"><a href="#cb218-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-6"><a href="#cb218-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-9"><a href="#cb218-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-10"><a href="#cb218-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-11"><a href="#cb218-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-12"><a href="#cb218-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-13"><a href="#cb218-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-14"><a href="#cb218-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-15"><a href="#cb218-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-16"><a href="#cb218-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-17"><a href="#cb218-17" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb218-18"><a href="#cb218-18" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb218-19"><a href="#cb218-19" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-20"><a href="#cb218-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-21"><a href="#cb218-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-22"><a href="#cb218-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-23"><a href="#cb218-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb218-24"><a href="#cb218-24" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-25"><a href="#cb218-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-26"><a href="#cb218-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-27"><a href="#cb218-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb218-28"><a href="#cb218-28" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-29"><a href="#cb218-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-30"><a href="#cb218-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-31"><a href="#cb218-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-32"><a href="#cb218-32" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb218-33"><a href="#cb218-33" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb218-34"><a href="#cb218-34" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-35"><a href="#cb218-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-36"><a href="#cb218-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-37"><a href="#cb218-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-38"><a href="#cb218-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb218-39"><a href="#cb218-39" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-40"><a href="#cb218-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-41"><a href="#cb218-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-42"><a href="#cb218-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-43"><a href="#cb218-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb218-44"><a href="#cb218-44" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb218-45"><a href="#cb218-45" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-46"><a href="#cb218-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-47"><a href="#cb218-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-48"><a href="#cb218-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-49"><a href="#cb218-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb218-50"><a href="#cb218-50" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-51"><a href="#cb218-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-52"><a href="#cb218-52" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-53"><a href="#cb218-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb218-54"><a href="#cb218-54" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-55"><a href="#cb218-55" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-56"><a href="#cb218-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-57"><a href="#cb218-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-58"><a href="#cb218-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-59"><a href="#cb218-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-60"><a href="#cb218-60" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-61"><a href="#cb218-61" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-62"><a href="#cb218-62" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb218-63"><a href="#cb218-63" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb218-64"><a href="#cb218-64" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb218-65"><a href="#cb218-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9326,13 +9737,13 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">1</a></span>
+<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
-<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">2</a></span>
+<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9344,10 +9755,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9356,7 +9767,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9368,7 +9779,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9381,23 +9792,23 @@ each ternary function template <code class="sourceCode cpp">std<span class="op">
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL-R</em><span class="op">(^</span>R, <span class="op">^</span>T, r<span class="op">)</span>_type</code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL-R</em>_v<span class="op">&lt;</span>R, T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb219-10"><a href="#cb219-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb219-11"><a href="#cb219-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb219-12"><a href="#cb219-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb219-13"><a href="#cb219-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb219-14"><a href="#cb219-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb219-15"><a href="#cb219-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb219-16"><a href="#cb219-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">5</a></span>
+<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb221-4"><a href="#cb221-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb221-5"><a href="#cb221-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb221-6"><a href="#cb221-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-8"><a href="#cb221-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-9"><a href="#cb221-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-10"><a href="#cb221-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-11"><a href="#cb221-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-12"><a href="#cb221-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-13"><a href="#cb221-13" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-14"><a href="#cb221-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb221-15"><a href="#cb221-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9419,7 +9830,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9431,19 +9842,19 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
-<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-3"><a href="#cb222-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-4"><a href="#cb222-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-5"><a href="#cb222-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb222-6"><a href="#cb222-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9452,16 +9863,16 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
-<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb223-3"><a href="#cb223-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9470,15 +9881,15 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
-<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9487,15 +9898,15 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
-<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9504,15 +9915,15 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.6 <a href="https://wg21.link/meta.trans.ptr">[meta.trans.ptr]</a></span>.</p>
-<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9531,7 +9942,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9539,7 +9950,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9549,7 +9960,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9560,29 +9971,29 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>invoke_result<span class="op">(^</span>T, r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span>invoke_result_t<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 (<span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>).</p>
-<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb225-4"><a href="#cb225-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb225-5"><a href="#cb225-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb225-6"><a href="#cb225-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb225-7"><a href="#cb225-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-8"><a href="#cb225-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb225-9"><a href="#cb225-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb225-10"><a href="#cb225-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb225-11"><a href="#cb225-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">4</a></span></p>
+<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-3"><a href="#cb227-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb227-4"><a href="#cb227-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb227-5"><a href="#cb227-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb227-6"><a href="#cb227-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb227-7"><a href="#cb227-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-8"><a href="#cb227-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb227-9"><a href="#cb227-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb227-10"><a href="#cb227-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb227-11"><a href="#cb227-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
-<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb226-3"><a href="#cb226-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb226-4"><a href="#cb226-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb226-5"><a href="#cb226-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb226-6"><a href="#cb226-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb226-7"><a href="#cb226-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
-<span id="cb226-8"><a href="#cb226-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb226-9"><a href="#cb226-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
+<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb228-3"><a href="#cb228-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
+<span id="cb228-4"><a href="#cb228-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb228-5"><a href="#cb228-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb228-6"><a href="#cb228-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb228-7"><a href="#cb228-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
+<span id="cb228-8"><a href="#cb228-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb228-9"><a href="#cb228-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -9593,7 +10004,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -9601,7 +10012,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -9610,11 +10021,11 @@ defined in this clause with the signature <code class="sourceCode cpp">info<span
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^</span>T<span class="op">)</span></code>
 returns a reflection representing the type <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb227-3"><a href="#cb227-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb227-4"><a href="#cb227-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb227-5"><a href="#cb227-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb229-3"><a href="#cb229-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-4"><a href="#cb229-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb229-5"><a href="#cb229-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9625,7 +10036,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -9633,27 +10044,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -9671,10 +10082,10 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb228"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
-<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
-<span id="cb228-3"><a href="#cb228-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
-<span id="cb228-4"><a href="#cb228-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
+<div class="sourceCode" id="cb230"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
+<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
+<span id="cb230-3"><a href="#cb230-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
+<span id="cb230-4"><a href="#cb230-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2024XXL</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -9682,7 +10093,7 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb229"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb231"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2024XXL // also in &lt;meta&gt;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-11-09" />
+  <meta name="dcterms.date" content="2024-11-12" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-11-09</td>
+    <td>2024-11-12</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -767,8 +767,6 @@ Linkage<span></span></a></li>
 <li><a href="#basic.fundamental-fundamental-types" id="toc-basic.fundamental-fundamental-types"><span>6.8.2
 <span>[basic.fundamental]</span></span> Fundamental
 types<span></span></a></li>
-<li><a href="#conv.ptr-pointer-conversions" id="toc-conv.ptr-pointer-conversions"><span>7.3.12
-<span>[conv.ptr]</span></span> Pointer conversions<span></span></a></li>
 <li><a href="#expr.prim-primary-expressions" id="toc-expr.prim-primary-expressions"><span>7.5
 <span>[expr.prim]</span></span> Primary
 expressions<span></span></a></li>
@@ -804,8 +802,6 @@ specifier<span></span></a></li>
 <li><a href="#dcl.type.simple-simple-type-specifiers" id="toc-dcl.type.simple-simple-type-specifiers"><span>9.2.9.3
 <span>[dcl.type.simple]</span></span> Simple type
 specifiers<span></span></a></li>
-<li><a href="#dcl.type.splice-type-splicing" id="toc-dcl.type.splice-type-splicing">9.2.9* [dcl.type.splice] Type
-splicing<span></span></a></li>
 <li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.4.1
 <span>[dcl.init.general]</span></span> Initializers
 (General)<span></span></a></li>
@@ -852,9 +848,6 @@ specializations<span></span></a></li>
 <li><a href="#temp.arg.type-template-type-arguments" id="toc-temp.arg.type-template-type-arguments"><span>13.4.2
 <span>[temp.arg.type]</span></span> Template type
 arguments<span></span></a></li>
-<li><a href="#temp.arg.nontype-template-non-type-arguments" id="toc-temp.arg.nontype-template-non-type-arguments"><span>13.4.3
-<span>[temp.arg.nontype]</span></span> Template non-type
-arguments<span></span></a></li>
 <li><a href="#temp.arg.template-template-template-arguments" id="toc-temp.arg.template-template-template-arguments"><span>13.4.4
 <span>[temp.arg.template]</span></span> Template template
 arguments<span></span></a></li>
@@ -865,9 +858,6 @@ arguments<span></span></a></li>
 guides<span></span></a></li>
 <li><a href="#temp.alias-alias-templates" id="toc-temp.alias-alias-templates"><span>13.7.8
 <span>[temp.alias]</span></span> Alias templates<span></span></a></li>
-<li><a href="#temp.concept-concept-definitions" id="toc-temp.concept-concept-definitions"><span>13.7.9
-<span>[temp.concept]</span></span> Concept
-definitions<span></span></a></li>
 <li><a href="#temp.res.general-general" id="toc-temp.res.general-general"><span>13.8.1
 <span>[temp.res.general]</span></span> General<span></span></a></li>
 <li><a href="#temp.dep.expr-type-dependent-expressions" id="toc-temp.dep.expr-type-dependent-expressions"><span>13.8.3.3
@@ -991,6 +981,9 @@ allow for future use with negative offsets</li>
 <li>renamed the type traits from all being named
 <code class="sourceCode cpp">type_meow</code> to a more bespoke naming
 scheme.</li>
+<li>rewrote core wording for
+<code class="sourceCode cpp"><em>consteval-only type</em></code> and for
+all splicers.</li>
 </ul>
 <p>Since <span class="citation" data-cites="P2996R6">[<a href="https://wg21.link/p2996r6" role="doc-biblioref">P2996R6</a>]</span>:</p>
 <ul>
@@ -2474,25 +2467,27 @@ Proposed Features<a href="#proposed-features" class="self-link"></a></h1>
 <p>The reflection operator produces a reflection value from a
 grammatical construct (its operand):</p>
 <blockquote>
-<div class="line-block"><em>unary-expression</em>:<br />
+<div class="line-block"><code class="sourceCode cpp"><em>unary-expression</em></code>:<br />
       …<br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
 <code class="sourceCode cpp"><span class="op">::</span></code><br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
-<em>namespace-name</em><br />
+<code class="sourceCode cpp"><em>namespace-name</em></code><br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
-<em>type-id</em><br />
+<code class="sourceCode cpp"><em>type-id</em></code><br />
       <code class="sourceCode cpp"><span class="op">^</span></code>
-<em>id-expression</em></div>
+<code class="sourceCode cpp"><em>id-expression</em></code></div>
 </blockquote>
 <p>The expression
 <code class="sourceCode cpp"><span class="op">^::</span></code>
 evaluates to a reflection of the global namespace. When the operand is a
-<em>namespace-name</em> or <em>type-id</em>, the resulting value is a
-reflection of the designated namespace or type.</p>
-<p>When the operand is an <em>id-expression</em>, the resulting value is
-a reflection of the designated entity found by lookup. This might be any
-of:</p>
+<code class="sourceCode cpp"><em>namespace-name</em></code> or
+<code class="sourceCode cpp"><em>type-id</em></code>, the resulting
+value is a reflection of the designated namespace or type.</p>
+<p>When the operand is an
+<code class="sourceCode cpp"><em>id-expression</em></code>, the
+resulting value is a reflection of the designated entity found by
+lookup. This might be any of:</p>
 <ul>
 <li>a variable, static data member, or structured binding</li>
 <li>a function or member function</li>
@@ -2504,15 +2499,15 @@ of:</p>
 context, a failure to substitute the operand of a reflection operator
 construct causes that construct to not evaluate to constant.</p>
 <p>Earlier revisions of this paper allowed for taking the reflection of
-any <em>cast-expression</em> that could be evaluated as a constant
-expression, as we believed that a constant expression could be
-internally “represented” by just capturing the value to which it
-evaluated. However, the possibility of side effects from constant
-evaluation (introduced by this very paper) renders this approach
-infeasible: even a constant expression would have to be evaluated every
-time it’s spliced. It was ultimately decided to defer all support for
-expression reflection, but we intend to introduce it through a future
-paper using the syntax <code class="sourceCode cpp"><span class="op">^(</span>expr<span class="op">)</span></code>.</p>
+any <code class="sourceCode cpp"><em>cast-expression</em></code> that
+could be evaluated as a constant expression, as we believed that a
+constant expression could be internally “represented” by just capturing
+the value to which it evaluated. However, the possibility of side
+effects from constant evaluation (introduced by this very paper) renders
+this approach infeasible: even a constant expression would have to be
+evaluated every time it’s spliced. It was ultimately decided to defer
+all support for expression reflection, but we intend to introduce it
+through a future paper using the syntax <code class="sourceCode cpp"><span class="op">^(</span>expr<span class="op">)</span></code>.</p>
 <p>This paper does, however, support reflections of <em>values</em> and
 of <em>objects</em> (including subobjects). Such reflections arise
 naturally when iterating over template arguments.</p>
@@ -4964,10 +4959,12 @@ A function is named by an expression or conversion if it is the selected
 member of an overload set ([basic.lookup], [over.match], [over.over]) in
 an overload resolution performed as part of forming that expression or
 conversion, <span class="addu">or if it is designated by a
-<em>splice-expression</em> ([expr.prim.splice]),</span> unless it is a
-pure virtual function and either the expression is not an
-<em>id-expression</em> naming the function with an explicitly qualified
-name or the expression forms a pointer to member ([expr.unary.op]).</li>
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+([expr.prim.splice]),</span> unless it is a pure virtual function and
+either the expression is not an
+<code class="sourceCode cpp"><em>id-expression</em></code> naming the
+function with an explicitly qualified name or the expression forms a
+pointer to member ([expr.unary.op]).</li>
 </ul>
 </blockquote>
 </div>
@@ -4978,7 +4975,8 @@ variables:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_8" id="pnum_8">5</a></span>
 A variable is named by an expression if the expression is an
-<em>id-expression</em> <span class="addu">or <em>splice-expression</em>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code>
 ([expr.prim.splice])</span> that designates it.</li>
 </ul>
 </blockquote>
@@ -4990,8 +4988,9 @@ A variable is named by an expression if the expression is an
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_9" id="pnum_9">6</a></span>
 A structured binding is odr-used if it appears as a
 potentially-evaluated expression<span class="addu">, or if a reflection
-of it is the operand of a potentially-evaluated
-<em>splice-expression</em> ([expr.prim.splice])</span>.</li>
+representing it is the operand of a potentially-evaluated
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+([expr.prim.splice])</span>.</li>
 </ul>
 </blockquote>
 </div>
@@ -5039,13 +5038,8 @@ If <code class="sourceCode cpp">T</code> is a class type …</li>
 </div>
 <h3 class="unnumbered" id="basic.lookup.qual.general-general"><span>6.5.5.1 <a href="https://wg21.link/basic.lookup.qual.general">[basic.lookup.qual.general]</a></span>
 General<a href="#basic.lookup.qual.general-general" class="self-link"></a></h3>
-<p>FIXME. Have to handle splices in here, because they’re not actually
-“component names”. Now
-<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>
-is only a namespace too.</p>
-<p>Extend <span>6.5.5.1 <a href="https://wg21.link/basic.lookup.qual.general">[basic.lookup.qual.general]</a></span>/1-2
-to cover
-<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>:</p>
+<p>Extend paragraph 1 to cover
+<code class="sourceCode cpp"><em>splice-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">1</a></span>
@@ -5053,27 +5047,15 @@ Lookup of an <em>identifier</em> followed by a
 <code class="sourceCode cpp"><span class="op">::</span></code> scope
 resolution operator considers only namespaces, types, and templates
 whose specializations are types. If a name,
-<code class="sourceCode cpp"><em>template-id</em></code>, <span class="rm" style="color: #bf0303"><del>or</del></span>
-<code class="sourceCode cpp"><em>computed-type-specifier</em></code><span class="addu">, or
-<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code></span>
+<code class="sourceCode cpp"><em>template-id</em></code>, <span class="addu"><code class="sourceCode cpp"><em>splice-specifier</em></code>,</span>
+or <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
 is followed by a
 <code class="sourceCode cpp"><span class="op">::</span></code>, it shall
-designate a namespace, class, enumeration, or dependent type, and the
+designate a namespace, class, enumeration, <span class="addu">dependent
+<code class="sourceCode cpp"><em>splice-specifier</em></code>,</span> or
+dependent type, and the
 <code class="sourceCode cpp"><span class="op">::</span></code> is never
 interpreted as a complete nested-name-specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">2</a></span>
-A member-qualified name is the (unique) component name
-([expr.prim.id.unqual]), if any, of</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(2.1)</a></span>
-an <em>unqualified-id</em> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(2.2)</a></span>
-a <code class="sourceCode cpp"><em>nested-name-specifier</em></code> of
-the form <code class="sourceCode cpp"><em>type-name</em> <span class="op">::</span></code>
-<span class="rm" style="color: #bf0303"><del>or</del></span><span class="addu">,</span> <code class="sourceCode cpp"><em>namespace-name</em> <span class="op">::</span></code><span class="addu">, or <code class="sourceCode cpp"><em>splice-namespace-specifier</em> <span class="op">::</span></code></span></li>
-</ul>
-<p>in the <em>id-expression</em> of a class member access expression
-([expr.ref]). […]</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="basic.link-program-and-linkage"><span>6.6 <a href="https://wg21.link/basic.link">[basic.link]</a></span> Program and
@@ -5081,30 +5063,30 @@ Linkage<a href="#basic.link-program-and-linkage" class="self-link"></a></h3>
 <p>Add a bullet to paragraph 13:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">13</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>names</em> an entity <code class="sourceCode cpp"><em>E</em></code>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(13.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a
-<em>lambda-expression</em> whose closure type is
-<code class="sourceCode cpp"><em>E</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">(13.1+)</a></span>
+<code class="sourceCode cpp"><em>lambda-expression</em></code> whose
+closure type is <code class="sourceCode cpp"><em>E</em></code>,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(13.1+)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code>
 contains a reflection that represents either
 <code class="sourceCode cpp"><em>E</em></code> or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> or
 <code class="sourceCode cpp"><em>namespace-alias</em></code> that
 denotes <code class="sourceCode cpp"><em>E</em></code>,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">(13.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not a function or
 function template and <code class="sourceCode cpp"><em>D</em></code>
 contains an <em>id-expression</em>, <em>type-specifier</em>,
 <em>nested-name-specifier</em>, <em>template-name</em>, or
 <em>concept-name denoting</em>
 <code class="sourceCode cpp"><em>E</em></code>, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(13.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">(13.3)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a function or function
 template and <code class="sourceCode cpp"><em>D</em></code> contains an
 expression that names <code class="sourceCode cpp"><em>E</em></code>
@@ -5122,30 +5104,32 @@ also TU-local ]</span></p>
 include reflections:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">16</a></span>
 A value or object is <em>TU-local</em> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(16.1)</a></span>
 it is, or is a pointer to, a TU-local function or the object associated
 with a TU-local variable, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1a)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(16.1a)</a></span>
 it is a value or object of a TU-local type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.1b)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(16.1b)</a></span>
 it is a reflection representing
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">(16.1b.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(16.1b.1)</a></span>
 a TU-local value or object, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">(16.1b.2)</a></span>
-a <code class="sourceCode cpp"><em>typedef-name</em></code>, namespace
-alias, or base specifier introduced by an exposure, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">(16.1b.2)</a></span>
+a <code class="sourceCode cpp"><em>typedef-name</em></code>,
+<code class="sourceCode cpp"><em>namespace-alias</em></code>, or
+<code class="sourceCode cpp"><em>base-specifier</em></code> introduced
+by an exposure, or</li>
 </ul></li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(16.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(16.2)</a></span>
 it is an object of class or array type and any of its subobjects or any
 of the objects or functions to which its non-static data members of
 reference type refer is TU-local and is usable in constant
@@ -5159,7 +5143,7 @@ General<a href="#basic.types.general-general" class="self-link"></a></h3>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">9</a></span>
 Arithmetic types (6.8.2), enumeration types, pointer types,
 pointer-to-member types (6.8.4), <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -5172,39 +5156,39 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">12</a></span>
 A <em>consteval-only type</em> is one of the following:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(12.1)</a></span>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(12.2)</a></span>
 a pointer or reference to a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.3)</a></span>
-an (possibly multi-dimensional) array of a consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">(12.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(12.3)</a></span>
+a (possibly multi-dimensional) array of a consteval-only type,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(12.4)</a></span>
 a class type with a base class or non-static data member of
 consteval-only type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(12.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(12.5)</a></span>
 a function type with a return type or parameter type of consteval-only
 type, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(12.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(12.6)</a></span>
 a pointer-to-member type to a class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">M</code> where either
 <code class="sourceCode cpp">C</code> or
 <code class="sourceCode cpp">M</code> is a consteval-only type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">13</a></span>
-Every object of consteval-only type shall either be</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">13</a></span>
+Every object of consteval-only type shall be</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(13.1)</a></span>
 the object associated with a constexpr variable or a subobject
 thereof,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(13.2)</a></span>
 a template parameter object (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>) or a
 subobject thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">(13.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(13.3)</a></span>
 an object whose lifetime begins and ends during the evaluation of a
 manifestly constant-evaluated expression.</li>
 </ul>
@@ -5218,7 +5202,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">17 - 1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">17 - 1</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
@@ -5229,70 +5213,22 @@ reflection</em>; every other reflection is a representation of</p>
 <li>a structured binding,</li>
 <li>a function,</li>
 <li>an enumerator,</li>
-<li>a type,</li>
-<li>a <code class="sourceCode cpp"><em>typedef-name</em></code>,</li>
+<li>a type or
+<code class="sourceCode cpp"><em>typedef-name</em></code>,</li>
 <li>a class member,</li>
 <li>a bit-field,</li>
 <li>a primary class template, function template, primary variable
 template, alias template, or concept,</li>
-<li>a namespace or namespace alias,</li>
-<li>a base class specifier, or</li>
+<li>a namespace or
+<code class="sourceCode cpp"><em>namespace-alias</em></code>,</li>
+<li>a <code class="sourceCode cpp"><em>base-specifier</em></code>,
+or</li>
 <li>a description of a declaration of a non-static data member.</li>
 </ul>
 <p>An expression convertible to a reflection is said to
-<em>represent</em> the corresponding entity, alias, object, value, base
-class specifier, or description of a declaration of a non-static data
-member. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
+<em>represent</em> the corresponding construct. <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>
 shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span><span class="dt">void</span><span class="op">*)</span></code>.</p>
 </div>
-</blockquote>
-</div>
-<h3 class="unnumbered" id="conv.ptr-pointer-conversions"><span>7.3.12 <a href="https://wg21.link/conv.ptr">[conv.ptr]</a></span> Pointer
-conversions<a href="#conv.ptr-pointer-conversions" class="self-link"></a></h3>
-<p>Expand paragraph 2 to disallow conversions to <code class="sourceCode cpp"><span class="dt">void</span> <span class="op">*</span></code>
-from pointers of consteval-only types.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">2</a></span>
-A prvalue of type “pointer to
-<code class="sourceCode cpp"><em>cv</em> T</code>”, where
-<code class="sourceCode cpp">T</code> is an object type, can be
-converted to a prvalue of type “pointer to
-<code class="sourceCode cpp"><em>cv</em> <span class="dt">void</span></code>”.
-The pointer value ([basic.compound]) is unchanged by this conversion.
-<span class="addu">If <code class="sourceCode cpp">T</code> is a
-consteval-only type ([basic.types.general]), a program that necessitates
-this conversion is ill-formed.</span></p>
-</blockquote>
-</div>
-<p>Expand paragraph 3 to also disallow conversions from pointers of
-consteval-only type to pointers to base classes that are not of
-consteval-only type.</p>
-<div class="std">
-<blockquote>
-<p>A prvalue <code class="sourceCode cpp">v</code> of type “pointer to
-<code class="sourceCode cpp"><em>cv</em> D</code>”, where
-<code class="sourceCode cpp">D</code> is a complete class type, can be
-converted to a prvalue of type “pointer to
-<code class="sourceCode cpp"><em>cv</em> B</code>”, where
-<code class="sourceCode cpp">B</code> is a base class ([class.derived])
-of <code class="sourceCode cpp">D</code>. If
-<code class="sourceCode cpp">B</code> is an inaccessible
-([class.access]) or ambiguous ([class.member.lookup]) base class of
-<code class="sourceCode cpp">D</code>, <span class="addu">or if
-<code class="sourceCode cpp">D</code> is of consteval-only type
-([basic.types.general]) and <code class="sourceCode cpp">B</code> is
-not,</span> a program that necessitates this conversion is ill-formed.
-If <code class="sourceCode cpp">v</code> is a null pointer value, the
-result is a null pointer value. Otherwise, if
-<code class="sourceCode cpp">B</code> is a virtual base class of
-<code class="sourceCode cpp">D</code> and
-<code class="sourceCode cpp">v</code> does not point to an object whose
-type is similar ([conv.qual]) to <code class="sourceCode cpp">D</code>
-and that is within its lifetime or within its period of construction or
-destruction ([class.dtor]), the behavior is undefined. Otherwise, the
-result is a pointer to the base class subobject of the derived class
-object.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="expr.prim-primary-expressions"><span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> Primary
@@ -5318,28 +5254,83 @@ as follows:</p>
 </div>
 <h3 class="unnumbered" id="expr.prim.id.splice-splice-specifiers">7.5.4.0*
 [expr.prim.id.splice] Splice specifiers<a href="#expr.prim.id.splice-splice-specifiers" class="self-link"></a></h3>
-<p>FIXME: The wording here, and usage throughout.</p>
-<p>Add a new grammar term for convenience:</p>
+<p>Add a new vocabulary of nonterminals for various forms of
+splicers:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb105"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a><em>splice-specifier</em>:</span>
-<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">1</a></span>
+<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>  [: <em>constant-expression</em> :]</span>
+<span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a><em>splice-expr-template-specifier</em>:</span>
+<span id="cb105-5"><a href="#cb105-5" aria-hidden="true" tabindex="-1"></a>    template <em>splice-specifier</em></span>
+<span id="cb105-6"><a href="#cb105-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb105-7"><a href="#cb105-7" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
+<span id="cb105-8"><a href="#cb105-8" aria-hidden="true" tabindex="-1"></a>    typename<sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>splice-specifier</em></span></code></pre></div>
+<p>The term <em>splicer</em> generically refers to a
+<code class="sourceCode cpp"><em>splice-specifier</em></code>, a
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>,
+or a
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">1</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> shall be
 a converted constant expression ([expr.const]) contextually convertible
-to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">2</a></span>
-Let <code class="sourceCode cpp">E</code> be the value of the converted
-<code class="sourceCode cpp"><em>constant-expression</em></code>. The
-<code class="sourceCode cpp"><em>splice-specifier</em></code> designates
-what <code class="sourceCode cpp">E</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">3</a></span>
-A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
+to <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.
+A <code class="sourceCode cpp"><em>splice-specifier</em></code>
+designates the construct represented by the converted
+<code class="sourceCode cpp"><em>constant-expression</em></code>, and is
 dependent if the converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
 value-dependent.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">2</a></span>
+A
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
+or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
+designates the construct designated by the
+<code class="sourceCode cpp"><em>splice-specifier</em></code>. A
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
+designates either a function template a primary variable template, or a
+concept. A
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
+designates either a type,
+<code class="sourceCode cpp"><em>typedef-name</em></code>, primary class
+template, alias template, or concept.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">3</a></span>
+The form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em></code>
+is interpreted as a
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
+when</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">(3.1)</a></span>
+it is preceded by
+<code class="sourceCode cpp"><span class="kw">typename</span></code>,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">(3.2)</a></span>
+it is within a type-only context,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">(3.3)</a></span>
+it is followed by
+<code class="sourceCode cpp"><span class="kw">auto</span></code> or
+<code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span></code>,
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">(3.4)</a></span>
+the <code class="sourceCode cpp"><em>splice-specifier</em></code> is not
+dependent and designates a primary class template or alias
+template.</li>
+</ul>
+<p>In all other cases, it is interpreted as a
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">4</a></span>
+The <code class="sourceCode cpp"><span class="kw">typename</span></code>
+in a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
+may only be omitted in a type-only context, or when the
+<code class="sourceCode cpp"><em>splice-specifier</em></code> is
+preceded by
+<code class="sourceCode cpp"><span class="kw">template</span></code>.</p>
+<div class="example">
+<span>[ <em>Example 1:</em> </span>
+<div class="sourceCode" id="cb106"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>FIXME</span></code></pre></div>
+<span> — <em>end example</em> ]</span>
+</div>
 </div>
 </blockquote>
 </div>
@@ -5349,26 +5340,26 @@ General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
 <p>Add a carve-out for reflection in <span>7.5.4.1 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>/4:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">4</a></span>
 An <code class="sourceCode cpp"><em>id-expression</em></code> that
 denotes a non-static data member or implicit object member function of a
 class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(4.1)</a></span>
 as part of a class member access (after any implicit transformation (see
 above)) in which the object expression refers to the member’s class or a
 class derived from that class, or</li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">(4.2)</a></span>
 as an operand to the reflection operator ([expr.reflect]), or</li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">(4.3)</a></span>
 to form a pointer to member ([expr.unary.op]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">(4.4)</a></span>
 if that id-expression denotes a non-static data member and it appears in
 an unevaluated operand.</li>
 </ul>
@@ -5382,32 +5373,31 @@ follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb106"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>  <em>nested-name-specifier</em>:</span>
-<span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
-<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
-<span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
-<span id="cb106-5"><a href="#cb106-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-namespace-specifier</em> ::</span></span>
-<span id="cb106-6"><a href="#cb106-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
-<span id="cb106-7"><a href="#cb106-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
-<span id="cb106-8"><a href="#cb106-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span>
-<span id="cb106-9"><a href="#cb106-9" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb106-10"><a href="#cb106-10" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-namespace-specifier</em>:</span></span>
-<span id="cb106-11"><a href="#cb106-11" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb107"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a>  <em>nested-name-specifier</em>:</span>
+<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>      ::</span>
+<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>      <em>type-name</em> ::</span>
+<span id="cb107-4"><a href="#cb107-4" aria-hidden="true" tabindex="-1"></a>      <em>namespace-name</em> ::</span>
+<span id="cb107-5"><a href="#cb107-5" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em> ::</span></span>
+<span id="cb107-6"><a href="#cb107-6" aria-hidden="true" tabindex="-1"></a>      <em>computed-type-specifier</em> ::</span>
+<span id="cb107-7"><a href="#cb107-7" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> <em>identifier</em> ::</span>
+<span id="cb107-8"><a href="#cb107-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em> template<sub><em>opt</em></sub> <em>simple-template-id</em> ::</span></code></pre></div>
 </div>
 </blockquote>
 </div>
 <p>Add a new paragraph restricting
-<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>,
-and renumber accordingly:</p>
+<code class="sourceCode cpp"><em>splice-specifier</em></code>, and
+renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">0</a></span>
-The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
-<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>
-shall designate a namespace or namespace alias.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">0</a></span>
+A <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>
+either is dependent or designates a type,
+<code class="sourceCode cpp"><em>typedef-name</em></code>, namespace, or
+<code class="sourceCode cpp"><em>namespace-alias</em></code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">1</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-id</em></code> are […]</p>
 </blockquote>
@@ -5416,7 +5406,7 @@ The component names of a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -5431,7 +5421,8 @@ the <code class="sourceCode cpp"><em>id-expression</em></code> of a
 <p>A declarative
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> shall
 not have a
-<code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or a
+<code class="sourceCode cpp"><em>computed-type-specifier</em></code>
+<span class="addu">or a
 <code class="sourceCode cpp"><em>splice-specifier</em></code></span>. A
 declaration that uses a declarative
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> shall
@@ -5443,9 +5434,9 @@ being redeclared or specialized.</p>
 “designate” over “nominate”:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">3</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
-<code class="sourceCode cpp">​<span class="op">::</span></code>​ <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
+<code class="sourceCode cpp"><span class="op">::</span></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace. A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
 a <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
 <span class="rm" style="color: #bf0303"><del>nominates</del></span>
@@ -5453,11 +5444,13 @@ a <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>,
 which shall be a class or enumeration type. <span class="addu">A
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
-a
-<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>
-designates the same namespace or namespace alias as the
-<code class="sourceCode cpp"><em>splice-namespace-specifier</em></code>.</span>
-If a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
+a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
+designates an entity itself designates the same entity. A
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> with
+a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
+designates a name itself designates the entity nominated by that
+name.</span> If a
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <em>N</em> is declarative and has a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> with a
 template argument list <em>A</em> that involves a template parameter,
@@ -5474,22 +5467,34 @@ let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nomi
 <blockquote>
 <div class="addu">
 <p><strong>Expression Splicing [expr.prim.splice]</strong></p>
-<p>FIXME: text for the template version.</p>
-<div class="sourceCode" id="cb107"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
-<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
-<span id="cb107-3"><a href="#cb107-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">1</a></span>
-The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
-not designate an unnamed bit-field, a constructor or destructor, or a
-constructor template or destructor template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">2</a></span>
-For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
-the form <code class="sourceCode cpp"><em>splice-specifier</em></code>,
-let <code class="sourceCode cpp"><em>E</em></code> be the object, value,
-or entity designated by
+<div class="sourceCode" id="cb108"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
+<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">1</a></span>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code>
+designates either</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(1.1)</a></span>
+a value or object,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(1.2)</a></span>
+a variable,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(1.3)</a></span>
+a structured binding,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(1.4)</a></span>
+a function,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(1.5)</a></span>
+an enumerator, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(1.6)</a></span>
+a non-static data member.</li>
+</ul>
+<p>The <code class="sourceCode cpp"><em>splice-specifier</em></code>
+shall not designate an unnamed bit-field, a constructor, or a
+destructor.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">2</a></span>
+Let <code class="sourceCode cpp"><em>E</em></code> be the construct
+designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(2.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(2.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an object, a
 function, or a non-static data member, the expression is an lvalue
 designating <code class="sourceCode cpp"><em>E</em></code>. The
@@ -5497,15 +5502,15 @@ expression has the same type as
 <code class="sourceCode cpp"><em>E</em></code>, and is a bit-field if
 and only if <code class="sourceCode cpp"><em>E</em></code> is a
 bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(2.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(2.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>E</em></code> is a
 variable or a structured binding, the expression is an lvalue
-designating the same object as
+designating the object associated with
 <code class="sourceCode cpp"><em>E</em></code>. The expression has the
 same type as <code class="sourceCode cpp"><em>E</em></code>, and is a
 bit-field if and only if <code class="sourceCode cpp"><em>E</em></code>
 is a bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(2.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>E</em></code> shall be a
 value or an enumerator. The expression is a prvalue whose evaluation
 computes <code class="sourceCode cpp"><em>E</em></code> and whose type
@@ -5525,13 +5530,15 @@ splices in member access expressions:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb108"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a>[1]{.pnum} Postfix expressions group left-to-right.</span>
-<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a>  <em>postfix-expression</em>:</span>
-<span id="cb108-3"><a href="#cb108-3" aria-hidden="true" tabindex="-1"></a>    ...</span>
-<span id="cb108-4"><a href="#cb108-4" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
-<span id="cb108-5"><a href="#cb108-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span>
-<span id="cb108-6"><a href="#cb108-6" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
-<span id="cb108-7"><a href="#cb108-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>splice-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb109"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a>[1]{.pnum} Postfix expressions group left-to-right.</span>
+<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>  <em>postfix-expression</em>:</span>
+<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a>    ...</span>
+<span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> . <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
+<span id="cb109-5"><a href="#cb109-5" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>splice-expression</em></span></span>
+<span id="cb109-6"><a href="#cb109-6" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> . <em>splice-expr-template-specifier</em></span></span>
+<span id="cb109-7"><a href="#cb109-7" aria-hidden="true" tabindex="-1"></a>    <em>postfix-expression</em> -&gt; <em>template</em><sub><em>opt</em></sub> <em>id-expression</em></span>
+<span id="cb109-8"><a href="#cb109-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>splice-expression</em></span></span>
+<span id="cb109-9"><a href="#cb109-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>postfix-expression</em> -&gt; <em>splice-expr-template-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5539,16 +5546,19 @@ splices in member access expressions:</p>
 <a href="https://wg21.link/expr.ref">[expr.ref]</a></span> Class member
 access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 <p>Modify paragraph 1 to account for splices in member access
-expressions:</p>
+expressions. Prefer the word “possibly” to “optionally” since
+<code class="sourceCode cpp"><span class="kw">template</span></code>
+cannot precede a <code class="sourceCode cpp">splice<span class="op">-</span>expression</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
-optionally followed by the keyword template, and then followed by an
-<em>id-expression</em><span class="addu">, or a
-<em>splice-expression</em> designating a class member</span>, is a
+<span class="rm" style="color: #bf0303"><del>optionally</del></span>
+<span class="addu">possibly</span> followed by the keyword template, and
+then followed by an
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or a splicer designating a class member</span>, is a
 postfix expression. <span class="note"><span>[ <em>Note 1:</em>
 </span>If the keyword
 <code class="sourceCode cpp"><span class="kw">template</span></code> is
@@ -5556,72 +5566,67 @@ used, the following unqualified name is considered to refer to a
 template ([temp.names]). If a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> results
 and is followed by a
-<code class="sourceCode cpp">​<span class="op">::</span></code>​, the
-<em>id-expression</em> <span class="addu">or
-<em>splice-expression</em></span> is a qualified-id.<span> — <em>end
-note</em> ]</span></span></p>
+<code class="sourceCode cpp"><span class="op">::</span></code>, the
+<code class="sourceCode cpp"><em>id-expression</em></code> is a
+<code class="sourceCode cpp"><em>qualified-id</em></code>.<span>
+— <em>end note</em> ]</span></span></p>
 </blockquote>
 </div>
 <p>Modify paragraph 2 to account for splices in member access
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">2</a></span>
-For the first option, if the <span class="addu">dot is followed by
-an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
-<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-expression</em></code>
-designating</span> a static member or an enumerator, the first
-expression is a discarded-value expression ([expr.context]); if the
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-expression</em></code>
-designates</span> <span class="rm" style="color: #bf0303"><del>names</del></span> a non-static data member,
-the first expression shall be a glvalue. For the second option (arrow),
-the first expression shall be a prvalue having pointer type. The
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">2</a></span>
+<span class="rm" style="color: #bf0303"><del>For the first
+option,</del></span> <span class="rm" style="color: #bf0303"><del>if</del></span><span class="addu">If</span>
+the <span class="addu">dot is followed by an</span>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or splicer designating</span> a static member or an
+enumerator, the first expression is a discarded-value expression
+([expr.context]); if the
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or splicer designates</span> <span class="rm" style="color: #bf0303"><del>names</del></span> a non-static data member,
+the first expression shall be a glvalue. <span class="rm" style="color: #bf0303"><del>For the second option (arrow), the first
+expression</del></span> <span class="addu">A postfix expression followed
+by an arrow</span> shall be a prvalue having pointer type. The
 expression
 <code class="sourceCode cpp">E1<span class="op">-&gt;</span>E2</code> is
 converted to the equivalent form <code class="sourceCode cpp"><span class="op">(*(</span>E1<span class="op">)).</span>E2</code>;
-the remainder of [expr.ref] will address only the first option
-(dot).</p>
+the remainder of [expr.ref] will address only <span class="rm" style="color: #bf0303"><del>the first option (dot)</del></span> <span class="addu">expressions containing a dot</span>.</p>
 </blockquote>
 </div>
 <p>Modify paragraph 3 to account for splices in member access
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">3</a></span>
 The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
-<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-expression</em></code></span>,
-determines the result of the entire postfix expression.</p>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or splicer</span>, determines the result of the entire
+postfix expression.</p>
 </blockquote>
 </div>
 <p>Modify paragraph 4 to account for splices in member access
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">4</a></span>
 Abbreviating <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>postfix-expression</em></code></span>.<span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span>EXPR</code>,
 where <code class="sourceCode cpp">EXPR</code> is the
-<code class="sourceCode cpp"><em>id-expression</em></code> or
-<code class="sourceCode cpp"><em>splice-expression</em></code> following
-the dot,</span> as
+<code class="sourceCode cpp"><em>id-expression</em></code> or splicer
+following the dot,</span> as
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code>,
 <code class="sourceCode cpp">E1</code> is called the
 <code class="sourceCode cpp"><em>object expression</em></code>. […]</p>
 </blockquote>
 </div>
-<p>Adjust the language in paragraphs 6-9 to account for
-splice-specifiers.</p>
+<p>Adjust the language in paragraphs 6-9 to account for splicers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">7</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is declared to have type
 “reference to <code class="sourceCode cpp">T</code>”, then
@@ -5636,13 +5641,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(7.2)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
 <code class="sourceCode cpp">X</code>”, and the type of
@@ -5663,11 +5668,11 @@ member, then the type of
 </ul>
 <p>[…]</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(7.4)</a></span>
 If <code class="sourceCode cpp">E</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(7.5)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, the expression
@@ -5675,14 +5680,14 @@ If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">8</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static member <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>, the
 program is ill-formed if the class of which <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>
 is directly a member is an ambiguous base ([class.member.lookup]) of the
 naming class ([class.access.base]) of <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default">E2</code></span></del></span>
 <span class="addu"><code class="sourceCode cpp"><em>M</em></code></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -5696,13 +5701,13 @@ General<a href="#expr.unary.general-general" class="self-link"></a></h3>
 paragraph 1 to add productions for the new operator:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
-<div class="sourceCode" id="cb109"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
-<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a>     ...</span>
-<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a>     <em>delete-expression</em></span>
-<span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb110"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
+<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>     ...</span>
+<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>     <em>delete-expression</em></span>
+<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>reflect-expression</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -5713,13 +5718,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -5729,7 +5734,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -5740,7 +5745,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -5757,116 +5762,108 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <blockquote>
 <div class="addu">
 <p><strong>The Reflection Operator [expr.reflect]</strong></p>
-<p>FIXME: <code class="sourceCode cpp"><em>template-name</em></code> and
-<code class="sourceCode cpp"><em>id-expression</em></code> can both
-refer to template names, have to handle this better. See wording in the
-template argument parsing section.</p>
-<div class="sourceCode" id="cb110"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><em>reflect-expression</em>:</span>
-<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>   ^ ::</span>
-<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
-<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></span>
-<span id="cb110-5"><a href="#cb110-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
-<span id="cb110-6"><a href="#cb110-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
-<span id="cb110-7"><a href="#cb110-7" aria-hidden="true" tabindex="-1"></a>   ^ <em>id-expression</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">1</a></span>
+<div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><em>reflect-expression</em>:</span>
+<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>   ^ ::</span>
+<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>   ^ <em>unqualified-id</em></span>
+<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a>   ^ <em>qualified-id</em></span>
+<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a>   ^ <em>type-id</em></span>
+<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>   ^ <em>pack-index-expression</em></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">2</a></span>
-A <em>reflect-expression</em> is parsed as the longest possible sequence
-of tokens that could syntactically form a
-<em>reflect-expression</em>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">2</a></span>
+A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
+parsed as the longest possible sequence of tokens that could
+syntactically form a
+<code class="sourceCode cpp"><em>reflect-expression</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb111"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
-<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb111-3"><a href="#cb111-3" aria-hidden="true" tabindex="-1"></a>template&lt;bool&gt; struct X {};</span>
-<span id="cb111-4"><a href="#cb111-4" aria-hidden="true" tabindex="-1"></a>bool operator&lt;(std::meta::info, X&lt;false&gt;);</span>
-<span id="cb111-5"><a href="#cb111-5" aria-hidden="true" tabindex="-1"></a>consteval void g(std::meta::info r, X&lt;false&gt; xv) {</span>
-<span id="cb111-6"><a href="#cb111-6" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp; true;    // error: ^ applies to the type-id &quot;int&amp;&amp;&quot;</span>
-<span id="cb111-7"><a href="#cb111-7" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp; true;     // error: ^ applies to the type-id &quot;int&amp;&quot;</span>
-<span id="cb111-8"><a href="#cb111-8" aria-hidden="true" tabindex="-1"></a>  r == (^int) &amp;&amp; true;  // OK</span>
-<span id="cb111-9"><a href="#cb111-9" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp;&amp;&amp; true;  // OK</span>
-<span id="cb111-10"><a href="#cb111-10" aria-hidden="true" tabindex="-1"></a>  ^X &lt; xv;              // error: &lt; starts template argument list</span>
-<span id="cb111-11"><a href="#cb111-11" aria-hidden="true" tabindex="-1"></a>  (^X) &lt; xv;            // OK</span>
-<span id="cb111-12"><a href="#cb111-12" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="cb111-13"><a href="#cb111-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
+<div class="sourceCode" id="cb112"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a>static_assert(is_type(^int()));    // ^ applies to the type-id &quot;int()&quot;</span>
+<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a>template&lt;bool&gt; struct X {};</span>
+<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a>bool operator&lt;(std::meta::info, X&lt;false&gt;);</span>
+<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a>consteval void g(std::meta::info r, X&lt;false&gt; xv) {</span>
+<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp; true;    // error: ^ applies to the type-id &quot;int&amp;&amp;&quot;</span>
+<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp; true;     // error: ^ applies to the type-id &quot;int&amp;&quot;</span>
+<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a>  r == (^int) &amp;&amp; true;  // OK</span>
+<span id="cb112-9"><a href="#cb112-9" aria-hidden="true" tabindex="-1"></a>  r == ^int &amp;&amp;&amp;&amp; true;  // OK</span>
+<span id="cb112-10"><a href="#cb112-10" aria-hidden="true" tabindex="-1"></a>  ^X &lt; xv;              // error: &lt; starts template argument list</span>
+<span id="cb112-11"><a href="#cb112-11" aria-hidden="true" tabindex="-1"></a>  (^X) &lt; xv;            // OK</span>
+<span id="cb112-12"><a href="#cb112-12" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb112-13"><a href="#cb112-13" aria-hidden="true" tabindex="-1"></a></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">4</a></span>
-When applied to
-<code class="sourceCode cpp"><span class="op">::</span></code>, the
-reflection operator produces a reflection for the global namespace. When
-applied to a
-<code class="sourceCode cpp"><em>namespace-name</em></code>, the
-reflection operator produces a reflection for the indicated namespace or
-namespace alias.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">5</a></span>
-When applied to a
-<code class="sourceCode cpp"><em>template-name</em></code>, the
-reflection operator produces a reflection for the indicated
-template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">6</a></span>
-When applied to a
-<code class="sourceCode cpp"><em>concept-name</em></code>, the
-reflection operator produces a reflection for the indicated concept.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">7</a></span>
-When applied to a
-<code class="sourceCode cpp"><em>typedef-name</em></code>, the
-reflection operator produces a reflection of the indicated
-<code class="sourceCode cpp"><em>typedef-name</em></code>. When applied
-to any other <code class="sourceCode cpp"><em>type-id</em></code>, the
-reflection operator produces a reflection of the indicated type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">8</a></span>
-When applied to an
-<code class="sourceCode cpp"><em>id-expression</em></code>, the
-reflection operator produces a reflection as follows:</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">4</a></span>
+A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
+the form <code class="sourceCode cpp"><span class="op">^</span> <span class="op">::</span></code>
+produces a reflection of the global namespace.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">5</a></span>
+A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
+the form <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>
+or <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>
+performs name lookup for the operand following
+<code class="sourceCode cpp"><span class="op">^</span></code> and
+produces a result as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(8.1)</a></span>
-When applied to an enumerator, the reflection operator produces a
-reflection of the enumerator designated by the operand.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(8.2)</a></span>
-Otherwise, when applied to an overload set
-<code class="sourceCode cpp">S</code>, if the assignment of
-<code class="sourceCode cpp">S</code> to an invented variable of type
-<code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(5.1)</a></span>
+If lookup finds an overload set
+<code class="sourceCode cpp"><em>S</em></code> such that the assignment
+of <code class="sourceCode cpp"><em>S</em></code> to an invented
+variable of type <code class="sourceCode cpp"><span class="kw">const</span> <span class="kw">auto</span></code>
 (<span>9.2.9.7.2 <a href="https://wg21.link/dcl.type.auto.deduct">[dcl.type.auto.deduct]</a></span>)
 would select a unique candidate function
-<code class="sourceCode cpp">F</code> from
-<code class="sourceCode cpp">S</code>, the result is a reflection of
-<code class="sourceCode cpp">F</code>. Otherwise, the expression
-<code class="sourceCode cpp"><span class="op">^</span>S</code> is
-ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(8.3)</a></span>
-Otherwise, when applied to one of</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">(8.3.1)</a></span>
-a non-type template parameter of non-class and non-reference type
-or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(8.3.2)</a></span>
-a <code class="sourceCode cpp"><em>pack-index-expression</em></code> of
-non-class and non-reference type</li>
+<code class="sourceCode cpp"><em>F</em></code> from
+<code class="sourceCode cpp"><em>S</em></code>, then the result is a
+reflection of <code class="sourceCode cpp"><em>F</em></code>. If lookup
+finds any other overload set, the program is ill-formed.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(5.2)</a></span>
+Otherwise, if lookup finds a
+<code class="sourceCode cpp"><em>typedef-name</em></code> or a
+<code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
+result is a reflection of the indicated name.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(5.3)</a></span>
+Otherwise, if lookup finds a non-type template parameter, the result is
+a reflection of the result computed by an
+<code class="sourceCode cpp"><em>id-expression</em></code> naming the
+parameter.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(5.4)</a></span>
+Otherwise, if lookup finds a variable, structured binding, function,
+enumerator, type, non-static member, template, or namespace, the result
+is a reflection of the denoted entity.</p></li>
 </ul>
-<p>the reflection operator produces a reflection of the value computed
-by the operand.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(8.4)</a></span>
-Otherwise, the reflection operator produces a reflection of the
-variable, function, or non-static member designated by the operand. The
-<code class="sourceCode cpp"><em>id-expression</em></code> is not
-evaluated.</p></li>
-</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">6</a></span>
+A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
+form
+<code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
+produces a reflection of the denoted type. A
+<code class="sourceCode cpp"><em>reflect-expression</em></code> that
+could be validly interpreted as either <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>
+or
+<code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
+is interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>unqualified-id</em></code>,
+and a <code class="sourceCode cpp"><em>reflect-expression</em></code>
+that could be validly interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>
+or
+<code class="sourceCode cpp"><span class="op">^</span> <em>type-id</em></code>
+is interpreted as <code class="sourceCode cpp"><span class="op">^</span> <em>qualified-id</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">7</a></span>
+A <code class="sourceCode cpp"><em>reflect-expression</em></code> having
+the form <code class="sourceCode cpp"><span class="op">^</span> <em>pack-index-expression</em></code>
+produces a reflection of the result computed by the
+<code class="sourceCode cpp"><em>pack-index-expression</em></code>.</p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb112"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">!=</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">==</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb112-3"><a href="#cb112-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span><span class="dt">int</span><span class="op">))</span>;</span>
-<span id="cb112-4"><a href="#cb112-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb112-5"><a href="#cb112-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> R <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
-<span id="cb112-6"><a href="#cb112-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> S <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: cannot reflect an overload set</span></span>
-<span id="cb112-7"><a href="#cb112-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb112-8"><a href="#cb112-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span></code></pre></div>
+<div class="sourceCode" id="cb113"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">!=</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^</span>T <span class="op">==</span> <span class="op">^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span><span class="dt">int</span><span class="op">))</span>;</span>
+<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> R <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
+<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> S <span class="op">=</span> <span class="op">^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: cannot reflect an overload set</span></span>
+<span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb113-8"><a href="#cb113-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -5878,11 +5875,10 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
-pointer-to-member type, or <span class="rm" style="color: #bf0303"><del>type</del></span> <span class="addu">one of
-the types <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-or</span> <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>.
+pointer-to-member type, <span class="addu">type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
+or type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>.
 The operators
 <code class="sourceCode cpp"><span class="op">==</span></code> and
 <code class="sourceCode cpp"><span class="op">!=</span></code> both
@@ -5897,47 +5893,49 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between <span>7.6.10 <a href="https://wg21.link/expr.eq">[expr.eq]</a></span>/5 and /6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">5</a></span>
-Two operands of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> or
-one operand of type <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code> and
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">5</a></span>
+Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
+one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">*</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(*.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(*.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(*.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(*.2)</a></span>
 Otherwise, if one operand represents a
 <code class="sourceCode cpp"><em>template-id</em></code> referring to a
 specialization of an alias template, then they compare equal if and only
 if the other operand represents the same
 <code class="sourceCode cpp"><em>template-id</em></code>
 ([temp.type]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(*.3)</a></span>
-Otherwise, if one operand represents a namespace alias or a
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(*.3)</a></span>
+Otherwise, if one operand represents a
+<code class="sourceCode cpp"><em>namespace-alias</em></code> or a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then they
 compare equal if and only if the construct represented by the other
 operand represents the same kind of construct, shares the same name, is
 declared within the same enclosing scope, and aliases the same
 underlying entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(*.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(*.4)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a template-argument-equivalent
 value (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(*.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(*.5)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(*.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(*.6)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(*.7)</a></span>
-Otherwise, if one operand represents a base class specifier, then they
-compare equal if and only if the other operand represents the same base
-class specifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(*.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(*.7)</a></span>
+Otherwise, if one operand represents a
+<code class="sourceCode cpp"><em>base-specifier</em></code>, then they
+compare equal if and only if the other operand represents the same
+<code class="sourceCode cpp"><em>base-specifier</em></code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(*.8)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -5957,7 +5955,7 @@ any), <code class="sourceCode cpp"><em>alignment-specifiers</em></code>
 (if any), width, and attributes.</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -5974,27 +5972,70 @@ Otherwise, the result of each of the operators is unspecified.</p>
 </div>
 <h3 class="unnumbered" id="expr.const-constant-expressions"><span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span> Constant
 Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3>
+<p>Modify paragraph 15 to disallow returning non-consteval-only pointers
+and references to consteval-only objects from constant expressions.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">15</a></span>
+A <em>constant-expression</em> is either a glvalue core constant
+expression that <span class="addu"> </span></p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(15.1)</a></span>
+refers to an entity that is a permitted result of a constant
+expression<span class="addu">, and</span></li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(15.2)</a></span>
+is of consteval-only type if the entity designated by the expression is
+of consteval-only type,</span></li>
+</ul>
+<p>or a prvalue core constant expression whose value satisfies the
+following constraints:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(15.3)</a></span>
+if the value is an object of class type, each non-static data member of
+reference type refers to an entity that is a permitted result of a
+constant expression <span class="addu">and has consteval-only type if
+the entity has consteval-only type</span>,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(15.4)</a></span>
+if the value is an object of scalar type, it does not have an
+indeterminate or erroneous value ([basic.indet]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(15.5)</a></span>
+if the value is of pointer type, it is a pointer to an object of static
+storage duration, a pointer past the end of such an object ([expr.add]),
+a pointer to a non-immediate function, or a null pointer value,</li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(15.6)</a></span>
+if the value is a pointer to an object of consteval-only type, or a
+pointer past the end of such an object, then the prvalue is also of
+consteval-only type,</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(15.7)</a></span>
+if the value is of pointer-to-member-function type, it does not
+designate an immediate function, and</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(15.8)</a></span>
+if the value is an object of class or array type, each subobject
+satisfies these constraints for the value.</li>
+</ul>
+</blockquote>
+</div>
 <p>Modify (and clean up) the definition of <em>immediate-escalating</em>
 to also apply to expressions of consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">18</a></span>
-A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evalauted</span> expression or conversion is
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">18</a></span>
+A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it <span class="rm" style="color: #bf0303"><del>is</del></span> either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(18.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(18.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">is an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> that denotes
 an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that is not a subexpression of an immediate
 invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(18.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(18.2)</a></span>
 <span class="addu">is</span> an immediate invocation that is not a
 constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(18.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(18.3)</a></span>
 has consteval-only type ([basic.types.general]).</span></li>
 </ul>
 </blockquote>
@@ -6005,41 +6046,41 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">20</a></span>
 An expression or conversion is <em>in substitution context</em> if it
 results from the substitution of template parameters</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(20.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(20.1)</a></span>
 during template argument deduction (<span>13.10.3 <a href="https://wg21.link/temp.deduct">[temp.deduct]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(20.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(20.2)</a></span>
 in a <code class="sourceCode cpp"><em>concept-id</em></code> (<span>13.3
 <a href="https://wg21.link/temp.names">[temp.names]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(20.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(20.3)</a></span>
 in a <code class="sourceCode cpp"><em>requires-expression</em></code>
 (<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span>).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">21</a></span>
 An expression or conversion is <em>plainly constant-evaluated</em> if it
 is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code> that
 is not in substitution context,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(21.3)</a></span>
 the initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
 <code class="sourceCode cpp"><span class="kw">constinit</span></code>
 (<span>9.2.7 <a href="https://wg21.link/dcl.constinit">[dcl.constinit]</a></span>)
 variable, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(21.4)</a></span>
 an immediate invocation, unless it is
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(21.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(21.4.1)</a></span>
 in substitution context, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(21.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(21.4.2)</a></span>
 within the body of an immediate-escalating function that contains an
 immediate-escalating expression.</li>
 </ul></li>
@@ -6053,24 +6094,24 @@ declarations are reachable at a point immediatelly following
 note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb113"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
-<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
-<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb113-6"><a href="#cb113-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
-<span id="cb113-7"><a href="#cb113-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb113-8"><a href="#cb113-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
-<span id="cb113-9"><a href="#cb113-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb113-10"><a href="#cb113-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
-<span id="cb113-11"><a href="#cb113-11" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
-<span id="cb113-12"><a href="#cb113-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb113-13"><a href="#cb113-13" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
-<span id="cb113-14"><a href="#cb113-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb113-15"><a href="#cb113-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb113-16"><a href="#cb113-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb113-17"><a href="#cb113-17" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
-<span id="cb113-18"><a href="#cb113-18" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
+<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">struct</span> RV <span class="op">{}</span>;</span>
+<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="co">// instantiations of &#39;T::f(0)&#39; are not plainly constant-evaluated</span></span>
+<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> RV<span class="op">&lt;</span>T<span class="op">::</span>f<span class="op">(</span><span class="dv">0</span><span class="op">)&gt;</span> check<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> cfn<span class="op">(</span><span class="dt">int</span><span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> <span class="kw">true</span>; <span class="op">}</span></span>
+<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> V<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">))</span>  <span class="co">// cfn(V) is not plainly constant-evaluated</span></span>
+<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> g<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">1</span><span class="op">))</span> <span class="op">{</span>       <span class="co">// cfn(V+1) is plainly constant-evaluated</span></span>
+<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> cfn<span class="op">(</span>V<span class="op">+</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// cfn(V+2) is plainly constant-evaluated</span></span>
+<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="dv">0</span>;</span>
+<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>cfn<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;        <span class="co">// !cfn(1) is plainly constant-evaluated</span></span>
+<span id="cb114-18"><a href="#cb114-18" aria-hidden="true" tabindex="-1"></a><span class="kw">const</span> <span class="dt">bool</span> b2 <span class="op">=</span> cfn<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;             <span class="co">// cfn(2) is not plainly constant-evaluated</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6081,22 +6122,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">22</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(22.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(22.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(22.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(22.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(22.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(22.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(22.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(22.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6119,7 +6160,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">23</a></span>
 The evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> can introduce an
 <em>injected declaration</em>. For each such declaration
@@ -6133,12 +6174,12 @@ non-injected point in the translation unit containing
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to injected points ([module.reach]).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">24</a></span>
 The program is ill-formed if an injected declaration is produced by the
 evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> that is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(24.1)</a></span>
 a manifestly constant-evaluated expression that is not plainly
 constant-evaluated, or</li>
 <li>within the body of an immediate-escalating function
@@ -6155,36 +6196,36 @@ declarations when such evaluations can be guaranteed to only happen
 once.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb114"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
-<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
-<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
-<span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
-<span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
-<span id="cb114-8"><a href="#cb114-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-9"><a href="#cb114-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
-<span id="cb114-10"><a href="#cb114-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
-<span id="cb114-11"><a href="#cb114-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
-<span id="cb114-12"><a href="#cb114-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-13"><a href="#cb114-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
-<span id="cb114-14"><a href="#cb114-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
-<span id="cb114-15"><a href="#cb114-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
-<span id="cb114-16"><a href="#cb114-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb114-17"><a href="#cb114-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb114-18"><a href="#cb114-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
-<span id="cb114-19"><a href="#cb114-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
-<span id="cb114-20"><a href="#cb114-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb114-21"><a href="#cb114-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
-<span id="cb114-22"><a href="#cb114-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
-<span id="cb114-23"><a href="#cb114-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
-<span id="cb114-24"><a href="#cb114-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evalauted.</span></span>
-<span id="cb114-25"><a href="#cb114-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
-<span id="cb114-26"><a href="#cb114-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
-<span id="cb114-27"><a href="#cb114-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb115"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> make_decl<span class="op">(</span><span class="dt">int</span><span class="op">)</span>;      <span class="co">// calling &#39;make_decl(n)&#39; produces a declaration</span></span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="dt">int</span> R<span class="op">&gt;</span> <span class="kw">requires</span> <span class="op">(</span>make_decl<span class="op">(</span>R<span class="op">))</span></span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> tfn<span class="op">()</span>;</span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b1 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">1</span><span class="op">)</span>;  <span class="co">// OK, constexpr variable so this is plainly</span></span>
+<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// constant evaluated</span></span>
+<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> b2 <span class="op">=</span> <span class="op">!</span>make_decl<span class="op">(</span><span class="dv">2</span><span class="op">)</span>;            <span class="co">// error: initializer !make_decl(42) produced</span></span>
+<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// a declaration but is not plainly constant</span></span>
+<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// evaluated</span></span>
+<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b3 <span class="op">=</span> tfn<span class="op">&lt;</span><span class="dv">3</span><span class="op">&gt;()</span>;       <span class="co">// error: the invocation of make_decl(R) in the</span></span>
+<span id="cb115-14"><a href="#cb115-14" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// requires clause produced a declaration but is</span></span>
+<span id="cb115-15"><a href="#cb115-15" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant evaluated</span></span>
+<span id="cb115-16"><a href="#cb115-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb115-17"><a href="#cb115-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">int</span> <span class="op">*</span>not_constant<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb115-18"><a href="#cb115-18" aria-hidden="true" tabindex="-1"></a>  make_decl<span class="op">(</span><span class="dv">4</span><span class="op">)</span>;</span>
+<span id="cb115-19"><a href="#cb115-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">new</span> <span class="dt">int</span> <span class="op">{}</span>;</span>
+<span id="cb115-20"><a href="#cb115-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb115-21"><a href="#cb115-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> b4 <span class="op">=</span> <span class="op">[]</span> <span class="op">{</span></span>
+<span id="cb115-22"><a href="#cb115-22" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> <span class="op">*</span>p <span class="op">=</span> not_constant<span class="op">()</span>;          <span class="co">// error: not_constant() produces a declaration</span></span>
+<span id="cb115-23"><a href="#cb115-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// in an immediate-escalated function, but is</span></span>
+<span id="cb115-24"><a href="#cb115-24" aria-hidden="true" tabindex="-1"></a>                                    <span class="co">// not plainly constant-evaluated.</span></span>
+<span id="cb115-25"><a href="#cb115-25" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> p;</span>
+<span id="cb115-26"><a href="#cb115-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="kw">true</span>;</span>
+<span id="cb115-27"><a href="#cb115-27" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines which declarations are found by certain expressions used
 for reflection. During the evaluation of a manifestly constant-evaluated
@@ -6193,14 +6234,14 @@ evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(24.2)</a></span>
 the injected points corresponding to any injected declarations
 ([expr.const]) produced by evaluations sequenced before
-<code class="sourceCode cpp"><em>E</em></code>.</li>
+<code class="sourceCode cpp"><em>E</em></code> ([intro.execution]).</li>
 </ul>
 </div>
 </blockquote>
@@ -6209,16 +6250,16 @@ the injected points corresponding to any injected declarations
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
 specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3>
 <p>Account for
-<code class="sourceCode cpp"><em>splice-template-speciifer</em></code>s
-in paragraph 3.</p>
+<code class="sourceCode cpp"><em>splice-type-speciifer</em></code>s in
+paragraph 3.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">3</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>typedef-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
-designate</span> <span class="rm" style="color: #bf0303"><del>names</del></span> an alias template or a
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
+designates</span> <span class="rm" style="color: #bf0303"><del>names</del></span> an alias template or a
 template
 <code class="sourceCode cpp"><em>template-parameter</em></code>.</p>
 </blockquote>
@@ -6226,58 +6267,74 @@ template
 <h3 class="unnumbered" id="dcl.type.simple-simple-type-specifiers"><span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>
 Simple type specifiers<a href="#dcl.type.simple-simple-type-specifiers" class="self-link"></a></h3>
 <p>Extend the grammar for
-<code class="sourceCode cpp"><em>simple-type-specifier</em></code> and
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code> as
 follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb115"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-type-specifier</em>:</span>
-<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>    <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>type-name</em></span>
-<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a>    <em>nested-name-specifier</em> template <em>simple-template-id</em></span>
-<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>    <em>computed-type-specifier</em></span>
-<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a>    <em>placeholder-type-specifier</em></span>
-<span id="cb115-6"><a href="#cb115-6" aria-hidden="true" tabindex="-1"></a>    <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></span>
-<span id="cb115-7"><a href="#cb115-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-specifier</em></span></span>
-<span id="cb115-8"><a href="#cb115-8" aria-hidden="true" tabindex="-1"></a>    ...</span>
-<span id="cb115-9"><a href="#cb115-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb115-10"><a href="#cb115-10" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
-<span id="cb115-11"><a href="#cb115-11" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
-<span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
-<span id="cb115-13"><a href="#cb115-13" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb116"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>  <em>computed-type-specifier</em>:</span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a>     <em>decltype-specifier</em></span>
+<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a>     <em>pack-index-specifier</em></span>
+<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Modify paragraph 3 to indicate that a
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
-can be deduced.</p>
+<p>Add a restriction to paragrpah 2 disallowing splicers from appearing
+after nested name specifiers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">3</a></span>
-A
-<code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
-is a placeholder for a type to be deduced ([dcl.spec.auto]). <span class="addu">The
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">2</a></span>
+The component names of a
+<code class="sourceCode cpp"><em>simple-type-specifier</em></code> are
+those of its
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
+<code class="sourceCode cpp"><em>type-name</em></code>,
+<code class="sourceCode cpp"><em>simple-template-id</em></code>,
+<code class="sourceCode cpp"><em>template-name</em></code>, and/or
+<code class="sourceCode cpp"><em>type-constraint</em></code> (if it is a
+<code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>).
+The component name of a
+<code class="sourceCode cpp"><em>type-name</em></code> is the first name
+in it. <span class="addu">The
 <code class="sourceCode cpp"><em>simple-template-id</em></code> in a
 <code class="sourceCode cpp"><em>type-specifier</em></code> of the form
 <code class="sourceCode cpp"><em>nested-name-specifier</em> <span class="kw">template</span> <em>simple-template-id</em></code>
-shall not contain a
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</span>
-A <code class="sourceCode cpp"><em>type-specifier</em></code> of the
-form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>
-<span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
-is a placeholder for a deduced class type ([dcl.type.class.deduct]). The
+shall not contain a splicer.</span></p>
+</blockquote>
+</div>
+<p>Indicate that a
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code> can
+be a placeholder for a deduced class type.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">3</a></span>
+A
+<code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
+is a placeholder for a type to be deduced ([dcl.spec.auto]). A
+<code class="sourceCode cpp"><em>type-specifier</em></code> <span class="rm" style="color: #bf0303"><del>of the form <span><code class="sourceCode default">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code></span></del></span>
+is a placeholder for a deduced class type ([dcl.type.class.deduct])
+<span class="addu">if it</span></p>
+<div class="addu">
+<ul>
+<li>is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
+or</li>
+<li>consists of a
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code> that
+designates a class template or alias template.</li>
+</ul>
+</div>
+<p>The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>, if
 any, shall be non-dependent and the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 shall <span class="rm" style="color: #bf0303"><del>name</del></span>
 <span class="addu">designate</span> a deducible template. A
 <em>deducible template</em> is either a class template or is an alias
 template whose
 <code class="sourceCode cpp"><em>defining-type-id</em></code> is of the
 form</p>
-<div class="sourceCode" id="cb116"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
+<div class="sourceCode" id="cb117"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a>typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> template<sub><em>opt</em></sub> <em>simple-template-id</em></span></code></pre></div>
 <p>where the
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> (if
 any) is non-dependent and the
@@ -6287,7 +6344,7 @@ deducible template.</p>
 </blockquote>
 </div>
 <p>Add a row to [tab:dcl.type.simple] to cover the
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 production.</p>
 <div class="std">
 <blockquote>
@@ -6341,7 +6398,7 @@ the types they specify [tab:dcl.type.simple]
 [dcl.type.class.deduct]</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;"><span class="addu"><code class="sourceCode cpp"><em>splice-template-specifier</em></code></span></td>
+<td style="text-align: left;"><span class="addu"><code class="sourceCode cpp"><em>splice-type-specifier</em></code></span></td>
 <td style="text-align: left;"><span class="addu">the type as defined in
 [dcl.type.class.deduct]</span></td>
 </tr>
@@ -6353,29 +6410,6 @@ the types they specify [tab:dcl.type.simple]
 </table>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.type.splice-type-splicing">9.2.9*
-[dcl.type.splice] Type splicing<a href="#dcl.type.splice-type-splicing" class="self-link"></a></h3>
-<p>Add a new subsection of <span>9.2.9 <a href="https://wg21.link/dcl.type">[dcl.type]</a></span> following
-<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>.</p>
-<div class="std">
-<blockquote>
-<div class="addu">
-<div>
-<div class="sourceCode" id="cb117"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="va">+  <em>splice-type-specifier</em></span></span>
-<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="va">+      typename<sub><em>opt</em></sub> <em>splice-specifier</em></span></span></code></pre></div>
-</div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">1</a></span>
-The <code class="sourceCode cpp"><span class="kw">typename</span></code>
-may be omitted only within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">2</a></span>
-The <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
-designate a type. The type designated by the
-<code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
-the same type designated by the
-<code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
-</div>
-</blockquote>
-</div>
 <h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 Initializers (General)<a href="#dcl.init.general-initializers-general" class="self-link"></a></h3>
 <p>Change paragraphs 6-8 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
@@ -6384,45 +6418,45 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type ([basic.types.general]), the object is
 initialized to the value obtained by converting the integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -6430,7 +6464,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -6439,23 +6473,38 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">9</a></span>
-A function type with a <em>cv-qualifier-seq</em> or a
-<em>ref-qualifier</em> (including a type named by <em>typedef-name</em>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">9</a></span>
+A function type with a
+<code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
+<code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
+type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(9.2)</a></span>
-…</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(9.5)</a></span>
-the <em>type-id</em> of a <em>template-argument</em> for a
-<em>type-parameter</em> ([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(9.2)</a></span>
+the function type to which a pointer to member refers,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(9.3)</a></span>
+the top-level function type of a function typedef declaration or
+<code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(9.4)</a></span>
+the <code class="sourceCode cpp"><em>type-id</em></code> in the default
+argument of a
+<code class="sourceCode cpp"><em>type-parameter</em></code>
+([temp.param]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(9.5)</a></span>
+the <code class="sourceCode cpp"><em>type-id</em></code> of a
+<code class="sourceCode cpp"><em>template-argument</em></code> for a
+<code class="sourceCode cpp"><em>type-parameter</em></code>
+([temp.arg.type])<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
+or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(9.6)</a></span>
-the operand of a <em>reflect-expression</em> ([expr.reflect]).</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(9.6)</a></span>
+the operand of a
+<code class="sourceCode cpp"><em>reflect-expression</em></code>
+([expr.reflect]).</li>
 </ul>
 </div>
 </blockquote>
@@ -6466,10 +6515,10 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
-the reflection operator</span>, is ill-formed.</p>
+the reflection operator ([expr.reflect])</span>, is ill-formed.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.7.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
@@ -6486,22 +6535,24 @@ follows:</p>
 <span id="cb118-4"><a href="#cb118-4" aria-hidden="true" tabindex="-1"></a>  <em>using-enum-declarator</em>:</span>
 <span id="cb118-5"><a href="#cb118-5" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
 <span id="cb118-6"><a href="#cb118-6" aria-hidden="true" tabindex="-1"></a>     <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>simple-template-id</em></span>
-<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-specifier</em></span></span></code></pre></div>
+<span id="cb118-7"><a href="#cb118-7" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<p>Modify paragraph 1 of <span>9.7.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> as
-follows:</p>
+<p>Modify paragraph 1 to handle splicers:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">1</a></span>
-A <code class="sourceCode cpp"><em>using-enum-declarator</em></code>
-<span class="addu">that is not a
-<code class="sourceCode cpp"><em>splice-specifier</em></code></span>
-names the set of declarations found by lookup (<span>6.5.3 <a href="https://wg21.link/basic.lookup.unqual">[basic.lookup.unqual]</a></span>,
-<span>6.5.5 <a href="https://wg21.link/basic.lookup.qual">[basic.lookup.qual]</a></span>)
-for the
-<code class="sourceCode cpp"><em>using-enum-declarator</em></code>. The
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">1</a></span>
+<span class="addu">A <code class="sourceCode cpp"><span class="kw">using</span><span class="op">-</span><span class="kw">enum</span><span class="op">-</span>declarator</code>
+of the form
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code> is
+considered in a type-only context, and designates the same construct
+designated by the splicer. Any other</span> <span class="rm" style="color: #bf0303"><del>A</del></span>
+<code class="sourceCode cpp"><em>using-enum-declarator</em></code> names
+the set of declarations found by type-only lookup
+([basic.lookup.general]) for the
+<code class="sourceCode cpp"><em>using-enum-declarator</em></code>
+([basic.lookup.unqual], [basic.lookup.qual]). The
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> shall
 designate a non-dependent type with a reachable
 <code class="sourceCode cpp"><em>enum-specifier</em></code>.</p>
@@ -6511,20 +6562,14 @@ designate a non-dependent type with a reachable
 <a href="https://wg21.link/namespace.alias">[namespace.alias]</a></span>
 Namespace alias<a href="#namespace.alias-namespace-alias" class="self-link"></a></h3>
 <p>Add a production to the grammar for
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+<code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 as follows:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias</em>:</span>
-<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>      <em>identifier</em></span>
-<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb119-4"><a href="#cb119-4" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
-<span id="cb119-5"><a href="#cb119-5" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
-<span id="cb119-6"><a href="#cb119-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb119-7"><a href="#cb119-7" aria-hidden="true" tabindex="-1"></a>  <em>qualified-namespace-specifier</em>:</span>
-<span id="cb119-8"><a href="#cb119-8" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
-<span id="cb119-9"><a href="#cb119-9" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>  <em>namespace-alias-definition</em>:</span>
+<span id="cb119-2"><a href="#cb119-2" aria-hidden="true" tabindex="-1"></a>      namespace <em>identifier</em> = <em>qualified-namespace-specifier</em></span>
+<span id="cb119-3"><a href="#cb119-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     namespace <em>identifier</em> = <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6532,47 +6577,40 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">0</a></span>
-If a
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
-is a <code class="sourceCode cpp"><em>splice-specifier</em></code>, the
-<code class="sourceCode cpp"><em>splice-specifier</em></code> shall
-designate a namespace or namespace alias; the
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
-designates the same namespace or namespace alias designated by the
-<code class="sourceCode cpp"><em>splice-specifier</em></code>.
-Otherwise, the
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
-designates the namespace found by lookup (<span>6.5.3 <a href="https://wg21.link/basic.lookup.unqual">[basic.lookup.unqual]</a></span>,
-<span>6.5.5 <a href="https://wg21.link/basic.lookup.qual">[basic.lookup.qual]</a></span>).</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">0</a></span>
+A <code class="sourceCode cpp"><em>splice-specifier</em></code>
+appearing in a
+<code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
+shall designate a namespace or
+<code class="sourceCode cpp"><em>namespace-alias</em></code>.</p>
 </div>
 </blockquote>
 </div>
-<p>Prefer the verb “designate” for
-<code class="sourceCode cpp"><em>qualified-namespace-specifiers</em></code>
-in the paragraph that immediately follows:</p>
+<p>Prefer the verb “designate” in the paragraph that immediately
+follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
 and denotes the namespace <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> by the
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>.</p>
+<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
+<span class="addu">or
+<code class="sourceCode cpp"><em>splice-specifier</em></code></span>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
 Using namespace directive<a href="#namespace.udir-using-namespace-directive" class="self-link"></a></h3>
-<p>Use
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
-in the grammar for
+<p>Add <code class="sourceCode cpp"><em>splice-specifier</em></code> to
+the grammar for
 <code class="sourceCode cpp"><em>using-directive</em></code>:</p>
 <div class="std">
 <blockquote>
 <div>
 <div class="sourceCode" id="cb120"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>  <em>using-directive</em>:</span>
-<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a><span class="st">-    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span></span>
-<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+    <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>qualified-namespace-specifier</em></span></span></code></pre></div>
+<span id="cb120-2"><a href="#cb120-2" aria-hidden="true" tabindex="-1"></a>      <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>namespace-name</em></span>
+<span id="cb120-3"><a href="#cb120-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>attribute-specifier-seq</em><sub><em>opt</em></sub> using namespace <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6581,15 +6619,15 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">0</a></span>
-The
-<code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
-shall neither contain a dependent
-<code class="sourceCode cpp"><em>nested-name-specifier</em></code> nor a
-dependent
-<code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">0</a></span>
+The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
+any, designates a namespace or
+<code class="sourceCode cpp"><em>namespace-alias</em></code>. Neither
+the <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
+nor the <code class="sourceCode cpp"><em>splice-specifier</em></code>
+shall be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -6653,7 +6691,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -6673,12 +6711,12 @@ the two-token sequence
 <h3 class="unnumbered" id="module.global.frag-global-module-fragment">[module.global.frag]
 Global module fragment<a href="#module.global.frag-global-module-fragment" class="self-link"></a></h3>
 <p>Extend the caveat in paragraph 3.7 to also apply to
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -6687,15 +6725,15 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
-does denote a dependent type and whose
+does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template is replaced by its
 denoted type prior to this determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(3.8)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -6706,23 +6744,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 an injected point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 injected point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 ([module.global.frag]), appears in a translation unit that is reachable
 from <code class="sourceCode cpp"><em>P</em></code>, and does not appear
@@ -6731,9 +6769,7 @@ within a <em>private-module-framgent</em>.</li>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="class.pre-preamble">[class.pre] Preamble<a href="#class.pre-preamble" class="self-link"></a></h3>
-<p>Disallow a
-<code class="sourceCode cpp"><em>slice-template-specifier</em></code>
-from appearing in a declaration of a
+<p>Disallow splicers from appearing in a declaration of a
 <code class="sourceCode cpp"><em>class-name</em></code> in paragraph
 1.</p>
 <div class="std">
@@ -6746,9 +6782,8 @@ from appearing in a declaration of a
 an explicit specialization ([temp.expl.spec]) or a partial
 specialization ([temp.spec.partial]). <span class="addu">The
 <code class="sourceCode cpp"><em>simple-template-id</em></code> shall
-not contain a
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</span>
-A <code class="sourceCode cpp"><em>class-specifier</em></code> whose
+not contain a splicer.</span> A
+<code class="sourceCode cpp"><em>class-specifier</em></code> whose
 <code class="sourceCode cpp"><em>class-head</em></code> omits the
 <code class="sourceCode cpp"><em>class-head-name</em></code> defines an
 <em>unnamed class</em>.</p>
@@ -6756,14 +6791,14 @@ A <code class="sourceCode cpp"><em>class-specifier</em></code> whose
 </div>
 <h3 class="unnumbered" id="class.name-class-names">[class.name] Class
 names<a href="#class.name-class-names" class="self-link"></a></h3>
-<p>Cover `$splice-template-specifier$s in paragraph 5.</p>
+<p>Cover `$splice-type-specifier$s in paragraph 5.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">5</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> is
 only a <code class="sourceCode cpp"><em>class-name</em></code> if its
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a class template.</p>
 </blockquote>
 </div>
@@ -6774,7 +6809,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -6797,33 +6832,33 @@ corresponding to each non-static data member of its class</span><span>
 <a href="https://wg21.link/over.match.class.deduct">[over.match.class.deduct]</a></span>
 Class template argument deduction<a href="#over.match.class.deduct-class-template-argument-deduction" class="self-link"></a></h3>
 <p>Extend paragraph 1 to work with
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">1</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.class.deduct]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a primary class template
 <code class="sourceCode cpp">C</code>, a set of functions and function
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
 </div>
 <p>Extend paragraph 3 to also cover
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">3</a></span>
 When resolving a placeholder for a deduced class type
 ([dcl.type.simple]) where the
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an alias template
 <code class="sourceCode cpp">A</code>, the
 <code class="sourceCode cpp"><em>defining-type-id</em></code> of
@@ -6840,10 +6875,10 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
-or <code class="sourceCode cpp">std​<span class="op">::</span>​nullptr_t</code>,
+or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 there exist candidate operator functions of the form</p>
 <div class="sourceCode" id="cb124"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">==(</span>T, T<span class="op">)</span>;</span>
 <span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a><span class="dt">bool</span> <span class="kw">operator</span><span class="op">!=(</span>T, T<span class="op">)</span>;</span></code></pre></div>
@@ -6851,58 +6886,68 @@ there exist candidate operator functions of the form</p>
 </div>
 <h3 class="unnumbered" id="temp.param-template-parameters"><span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span> Template
 parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
-<p>Extend the last sentence of paragraph 4 to disallow splicing concepts
-in template parameter declarations.</p>
+<p>Extend the grammar for
+<code class="sourceCode cpp"><em>type-constraint</em></code> to include
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">4</a></span>
-… The concept designated by a type-constraint shall be a type concept
-([temp.concept]) <span class="addu">that is not a
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>.</p>
+<div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>type-constraint</em>:</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub>&gt;</span>
+<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em></span></span></code></pre></div>
+</div>
+</blockquote>
+</div>
+<p>Add a paragraph after paragraph 3 to restrict the type splicers that
+form <code class="sourceCode cpp"><em>type-constraint</em></code>s.</p>
+<div class="std">
+<blockquote>
+<div class="addu">
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">3+</a></span>
+A non-dependent
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
+forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
+when it designates a concept. A
+<code class="sourceCode cpp"><em>type-constraint</em></code> of the form
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code> shall
+not appear in a
+<code class="sourceCode cpp"><em>type-parameter</em></code>.</p>
+</div>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.names-names-of-template-specializations"><span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span> Names of
 template specializations<a href="#temp.names-names-of-template-specializations" class="self-link"></a></h3>
-<p>Introduce
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
-and
-<code class="sourceCode cpp"><em>splice-template-argument</em></code>
-nonterminals. Extend
+<p>Extend
 <code class="sourceCode cpp"><em>simple-template-id</em></code> and
 <code class="sourceCode cpp"><em>template-argument</em></code> to
-leverage these.</p>
+leverage splicers.</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb125"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-template-id</em>:</span>
-<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a>      <em>template-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
-<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>  <em>template-id</em>:</span>
-<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a>      <em>simple-template-id</em></span>
-<span id="cb125-7"><a href="#cb125-7" aria-hidden="true" tabindex="-1"></a>      $operator-function-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb125-8"><a href="#cb125-8" aria-hidden="true" tabindex="-1"></a>      $literal-operator-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
-<span id="cb125-9"><a href="#cb125-9" aria-hidden="true" tabindex="-1"></a>  </span>
-<span id="cb125-10"><a href="#cb125-10" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
-<span id="cb125-11"><a href="#cb125-11" aria-hidden="true" tabindex="-1"></a>      identifier</span>
-<span id="cb125-12"><a href="#cb125-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-13"><a href="#cb125-13" aria-hidden="true" tabindex="-1"></a>  <em>template-argument-list</em>:</span>
-<span id="cb125-14"><a href="#cb125-14" aria-hidden="true" tabindex="-1"></a>      <em>template-argument</em> ...<sub><em>opt</em></sub></span>
-<span id="cb125-15"><a href="#cb125-15" aria-hidden="true" tabindex="-1"></a>      <em>template-argument-list</em> , <em>template-argument</em> ...<sub><em>opt</em></sub></span>
-<span id="cb125-16"><a href="#cb125-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb125-17"><a href="#cb125-17" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
-<span id="cb125-18"><a href="#cb125-18" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
-<span id="cb125-19"><a href="#cb125-19" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
-<span id="cb125-20"><a href="#cb125-20" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
-<span id="cb125-21"><a href="#cb125-21" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
-<span id="cb125-22"><a href="#cb125-22" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-template-argument</em></span></span>
-<span id="cb125-23"><a href="#cb125-23" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb125-24"><a href="#cb125-24" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-specifier</em>:</span></span>
-<span id="cb125-25"><a href="#cb125-25" aria-hidden="true" tabindex="-1"></a><span class="va">+     template <em>splice-specifier</em></span></span>
-<span id="cb125-26"><a href="#cb125-26" aria-hidden="true" tabindex="-1"></a><span class="va">+     typename template<sub><em>opt</em></sub> <em>splice-specifier</em></span></span>
-<span id="cb125-27"><a href="#cb125-27" aria-hidden="true" tabindex="-1"></a><span class="va">+</span></span>
-<span id="cb125-28"><a href="#cb125-28" aria-hidden="true" tabindex="-1"></a><span class="va">+ <em>splice-template-argument</em>:</span></span>
-<span id="cb125-29"><a href="#cb125-29" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>  <em>simple-template-id</em>:</span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>      <em>template-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-expr-template-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
+<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></span>
+<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>  <em>template-id</em>:</span>
+<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>      <em>simple-template-id</em></span>
+<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>      $operator-function-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>      $literal-operator-id &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span>
+<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a>  <em>template-name</em>:</span>
+<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a>      identifier</span>
+<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a>  <em>template-argument-list</em>:</span>
+<span id="cb126-15"><a href="#cb126-15" aria-hidden="true" tabindex="-1"></a>      <em>template-argument</em> ...<sub><em>opt</em></sub></span>
+<span id="cb126-16"><a href="#cb126-16" aria-hidden="true" tabindex="-1"></a>      <em>template-argument-list</em> , <em>template-argument</em> ...<sub><em>opt</em></sub></span>
+<span id="cb126-17"><a href="#cb126-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb126-18"><a href="#cb126-18" aria-hidden="true" tabindex="-1"></a>  <em>template-argument</em>:</span>
+<span id="cb126-19"><a href="#cb126-19" aria-hidden="true" tabindex="-1"></a>      <em>constant-expression</em></span>
+<span id="cb126-20"><a href="#cb126-20" aria-hidden="true" tabindex="-1"></a>      <em>type-id</em></span>
+<span id="cb126-21"><a href="#cb126-21" aria-hidden="true" tabindex="-1"></a>      <em>id-expression</em></span>
+<span id="cb126-22"><a href="#cb126-22" aria-hidden="true" tabindex="-1"></a>      <em>braced-init-list</em></span>
+<span id="cb126-23"><a href="#cb126-23" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -6912,7 +6957,7 @@ leverage these.</p>
 component name.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">2</a></span>
 The component name of a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>simple-template-id</em></code></span>,
 <span><code class="sourceCode default"><em>template-id</em></code></span>,
 or</del></span>
@@ -6927,50 +6972,34 @@ its <code class="sourceCode cpp"><em>simple-template-id</em></code>,
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>.</span></p>
 </blockquote>
 </div>
-<p>Add a paragraph following paragraph 2 defining the semantics of a
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</p>
-<div class="std">
-<blockquote>
-<div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">2+</a></span>
-A <code class="sourceCode cpp"><em>splice-template-specifier</em></code>
-designates the same entity designated by its
-<code class="sourceCode cpp"><em>splice-specifier</em></code>. A
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
-shall designate a concept, variable template, class template, alias
-template, or function template. A
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
-shall not designate a constructor template or destructor template.</p>
-</div>
-</blockquote>
-</div>
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows <span class="addu">either</span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(3.1)</a></span>
 a
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>,
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
+or <code class="sourceCode cpp"><em>splice-type-specifier</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -6984,20 +7013,20 @@ appear.<span> — <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div>
-<div class="sourceCode" id="cb126"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
-<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
-<span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
-<span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>};</span>
-<span id="cb126-5"><a href="#cb126-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
-<span id="cb126-6"><a href="#cb126-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
-<span id="cb126-7"><a href="#cb126-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
-<span id="cb126-8"><a href="#cb126-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
-<span id="cb126-9"><a href="#cb126-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
-<span id="cb126-10"><a href="#cb126-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb126-11"><a href="#cb126-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
-<span id="cb126-12"><a href="#cb126-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
-<span id="cb126-13"><a href="#cb126-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
-<span id="cb126-14"><a href="#cb126-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>struct X {</span>
+<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; X* alloc();</span>
+<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a>  template&lt;std::size_t&gt; static X* adjust();</span>
+<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>};</span>
+<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>template&lt;class T&gt; void f(T* p) {</span>
+<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a>  T* p1 = p-&gt;alloc&lt;200&gt;();              // error: &lt; means less than</span>
+<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a>  T* p2 = p-&gt;template alloc&lt;200&gt;();     // OK, &lt; starts template argument list</span>
+<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a>  T::adjust&lt;100&gt;();                     // error: &lt; means less than</span>
+<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a>  T::template adjust&lt;100&gt;();            // OK, &lt; starts template argument list</span>
+<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb127-11"><a href="#cb127-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ static constexpr auto r = ^T::adjust;</span></span>
+<span id="cb127-12"><a href="#cb127-12" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p3 = [:r:]&lt;200&gt;();                 // error: &lt; means less than</span></span>
+<span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a><span class="va">+ T* p4 = template [:r:]&lt;200&gt;();        // OK, &lt; starts template argument list</span></span>
+<span id="cb127-14"><a href="#cb127-14" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -7006,15 +7035,13 @@ appear.<span> — <em>end note</em> ]</span></span></p>
 <p>Extend paragraph 8 to also cover
 <code class="sourceCode cpp"><em>simple-template-id</em></code>s
 containing
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code>
-<span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
-of a <code class="sourceCode cpp"><em>simple-template-id</em></code>
-<span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a constrained non-function template or a
+<span class="addu">or splicer</span> of a
+<code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> a constrained non-function template or a
 constrained template
 <code class="sourceCode cpp"><em>template-parameter</em></code>, and all
 <code class="sourceCode cpp"><em>template-arguments</em></code> in the
@@ -7027,15 +7054,23 @@ non-dependent ([temp.dep.temp]), the associated contraints
 <p>Change paragraph 9 to allow splicing into a <em>concept-id</em>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">9</a></span>
 A <em>concept-id</em> is a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> where
 <span class="addu">either</span> the
 <code class="sourceCode cpp"><em>template-name</em></code> is a
 <code class="sourceCode cpp"><em>concept-name</em></code> <span class="addu">or the
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>
-designates a concept</span>. A concept-id is a prvalue of type bool, and
-does not name a template specialization.</p>
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
+designates a concept</span>. A concept-id is a prvalue of type
+<code class="sourceCode cpp"><span class="dt">bool</span></code>, and
+does not name a template specialization. A concept-id evaluates to
+<code class="sourceCode cpp"><span class="kw">true</span></code> if the
+concept’s normalized
+<code class="sourceCode cpp"><em>constraint-expression</em></code>
+([temp.constr.decl]) is satisfied ([temp.constr.constr]) by the
+specified template arguments and
+<code class="sourceCode cpp"><span class="kw">false</span></code>
+otherwise.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.arg.general-general"><span>13.4.1 <a href="https://wg21.link/temp.arg.general">[temp.arg.general]</a></span>
@@ -7044,33 +7079,28 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">3</a></span>
-<span class="addu">A
-<code class="sourceCode cpp"><em>template-argument</em></code> of the
-form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
-interpreted as a
-<code class="sourceCode cpp"><em>splice-template-argument</em></code>.</span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
 In a <code class="sourceCode cpp"><em>template-argument</em></code>
 <span class="addu">that is not a
-<code class="sourceCode cpp"><em>splice-template-argument</em></code></span>,
-an ambiguity between a
-<code class="sourceCode cpp"><em>type-id</em></code> and an expression
-is resolved to a <code class="sourceCode cpp"><em>type-id</em></code>,
-regardless of the form of the corresponding
+<code class="sourceCode cpp"><em>splice-specifier</em></code></span>, an
+ambiguity between a <code class="sourceCode cpp"><em>type-id</em></code>
+and an expression is resolved to a
+<code class="sourceCode cpp"><em>type-id</em></code>, regardless of the
+form of the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>.</p>
 <div class="example2">
 <span>[ <em>Example 2:</em> </span>
 <div>
-<div class="sourceCode" id="cb127"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
-<span id="cb127-2"><a href="#cb127-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
-<span id="cb127-3"><a href="#cb127-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb127-4"><a href="#cb127-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
-<span id="cb127-5"><a href="#cb127-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
-<span id="cb127-6"><a href="#cb127-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb127-7"><a href="#cb127-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
-<span id="cb127-8"><a href="#cb127-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-template-argument: calls the first f()</span></span>
-<span id="cb127-9"><a href="#cb127-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-template-argument: calls the second f()</span></span>
-<span id="cb127-10"><a href="#cb127-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>  template&lt;class T&gt; void f();</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>  template&lt;int I&gt; void f();</span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>  void g() {</span>
+<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>    f&lt;int()&gt;();       // int() is a type-id: call the first f()</span>
+<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a><span class="va">+   constexpr int x = 42;</span></span>
+<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^int:]&gt;();    // splice-specifier: calls the first f()</span></span>
+<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a><span class="va">+   f&lt;[:^x:]&gt;();      // splice-specifier: calls the second f()</span></span>
+<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a>  }</span></code></pre></div>
 </div>
 <span> — <em>end example</em> ]</span>
 </div>
@@ -7082,48 +7112,47 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
 <code class="sourceCode cpp"><em>type-id</em></code> <span class="addu">or a
-<code class="sourceCode cpp"><em>splice-template-argument</em></code>
-whose <code class="sourceCode cpp"><em>splice-specifier</em></code>
-designates a type</span>.</p>
+<code class="sourceCode cpp"><em>splice-specifier</em></code> that is
+either dependent or designates a type</span>.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="temp.arg.nontype-template-non-type-arguments"><span>13.4.3 <a href="https://wg21.link/temp.arg.nontype">[temp.arg.nontype]</a></span>
-Template non-type arguments<a href="#temp.arg.nontype-template-non-type-arguments" class="self-link"></a></h3>
-<p>TODO: splice-specifier shall designate a value or something.</p>
 <h3 class="unnumbered" id="temp.arg.template-template-template-arguments"><span>13.4.4 <a href="https://wg21.link/temp.arg.template">[temp.arg.template]</a></span>
 Template template arguments<a href="#temp.arg.template-template-template-arguments" class="self-link"></a></h3>
 <p>Extend <span>13.4.4 <a href="https://wg21.link/temp.arg.template">[temp.arg.template]</a></span>/1
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
-shall be the name of a class template or an alias template, expressed as
-<code class="sourceCode cpp"><em>id-expression</em></code><span class="addu">, or a
-<code class="sourceCode cpp"><em>splice-template-argument</em></code>
-whose <code class="sourceCode cpp"><em>splice-specifier</em></code>
-designates a template</span>.</p>
+shall be <span class="rm" style="color: #bf0303"><del>the name
+of</del></span> a class template or an alias template, expressed as
+<span class="addu">an</span>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or a (possibly dependent) splicer</span>. Only primary
+templates are considered when matching the template argument with the
+corresponding parameter; partial specializations are not considered even
+if their parameter lists match that of the template template
+parameter.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="temp.type-type-equivalence"><span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span> Type
 equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <p>Extend <code class="sourceCode cpp"><em>template-id</em></code>
-equivalence as defined by paragraph 1 to cover
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s.</p>
+equivalence as defined by paragraph 1 to cover splicers.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s are the
 same if</p>
 <ul>
 <li>their <code class="sourceCode cpp"><em>template-name</em></code>s,
-<span class="addu"><code class="sourceCode cpp"><em>splice-template-specifier</em></code>s,</span>
+<span class="addu"><code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>s,
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s,</span>
 <code class="sourceCode cpp"><em>operator-function-id</em></code>s, or
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>s refer
 to the same template, and</li>
@@ -7144,23 +7173,23 @@ are the same refer to the same class, function, or variable.</p>
 <p>Extend <em>template-argument-equivalent</em> to handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
-and they compare equal, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(2.4)</a></span>
+and their values are the same, or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7168,14 +7197,14 @@ they are of enumeration type and their values are the same, or</li>
 <h3 class="unnumbered" id="temp.deduct.guide-deduction-guides"><span>13.7.2.3 <a href="https://wg21.link/temp.deduct.guide">[temp.deduct.guide]</a></span>
 Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link"></a></h3>
 <p>Extend paragraph 1 to clarify that
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s
-can also leverage deduction guides.</p>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s can
+also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code></span>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 appears as a type specifier for a deduced class type
 ([dcl.type.class.deduct]). Deduction guides are not found by name
 lookup. Instead, when performing class template argument deduction
@@ -7184,11 +7213,11 @@ the class template are considered.</p>
 </blockquote>
 </div>
 <p>Notwithstanding the above, extend paragraph 3 to clarify that
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s
 cannot themselves appear in deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">3</a></span>
 The same restrictions apply to the
 <code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
 of a deduction guide as in a function declaration ([dcl.fct]), except
@@ -7218,7 +7247,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When</del></span> <span class="addu">Except when used as the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>,</span>
 a <code class="sourceCode cpp"><em>template-id</em></code> <span class="rm" style="color: #bf0303"><del>refers</del></span> <span class="addu">referring</span> to a specialization of an alias
@@ -7230,50 +7259,28 @@ is equivalent to the associated type obtained by substitution of its
 alias template.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="temp.concept-concept-definitions"><span>13.7.9 <a href="https://wg21.link/temp.concept">[temp.concept]</a></span> Concept
-definitions<a href="#temp.concept-concept-definitions" class="self-link"></a></h3>
-<p>Extend the grammar of
-<code class="sourceCode cpp"><em>concept-name</em></code> to allow for
-splicing reflections of concepts:</p>
-<div class="std">
-<blockquote>
-<div>
-<div class="sourceCode" id="cb128"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a>  <em>concept-name</em>:</span>
-<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a>    <em>identifier</em></span>
-<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   <em>splice-template-specifier</em></span></span></code></pre></div>
-</div>
-</blockquote>
-</div>
-<p>Modify paragraph 2 to account for splicing reflections of
-concepts:</p>
-<div class="std">
-<blockquote>
-<p>A <code class="sourceCode cpp"><em>concept-definition</em></code>
-declares a concept. Its <span class="addu"><code class="sourceCode cpp"><em>concept-name</em></code>
-shall be an <code class="sourceCode cpp"><em>identifier</em></code>, and
-the</span> <code class="sourceCode cpp"><em>identifier</em></code>
-becomes a <em>concept-name</em> referring to that concept within its
-scope. The optional <em>attribute-specifier-seq</em> appertains to the
-concept.</p>
-</blockquote>
-</div>
 <h3 class="unnumbered" id="temp.res.general-general"><span>13.8.1 <a href="https://wg21.link/temp.res.general">[temp.res.general]</a></span>
 General<a href="#temp.res.general-general" class="self-link"></a></h3>
 <p>Disallow
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>s
-from appearing in
-<code class="sourceCode cpp"><em>typename-specifier</em></code>s.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">3</a></span>
+<code class="sourceCode cpp"><em>splice-type-specifier</em></code>s from
+appearing in
+<code class="sourceCode cpp"><em>typename-specifier</em></code>s, since
+splicers can’t follow
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code>s.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">3</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>typename-specifier</em></code> are its
 <code class="sourceCode cpp"><em>identifier</em></code> (if any) and
 those of its
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> and
 <code class="sourceCode cpp"><em>simple-template-id</em></code> (if
-any). The
+any). <span class="addu">The
 <code class="sourceCode cpp"><em>simple-template-id</em></code> shall
-not contain a
-<code class="sourceCode cpp"><em>splice-template-specifier</em></code>.</p>
+not contain a splicer.</span></p>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="temp.dep.expr-type-dependent-expressions"><span>13.8.3.3 <a href="https://wg21.link/temp.dep.expr">[temp.dep.expr]</a></span>
 Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" class="self-link"></a></h3>
 <p>Add to the list of never-type-dependent expression forms in
@@ -7301,16 +7308,23 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
-<code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
-is type-dependent if the
-<code class="sourceCode cpp"><em>splice-specifier</em></code> is
-value-dependent or if the optional
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
+is type-dependent if</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(9.1)</a></span>
+the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
+is dependent, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(9.2)</a></span>
+the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
-contains a value-dependent non-type or template argument, or a dependent
-type argument.</p>
+contains a dependent type argument, a value-dependent non-type argument,
+a dependent template template argument, or a dependent
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.</li>
+</ul>
 </div>
 </blockquote>
 </div>
@@ -7320,10 +7334,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -7337,28 +7351,33 @@ the <em>type-id</em> is dependent:</p>
 <span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>noexcept ( expression )</span></code></pre></div>
 <p><span class="addu">A
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
-value-dependent if the operand of the reflection operator is a
-type-dependent or value-dependent expression or if that operand is a
-dependent <code class="sourceCode cpp"><em>type-id</em></code>, a
-dependent <code class="sourceCode cpp"><em>namespace-name</em></code>,
-or a dependent
-<code class="sourceCode cpp"><em>template-name</em></code>.</span></p>
+value-dependent if the operand following
+<code class="sourceCode cpp"><span class="op">^</span></code> is a
+dependent name, names a dependent type, or contains a dependent
+<code class="sourceCode cpp"><em>pack-index-expression</em></code>.</span></p>
 </blockquote>
 </div>
-<p>Add a new paragraph after <span>13.8.3.4 <a href="https://wg21.link/temp.dep.constexpr">[temp.dep.constexpr]</a></span>/4:</p>
+<p>Add a new paragraph after <span>13.8.3.4 <a href="https://wg21.link/temp.dep.constexpr">[temp.dep.constexpr]</a></span>/5:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
-<code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em>  <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
-is value-dependent if the
-<code class="sourceCode cpp"><em>constant-expression</em></code> is
-value-dependent or if the optional
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
+is value-dependent if</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.1)</a></span>
+the <code class="sourceCode cpp"><em>splice-specifier</em></code> or
+<code class="sourceCode cpp"><em>splice-expr-template-specifier</em></code>
+is dependent, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(6.2)</a></span>
+the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
-contains a value-dependent non-type or template argument, or a dependent
-type argument.</p>
+contains a dependent type argument, a value-dependent non-type argument,
+a dependent template template argument, or a dependent
+<code class="sourceCode cpp"><em>splice-specifier</em></code>.</li>
+</ul>
 </div>
 </blockquote>
 </div>
@@ -7370,7 +7389,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -7388,19 +7407,19 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const])</li>
 </ul>
@@ -7413,7 +7432,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -7421,7 +7440,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -7430,14 +7449,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not produce reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -7883,7 +7902,7 @@ synopsis</strong></p>
 <span id="cb135-345"><a href="#cb135-345" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb135-346"><a href="#cb135-346" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb135-347"><a href="#cb135-347" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
@@ -7899,7 +7918,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -8152,10 +8171,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -8163,11 +8182,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb138"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -8182,33 +8201,33 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb139"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed entity,
 then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a constructor
 template, operator function template, or conversion function
 template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><em>typedef-name</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
 the <code class="sourceCode cpp"><em>typedef-name</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -8217,23 +8236,24 @@ for linkage purposes ([dcl.typedef]) or the
 <code class="sourceCode cpp"><em>class-name</em></code> introduced by
 the declaration of <code class="sourceCode cpp"><em>C</em></code> is an
 identifier.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> does not represent a variable
 template specialization.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
-namespace, or namespace alias, then
+namespace, or
+<code class="sourceCode cpp"><em>namespace-alias</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(1.9)</a></span>
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8242,43 +8262,44 @@ that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(1.10)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb140"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, <code class="sourceCode cpp"><em>typedef-name</em></code>, or
-namespace alias, then the identifier introduced by the declaration of
-what is represented by <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(4.4)</a></span>
+<code class="sourceCode cpp"><em>namespace-alias</em></code>, then the
+identifier introduced by the declaration of what is represented by
+<code class="sourceCode cpp">r</code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then the identifier introduced by the declaration of
 the type of the base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(4.5)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
@@ -8290,21 +8311,21 @@ encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a description of a
 declaration of a non-static data member, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or base specifier that was introduced by a
 declaration, implementations should return a value corresponding to a
@@ -8322,7 +8343,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb143"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-2"><a href="#cb143-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb143-3"><a href="#cb143-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or base
@@ -8330,7 +8351,7 @@ class specifier that is public, protected, or private, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -8338,7 +8359,7 @@ function or a virtual base class specifier. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb145"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8346,7 +8367,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb146"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb146-1"><a href="#cb146-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -8354,7 +8375,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb147"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb147-1"><a href="#cb147-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb147-2"><a href="#cb147-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8363,7 +8384,7 @@ defined as deleted ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -8371,7 +8392,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb149"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -8386,7 +8407,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8404,7 +8425,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -8414,7 +8435,7 @@ declared with the properties represented by
 <code class="sourceCode cpp">r</code> would be a bit-field. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -8422,7 +8443,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -8431,7 +8452,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -8440,7 +8461,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -8450,7 +8471,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -8461,7 +8482,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb157-2"><a href="#cb157-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-3"><a href="#cb157-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb157-4"><a href="#cb157-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -8470,13 +8491,13 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">16</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -8486,13 +8507,13 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">19</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -8501,20 +8522,20 @@ that no entities not already declared may be introduced within the scope
 of <code class="sourceCode cpp"><em>E</em></code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
-namespace alias. Otherwise,
+<code class="sourceCode cpp"><em>namespace-alias</em></code>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type or a
@@ -8522,18 +8543,19 @@ namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
-<code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
-alias, respectively <span class="note"><span>[ <em>Note 3:</em>
-</span>An instantiation of an alias template is a
+<code class="sourceCode cpp"><em>typedef-name</em></code> or
+<code class="sourceCode cpp"><em>namespace-alias</em></code>,
+respectively <span class="note"><span>[ <em>Note 3:</em> </span>An
+instantiation of an alias template is a
 <code class="sourceCode cpp"><em>typedef-name</em></code><span>
 — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -8541,7 +8563,7 @@ alias, respectively <span class="note"><span>[ <em>Note 3:</em>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb165-3"><a href="#cb165-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -8556,7 +8578,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb166-7"><a href="#cb166-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-8"><a href="#cb166-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-9"><a href="#cb166-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -8566,14 +8588,14 @@ assignment operator, a move assignment operator, or a prospective
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">28</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -8590,7 +8612,7 @@ is
 <span id="cb168-7"><a href="#cb168-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-8"><a href="#cb168-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-9"><a href="#cb168-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -8599,7 +8621,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -8608,14 +8630,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -8626,7 +8648,7 @@ Otherwise,
 <span id="cb172-3"><a href="#cb172-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-4"><a href="#cb172-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb172-5"><a href="#cb172-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -8634,20 +8656,20 @@ namespace member, non-static data member, static member, base class
 specifier, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, base class
 specifier, or description of a declaration of a non-static data
 member.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then the type of what is represented by
 <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -8656,11 +8678,11 @@ then the type of the base class. Otherwise, the type of any data member
 declared with the properties represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">38</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -8676,33 +8698,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(39.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(39.1)</a></span>
 either an object or variable, usable in constant expressions from a
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(39.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(39.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">(39.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(39.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">40</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(40.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(40.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">(40.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(40.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">(40.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">(40.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -8718,24 +8740,26 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb179"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">41</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
-member, bit-field, template, namespace or namespace alias (other than
+member, bit-field, template, namespace or
+<code class="sourceCode cpp"><em>namespace-alias</em></code> (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>),
 <code class="sourceCode cpp"><em>typedef-name</em></code>, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">42</a></span>
 <em>Returns</em>: A reflection of the class, function, or namespace that
 is the target scope ([basic.scope.scope]) of the first declaration of
 what is represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">43</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
-<code class="sourceCode cpp"><em>typedef-name</em></code> or namespace
-alias <em>A</em>, then a reflection representing the entity named by
-<em>A</em>. Otherwise, <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">44</a></span></p>
+<code class="sourceCode cpp"><em>typedef-name</em></code> or
+<code class="sourceCode cpp"><em>namespace-alias</em></code> <em>A</em>,
+then a reflection representing the entity named by <em>A</em>.
+Otherwise, <code class="sourceCode cpp">r</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">44</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb181"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb181-1"><a href="#cb181-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -8747,15 +8771,15 @@ alias <em>A</em>, then a reflection representing the entity named by
 </div>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">46</a></span>
 <em>Returns</em>: A reflection of the template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb183"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -8777,11 +8801,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a namespace or a class type that is
 complete from some point in the evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -8794,13 +8818,13 @@ template, alias template, or concept,</li>
 <li>a function whose constraints (if any) are satisfied,</li>
 <li>a non-static data member,</li>
 <li>a namespace, or</li>
-<li>a namespace alias.</li>
+<li>a <code class="sourceCode cpp"><em>namespace-alias</em></code>.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Counterexamples of
 representable members include: injected class names, partial template
 specializations, friend declarations, and static assertions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-visible</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -8811,11 +8835,11 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">4</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a class template specialization with a definition reachable
 from the evaluation context, the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -8829,14 +8853,14 @@ unnamed bit-fields are indexed in the order in which they are declared,
 but the order of namespace members is unspecified. <span class="note"><span>[ <em>Note 2:</em> </span>Base classes are not
 members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">7</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">8</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -8846,92 +8870,92 @@ indexed in the order in which they appear in the
 <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">10</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct static data members of the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">13</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of the direct non-static data members of the
 type represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">18</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">19</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">20</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">21</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">22</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">23</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">24</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">25</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">26</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">27</a></span>
 <em>Effects</em>: If <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class template specialization with a reachable definition,
 the specialization is instantiated.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">28</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element, <code class="sourceCode cpp">e</code>, of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -8946,32 +8970,32 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or base class
 specifier.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be a constant defined
 as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a virtual base class
 specifier of an abstract class, then
 <code class="sourceCode cpp"><em>V</em></code> is an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>V</em></code> is the offset
 in bits from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -8980,7 +9004,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a description of a
@@ -8993,7 +9017,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing a type, object, variable, non-static data member
 that is not a bit-field, base class specifier, or description of a
@@ -9002,20 +9026,20 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(8.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a type, variable, or
 object, then the alignment requirement of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a base
 class specifier, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(8.4)</a></span>
 Otherwise (when <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> of any
@@ -9023,7 +9047,7 @@ data member declared having the properties described by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection of a type, object, value, variable of non-reference type,
 non-static data member, base class specifier, or description of a
@@ -9032,7 +9056,7 @@ declaration of a non-static data member. If
 <code class="sourceCode cpp"><em>T</em></code>, there is a point within
 the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field, or a description of a
 declaration of such a bit-field data member, then the width of the
@@ -9045,32 +9069,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from a point in the evaluation context
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -9078,7 +9102,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -9086,7 +9110,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -9094,52 +9118,52 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">7</a></span>
 <em>Returns</em>: a pointer value designating the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 enumerator that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">10</a></span>
 <em>Returns</em>: the value or enumerator
 <code class="sourceCode cpp"><em>V</em></code> represented by
 <code class="sourceCode cpp">r</code>, converted to
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -9157,36 +9181,36 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb202-5"><a href="#cb202-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb203-2"><a href="#cb203-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, variables, or aliases represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
 </div>
 </blockquote>
@@ -9198,32 +9222,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, shall be the address of or refer to an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -9231,37 +9255,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or entity that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -9274,18 +9298,18 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">1</a></span>
 The class <code class="sourceCode cpp">data_member_options_t</code> is a
 consteval-only type ([basic.types.general]), and is not a structural
 type ([temp.param]).</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -9306,71 +9330,71 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(1.1)</a></span>
 <code class="sourceCode cpp">type</code> represents either a type
 <code class="sourceCode cpp">cv <em>T</em></code>, or a
 <code class="sourceCode cpp"><em>typedef-name</em></code> designating a
 type <code class="sourceCode cpp">cv <em>T</em></code>, where
 <code class="sourceCode cpp"><em>T</em></code> is either an object type
 or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(1.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(1.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(1.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(1.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">(1.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(1.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_field</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(1.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 the alignment requirement of
 <code class="sourceCode cpp"><em>T</em></code>; and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(1.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(1.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(1.5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> represents an integral or
 enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(1.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(1.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(1.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(1.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(1.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(1.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">2</a></span>
 <em>Returns</em>: A reflection of a description of a declaration of a
 non-static data member declared with the type or <code class="sourceCode cpp"><span class="kw">typedef</span><span class="op">-</span>name</code>
 represented by <code class="sourceCode cpp">type</code>, and having the
 optional characteristics designated by
 <code class="sourceCode cpp">options</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">3</a></span>
 <em>Remarks</em>: The returned reflection value is primarily useful in
 conjunction with <code class="sourceCode cpp">define_aggregate</code>.
 Certain other functions in
@@ -9380,7 +9404,7 @@ Certain other functions in
 query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a description of a
@@ -9388,7 +9412,7 @@ declaration of a non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">5</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -9396,7 +9420,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -9413,18 +9437,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">(5.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(5.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(5.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -9438,7 +9462,7 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">6</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -9450,26 +9474,26 @@ that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">7</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(7.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(7.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(7.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(7.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -9482,29 +9506,29 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(7.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or <code class="sourceCode cpp"><em>typedef-name</em></code>
 represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(7.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(7.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">(7.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(7.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(7.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(7.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">(7.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(7.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -9516,18 +9540,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(7.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(7.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(7.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(7.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -9537,10 +9561,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -9561,7 +9585,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9583,7 +9607,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb215-13"><a href="#cb215-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb215-14"><a href="#cb215-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb215-15"><a href="#cb215-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb216"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -9609,7 +9633,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
@@ -9631,7 +9655,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
@@ -9641,7 +9665,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9652,7 +9676,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9738,12 +9762,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -9755,10 +9779,10 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9767,7 +9791,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^</span>T, <span class="op">^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9779,7 +9803,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">4</a></span>
 For any types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T</code> and
@@ -9808,7 +9832,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb221-14"><a href="#cb221-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb221-15"><a href="#cb221-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -9830,7 +9854,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -9842,7 +9866,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9863,7 +9887,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9881,7 +9905,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9898,7 +9922,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9915,7 +9939,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
@@ -9942,7 +9966,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
@@ -9950,7 +9974,7 @@ defined in this clause with signature <code class="sourceCode cpp">std<span clas
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">2</a></span>
 For any pack of types or
 <code class="sourceCode cpp"><em>typedef-names</em></code>
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
@@ -9960,7 +9984,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">3</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, pack of types or
@@ -9982,7 +10006,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb227-9"><a href="#cb227-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb227-10"><a href="#cb227-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb227-11"><a href="#cb227-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -10004,7 +10028,7 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">1</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -10012,7 +10036,7 @@ defined in this clause with the signature <code class="sourceCode cpp"><span cla
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">2</a></span>
 For any type or
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 <code class="sourceCode cpp">T</code> and value
@@ -10036,7 +10060,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -10044,27 +10068,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -969,9 +969,13 @@ to <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</s
 <code class="sourceCode cpp">reflect_invoke</code></li>
 <li>clarified that <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span> <span class="op">==</span></code>sizeof(void
 *)`</li>
+<li>rename <code class="sourceCode cpp">data_member_options_t</code> to
+<code class="sourceCode cpp">data_member_options</code>, as per LEWG
+feedback</li>
 <li>clarified that
-<code class="sourceCode cpp">data_member_options_t</code> is a
-non-structural consteval-only type</li>
+<code class="sourceCode cpp">data_member_options</code> and
+<code class="sourceCode cpp">name_type</code> are non-structural
+consteval-only types</li>
 <li>clarified that everything in
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 addressable</li>
@@ -4076,9 +4080,9 @@ be explained below.</p>
 <span id="cb76-128"><a href="#cb76-128" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span> <span class="op">-&gt;</span> <span class="dt">bool</span>;</span>
 <span id="cb76-129"><a href="#cb76-129" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb76-130"><a href="#cb76-130" aria-hidden="true" tabindex="-1"></a>  <span class="co">// <a href="#data_member_spec-define_aggregate">define_aggregate</a></span></span>
-<span id="cb76-131"><a href="#cb76-131" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> data_member_options_t;</span>
+<span id="cb76-131"><a href="#cb76-131" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> data_member_options;</span>
 <span id="cb76-132"><a href="#cb76-132" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> data_member_spec<span class="op">(</span>info type_class,</span>
-<span id="cb76-133"><a href="#cb76-133" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options <span class="op">=</span> <span class="op">{})</span> <span class="op">-&gt;</span> info;</span>
+<span id="cb76-133"><a href="#cb76-133" aria-hidden="true" tabindex="-1"></a>                                  data_member_options options <span class="op">=</span> <span class="op">{})</span> <span class="op">-&gt;</span> info;</span>
 <span id="cb76-134"><a href="#cb76-134" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb76-135"><a href="#cb76-135" aria-hidden="true" tabindex="-1"></a>    <span class="kw">consteval</span> <span class="kw">auto</span> define_aggregate<span class="op">(</span>info type_class, R<span class="op">&amp;&amp;)</span> <span class="op">-&gt;</span> info;</span>
 <span id="cb76-136"><a href="#cb76-136" aria-hidden="true" tabindex="-1"></a></span>
@@ -4445,7 +4449,7 @@ its operand.</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb94"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb94-1"><a href="#cb94-1" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> std<span class="op">::</span>meta <span class="op">{</span></span>
-<span id="cb94-2"><a href="#cb94-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> data_member_options_t <span class="op">{</span></span>
+<span id="cb94-2"><a href="#cb94-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> data_member_options <span class="op">{</span></span>
 <span id="cb94-3"><a href="#cb94-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">struct</span> name_type <span class="op">{</span></span>
 <span id="cb94-4"><a href="#cb94-4" aria-hidden="true" tabindex="-1"></a>      <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb94-5"><a href="#cb94-5" aria-hidden="true" tabindex="-1"></a>        <span class="kw">consteval</span> name_type<span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
@@ -4460,7 +4464,7 @@ its operand.</p>
 <span id="cb94-14"><a href="#cb94-14" aria-hidden="true" tabindex="-1"></a>    <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
 <span id="cb94-15"><a href="#cb94-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
 <span id="cb94-16"><a href="#cb94-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb94-17"><a href="#cb94-17" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options <span class="op">=</span> <span class="op">{})</span> <span class="op">-&gt;</span> info;</span>
+<span id="cb94-17"><a href="#cb94-17" aria-hidden="true" tabindex="-1"></a>                                  data_member_options options <span class="op">=</span> <span class="op">{})</span> <span class="op">-&gt;</span> info;</span>
 <span id="cb94-18"><a href="#cb94-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb94-19"><a href="#cb94-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="kw">auto</span> define_aggregate<span class="op">(</span>info type_class, R<span class="op">&amp;&amp;)</span> <span class="op">-&gt;</span> info;</span>
 <span id="cb94-20"><a href="#cb94-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
@@ -7891,7 +7895,7 @@ synopsis</strong></p>
 <span id="cb137-163"><a href="#cb137-163" aria-hidden="true" tabindex="-1"></a>    consteval info reflect_function(T&amp; fn);</span>
 <span id="cb137-164"><a href="#cb137-164" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb137-165"><a href="#cb137-165" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.define.aggregate], class definition generation</span>
-<span id="cb137-166"><a href="#cb137-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options_t {</span>
+<span id="cb137-166"><a href="#cb137-166" aria-hidden="true" tabindex="-1"></a>  struct data_member_options {</span>
 <span id="cb137-167"><a href="#cb137-167" aria-hidden="true" tabindex="-1"></a>    struct name_type {</span>
 <span id="cb137-168"><a href="#cb137-168" aria-hidden="true" tabindex="-1"></a>      template&lt;class T&gt; requires constructible_from&lt;u8string, T&gt;</span>
 <span id="cb137-169"><a href="#cb137-169" aria-hidden="true" tabindex="-1"></a>        consteval name_type(T &amp;&amp;);</span>
@@ -7908,7 +7912,7 @@ synopsis</strong></p>
 <span id="cb137-180"><a href="#cb137-180" aria-hidden="true" tabindex="-1"></a>    bool no_unique_address = false;</span>
 <span id="cb137-181"><a href="#cb137-181" aria-hidden="true" tabindex="-1"></a>  };</span>
 <span id="cb137-182"><a href="#cb137-182" aria-hidden="true" tabindex="-1"></a>  consteval info data_member_spec(info type,</span>
-<span id="cb137-183"><a href="#cb137-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options_t options = {});</span>
+<span id="cb137-183"><a href="#cb137-183" aria-hidden="true" tabindex="-1"></a>                                  data_member_options options = {});</span>
 <span id="cb137-184"><a href="#cb137-184" aria-hidden="true" tabindex="-1"></a>  consteval bool is_data_member_spec(info r);</span>
 <span id="cb137-185"><a href="#cb137-185" aria-hidden="true" tabindex="-1"></a>  template &lt;reflection_range R = initializer_list&lt;info&gt;&gt;</span>
 <span id="cb137-186"><a href="#cb137-186" aria-hidden="true" tabindex="-1"></a>  consteval info define_aggregate(info type_class, R&amp;&amp;);</span>
@@ -8436,8 +8440,8 @@ class specifier, then
 Otherwise if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member, then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
-<code class="sourceCode cpp">data_member_options_t</code> value such
-that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">)</span>, <em>o</em><span class="op">)</span> <span class="op">==</span> <em>r</em></code>,
+<code class="sourceCode cpp">data_member_options</code> value such that
+<code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">)</span>, <em>o</em><span class="op">)</span> <span class="op">==</span> <em>r</em></code>,
 then <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name</code>
 contains a value.</li>
@@ -8482,8 +8486,8 @@ the type of the base class.</li>
 Otherwise (if <code class="sourceCode cpp">r</code> represents a
 description of a declaration of a non-static data member), then letting
 <code class="sourceCode cpp"><em>o</em></code> be a
-<code class="sourceCode cpp">data_member_options_t</code> value such
-that <code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">)</span>, <em>o</em><span class="op">)</span> <span class="op">==</span> <em>r</em></code>,
+<code class="sourceCode cpp">data_member_options</code> value such that
+<code class="sourceCode cpp">data_member_spec<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">)</span>, <em>o</em><span class="op">)</span> <span class="op">==</span> <em>r</em></code>,
 then the <code class="sourceCode cpp">string</code> or
 <code class="sourceCode cpp">u8string</code> contents of <code class="sourceCode cpp"><em>o</em><span class="op">.</span>name<span class="op">.</span><em>contents</em></code>
 encoded with <code class="sourceCode cpp"><em>E</em></code>.</li>
@@ -9478,16 +9482,17 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <blockquote>
 <div class="addu">
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">1</a></span>
-The class <code class="sourceCode cpp">data_member_options_t</code> is a
-consteval-only type ([basic.types.general]), and is not a structural
-type ([temp.param]).</p>
+The classes <code class="sourceCode cpp">data_member_options</code> and
+<code class="sourceCode cpp">name_type</code> are consteval-only types
+([basic.types.general]), and are not a structural types
+([temp.param]).</p>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options_t<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
@@ -9508,7 +9513,7 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 <span> — <em>end note</em> ]</span>
 </div>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options_t options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options <span class="op">=</span> <span class="op">{})</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
 <em>Constant When</em>:</p>
 <ul>
@@ -9646,9 +9651,8 @@ Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
 {<code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub>k</sub></code>}
-be a sequence of
-<code class="sourceCode cpp">data_member_options_t</code> values such
-that</p>
+be a sequence of <code class="sourceCode cpp">data_member_options</code>
+values such that</p>
 <div class="sourceCode" id="cb216"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a>data_member_spec(<span class="math inline"><em>t</em></span><sub><span class="math inline"><em>k</em></span></sub>, <span class="math inline"><em>o</em></span><sub><span class="math inline"><em>k</em></span></sub>) == <span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></span></code></pre></div>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -143,7 +143,7 @@ Specifically, we are mostly proposing a subset of features suggested in [@P1240R
 
   - the representation of program elements via constant-expressions producing
      _reflection values_ — _reflections_ for short — of an opaque type `std::meta::info`,
-  - a _reflection operator_ (prefix `^`) that produces a reflection value for its operand construct,
+  - a _reflection operator_ (prefix `^`) that computes a reflection value for its operand construct,
   - a number of `consteval` _metafunctions_ to work with reflections (including deriving other reflections), and
   - constructs called _splicers_ to produce grammatical elements from reflections (e.g., `[: $refl$ :]`).
 
@@ -3214,10 +3214,10 @@ template <auto Var, auto Cls, auto TVar, auto TCls, auto Concept>
 void dependent() {
   [:Var:] *var;                      // OK, multiplication of 'var * var'
 
-  typename [:Cls:] *a;               // OK, declaration of 'cls *var'
+  typename [:Cls:] *a;               // OK, declaration of 'cls *a'
   template [:TVar:]<0> *var;         // OK, multiplication of 't_var<0> * var'
   template [:TCls:]<0> *var;         // error: cannot splice type as expression
-  typename [:TCls:]<0> *b;           // OK, declaration of 't_cls<0> *var'
+  typename [:TCls:]<0> *b;           // OK, declaration of 't_cls<0> *b'
   template typename [:TCls:]<0> *c;  // OK
 
   template [:Concept:] auto *d = 0;  // OK, deduced placeholder type
@@ -3443,7 +3443,7 @@ Add a new subsection of [expr.unary]{.sref} following [expr.delete]{.sref}
 
 ::: std
 ::: addu
-**The Reflection Operator   [expr.reflect]**
+**The reflection operator   [expr.reflect]**
 
 [The following grammar avoids use of `$id-expression$`, even though any operand to an `$id-expression$` can be an operand to a `$reflect-expression$`. The reason is that the operand of a `$reflect-expression$` is not necessarily an expression, as it could name a namespace, class template, type, etc.]{.ednote}
 
@@ -3481,11 +3481,11 @@ consteval void g(std::meta::info r, X<false> xv) {
 ```
 :::
 
-[#]{.pnum} A `$reflect-expression$` having the form `^ ::` produces a reflection of the global namespace.
+[#]{.pnum} A `$reflect-expression$` having the form `^ ::` computes a reflection of the global namespace.
 
-[#]{.pnum} A `$reflect-expression$` having the form `^ $unqualified-id$` or `^ $qualified-id$` performs name lookup for the operand following `^` and produces a result as follows:
+[#]{.pnum} A `$reflect-expression$` having the form `^ $unqualified-id$` or `^ $qualified-id$` performs name lookup for the operand following `^` and computes a result as follows:
 
-* [#.#]{.pnum} If the lookup finds an overload set `$S$` such that the assignment of `&$S$` to an invented variable of type `const auto` ([dcl.type.auto.deduct]{.sref}) would select a unique candidate function `$F$` from `$S$`, then the result is a reflection of `$F$`. If the lookup finds any other overload set, the program is ill-formed.
+* [#.#]{.pnum} If the lookup finds an overload set `$S$` such that the initialization of an invented variable of type `const auto` ([dcl.type.auto.deduct]{.sref}) with `&$S$` would select a unique candidate function `$F$` from `$S$`, then the result is a reflection of `$F$`. If the lookup finds any other overload set, the program is ill-formed.
 
 * [#.#]{.pnum} Otherwise, if the lookup finds a `$typedef-name$` or a `$namespace-alias$`, then the result is a reflection of the indicated name.
 
@@ -3493,13 +3493,13 @@ consteval void g(std::meta::info r, X<false> xv) {
 
 * [#.#]{.pnum} Otherwise, if the lookup finds a variable, structured binding, function, enumerator, type, non-static member, template, or namespace, then the result is a reflection of the denoted entity.
 
-* [#.#]{.pnum} Otherwise, if the lookup finds an implementation-defined construct not otherwise specified by this document, then the implementation may produce a reflection of the denoted construct.
+* [#.#]{.pnum} Otherwise, if the lookup finds an implementation-defined construct not otherwise specified by this document, then the implementation may compute a reflection of the denoted construct.
 
 * [#.#]{.pnum} Otherwise, the program is ill-formed.
 
-[#]{.pnum} A `$reflect-expression$` of the form `^ $type-id$` produces a reflection of the denoted type. A `$reflect-expression$` that could be validly interpreted as either `^ $unqualified-id$` or `^ $type-id$` is interpreted as `^ $unqualified-id$`, and a `$reflect-expression$` that could be validly interpreted as `^ $qualified-id$` or `^ $type-id$` is interpreted as `^ $qualified-id$`.
+[#]{.pnum} A `$reflect-expression$` of the form `^ $type-id$` computes a reflection of the denoted type. A `$reflect-expression$` that could be validly interpreted as either `^ $unqualified-id$` or `^ $type-id$` is interpreted as `^ $unqualified-id$`, and a `$reflect-expression$` that could be validly interpreted as `^ $qualified-id$` or `^ $type-id$` is interpreted as `^ $qualified-id$`.
 
-[#]{.pnum} A `$reflect-expression$` having the form `^ $pack-index-expression$` produces a reflection of the result computed by the `$pack-index-expression$`.
+[#]{.pnum} A `$reflect-expression$` having the form `^ $pack-index-expression$` computes a reflection of the result computed by the `$pack-index-expression$`.
 
 ::: example
 ```cpp
@@ -4454,7 +4454,7 @@ Unless F is designated an *addressable function*, the behavior of a C++ program 
 [6a]{.pnum}
 Let F denote a standard library function, member function, or function template.
 If F does not designate an addressable function, it is unspecified if or how a reflection value designating the associated entity can be formed.
-[For example, `std::meta::members_of` might not produce reflections of standard functions that an implementation handles through an extra-linguistic mechanism.]{.note}
+[For example, `std::meta::members_of` might not return reflections of standard functions that an implementation handles through an extra-linguistic mechanism.]{.note}
 
 [6b]{.pnum}
 Let `C` denote a standard library class or class template specialization. It is unspecified if or how a reflection value can be formed to any private member of `C`, or what the names of such members may be.

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3595,12 +3595,18 @@ template <auto> struct RV {};
 // instantiations of 'T::f(0)' are not plainly constant-evaluated
 template <class T> RV<T::f(0)> check(int);
 
-consteval bool cfn(int) { return true; }
+consteval int cfn(int) { return 1; }
 
-constexpr bool b1 = cfn(1);  // 'cfn(1)' is plainly constant-evaluated.
-const bool b2 = cfn(2);      // 'cfn(2)' is not plainly constant-evaluated.
+constexpr int b1 = cfn(1);            // 'cfn(1)' is plainly constant-evaluated
+constinit int b2 = cfn(2);            // 'cfn(2)' is plainly constant-evaluated
+const int b3 = cfn(3);                // 'cfn(3)' is not plainly constant-evaluated
 
-static_assert(b1);           // 'b1' is plainly constant-evaluated.
+static_assert(b1 > 0);                // 'b1 > 0' is plainly constant-evaluated
+
+struct Cls {
+  static constexpr int var = cfn(4);  // 'cfn(4)' is plainly constant-evaluated
+  int arr[cfn(5)];                    // 'cfn(5)' is not plainly constant-evaluated
+};
 ```
 :::
 

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3631,18 +3631,64 @@ constexpr bool b4 = [] {
 :::
 :::
 
+### [dcl.typedef]{.sref} The `typedef` specifier {-}
+
+Account for `$splice-template-speciifer$`s in paragraph 3.
+
+::: std
+[3]{.pnum} A `$simple-template-id$` is only a `$typedef-name$` if its `$template-name$` [or `$splice-template-specifier$` designate]{.addu} [names]{.rm} an alias template or a template `$template-parameter$`.
+
+:::
 
 ### [dcl.type.simple]{.sref} Simple type specifiers {-}
 
-Extend the grammar for `$computed-type-specifier$` as follows:
+Extend the grammar for `$simple-type-specifier$` and `$computed-type-specifier$` as follows:
 
 ::: std
 ```diff
+  $simple-type-specifier$:
+    $nested-name-specifier$@~_opt_~@ $type-name$
+    $nested-name-specifier$ template $simple-template-id$
+    $computed-type-specifier$
+    $placeholder-type-specifier$
+    $nested-name-specifier$@~_opt_~@ $template-name$
++   $splice-template-specifier$
+    ...
+
   $computed-type-specifier$:
      $decltype-specifier$
      $pack-index-specifier$
 +    $splice-type-specifier$
 ```
+:::
+
+Modify paragraph 3 to indicate that a `$splice-template-specifier$` can be deduced.
+
+::: std
+[3]{.pnum} A `$placeholder-type-specifier$` is a placeholder for a type to be deduced ([dcl.spec.auto]). [The `$simple-template-id$` in a `$type-specifier$` of the form `$nested-name-specifier$ template $simple-template-id$` shall not contain a `$splice-template-specifier$`.]{.addu} A `$type-specifier$` of the form `typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ $template-name$` [or `$splice-template-specifier$`]{.addu} is a placeholder for a deduced class type ([dcl.type.class.deduct]). The `$nested-name-specifier$`, if any, shall be non-dependent and the `$template-name$` [or `$splice-template-specifier$`]{.addu} shall [name]{.rm} [designate]{.addu} a deducible template. A _deducible template_ is either a class template or is an alias template whose `$defining-type-id$` is of the form
+
+```cpp
+typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ template@~_opt_~@ $simple-template-id$
+```
+
+where the `$nested-name-specifier$` (if any) is non-dependent and the `$template-name$` of the `$simple-template-id$` names a deducible template.
+
+:::
+
+Add a row to [tab:dcl.type.simple] to cover the `$splice-template-specifier$` production.
+
+::: std
+<center>Table 17: `$simple-type-specifier$`s and the types they specify [tab:dcl.type.simple]</center>
+|Specifier(s)|Type|
+|:-|:-|
+|`$type-name$`|the type named|
+|`$simple-template-id$`|the type as defined in [temp.names]|
+|`$decltype-specifier$`|the type as defined in [dcl.type.decltype]|
+|`$pack-index-specifier$`|the type as defined in [dcl.type.pack.index]|
+|`$placeholder-type-specifier$`|the type as defined in [dcl.spec.auto]|
+|`$template-name$`|the type as defined in [dcl.type.class.deduct]|
+|[`$splice-template-specifier$`]{.addu}|[the type as defined in [dcl.type.class.deduct]]{.addu}|
+|`...`|...|
 :::
 
 ### 9.2.9* [dcl.type.splice] Type splicing {-}
@@ -3839,6 +3885,19 @@ Change a sentence in paragraph 4 of [dcl.attr.grammar]{.sref} as follows:
 [4]{.pnum} [...] An `$attribute-specifier$` that contains no `$attribute$`s [and no `$alignment-specifier$`]{.addu} has no effect. [[That includes an `$attribute-specifier$` of the form `[ [ using $attribute-namespace$ :] ]` which is thus equivalent to replacing the `:]` token by the two-token sequence `:` `]`.]{.note}]{.addu} ...
 :::
 
+### [module.global.frag] Global module fragment {-}
+
+Extend the caveat in paragraph 3.7 to also apply to `$splice-template-specifier$`s.
+
+::: std
+In this determination, it is unspecified
+
+* [3.6]{.pnum} whether a reference to an `$alias-declaration$`, `typedef` declaration, `$using-declaration$`, or `$namespace-alias-definition$` is replaced by the declarations they name prior to this determination,
+* [#.#]{.pnum} whether a `$simple-template-id$` that does denote a dependent type and whose `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} an alias template is replaced by its denoted type prior to this determination,
+* [#.#]{.pnum} ...
+
+:::
+
 ### [module.reach]{.sref} Reachability {-}
 
 Modify the definition of reachability to account for injected declarations:
@@ -3851,6 +3910,26 @@ Modify the definition of reachability to account for injected declarations:
 * [#.#]{.pnum} `$D$` is not discarded ([module.global.frag]), appears in a translation unit that is reachable from `$P$`, and does not appear within a _private-module-framgent_.
 :::
 
+### [class.pre] Preamble {-}
+
+Disallow a `$slice-template-specifier$` from appearing in a declaration of a `$class-name$` in paragraph 1.
+
+::: std
+...
+
+A class declaration where the `$class-name$` in the `$class-head-name$` is a `$simple-template-id$` shall be an explicit specialization ([temp.expl.spec]) or a partial specialization ([temp.spec.partial]). [The `$simple-template-id$` shall not contain a `$splice-template-specifier$`.]{.addu} A `$class-specifier$` whose `$class-head$` omits the `$class-head-name$` defines an _unnamed class_.
+
+:::
+
+### [class.name] Class names {-}
+
+Cover `$splice-template-specifier$s in paragraph 5.
+
+::: std
+[5]{.pnum} A `$simple-template-id$` is only a `$class-name$` if its `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} a class template.
+
+:::
+
 ### [class.mem.general]{.sref} General {-}
 
 Extend paragraph 5, and modify note 3, to clarify the existence of subobjects corresponding to non-static data members of reference types.
@@ -3858,7 +3937,31 @@ Extend paragraph 5, and modify note 3, to clarify the existence of subobjects co
 ::: std
 [5]{.pnum} A data member or member function may be declared `static` in its _member-declaration_, in which case it is a _static member_ (see [class.static]) (a _static data member_ ([class.static.data]) or _static member function_ ([class.static.mfct]), respectively) of the class. Any other data member or member function is a _non-static member_ (a _non-static data member_ or _non-static member function_ ([class.mfct.non.static]), respectively). [For each non-static data member of reference type, there is a unique member subobject whose size and alignment is the same as if the data member were declared with the corresponding pointer type.]{.addu}
 
-[[A non-static data member of non-reference type is a member subobject of a class object.]{.rm} An object of class type has a member subobject corresponding to each non-static data member of its class]{.note3}
+[[A non-static data member of non-reference type is a member subobject of a class object.]{.rm} [An object of class type has a member subobject corresponding to each non-static data member of its class]{.addu}]{.note3}
+
+:::
+
+### [over.match.class.deduct]{.sref} Class template argument deduction {-}
+
+Extend paragraph 1 to work with `$splice-template-specifier$`s.
+
+::: std
+[1]{.pnum} When resolving a placeholder for a deduced class type ([dcl.type.class.deduct]) where the `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} a primary class template `C`, a set of functions and function templates, called the guides of `C`, is formed comprising:
+
+* [#.#]{.pnum} ...
+
+:::
+
+Extend paragraph 3 to also cover `$splice-template-specifier$`s.
+
+:::std
+[3]{.pnum} When resolving a placeholder for a deduced class type ([dcl.type.simple]) where the `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} an alias template `A`, the `$defining-type-id$` of `A` must be of the form
+
+```cpp
+typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ template@~_opt_~@ $simple-template-id$
+```
+
+as specified in [dcl.type.simple]. The guides of `A` are the set of functions or function templates formed as follows. ...
 
 :::
 
@@ -3879,24 +3982,30 @@ bool operator!=(T, T);
 Extend the last sentence of paragraph 4 to disallow splicing concepts in template parameter declarations.
 
 ::: std
-[4]{.pnum} ... The concept designated by a type-constraint shall be a type concept ([temp.concept]) [that is not a `$splice-template-name$`]{.addu}.
+[4]{.pnum} ... The concept designated by a type-constraint shall be a type concept ([temp.concept]) [that is not a `$splice-template-specifier$`]{.addu}.
 :::
 
 ### [temp.names]{.sref} Names of template specializations {-}
 
-Modify the grammars for `$template-id$` and `$template-argument$` as follows:
+Introduce `$splice-template-specifier$` and `$splice-template-argument$` nonterminals. Extend `$simple-template-id$` and `$template-argument$` to leverage these.
 
 ::: std
 ```diff
-+ $splice-template-name$:
-+     template $splice-specifier$
-+
-+ $splice-template-argument$:
-+     $splice-specifier$
-+
+  $simple-template-id$:
+      $template-name$ < $template-argument-list$@~_opt_~@ >
++     $splice-template-specifier$ < $template-argument-list$@~_opt_~@ >
+
+  $template-id$:
+      $simple-template-id$
+      $operator-function-id < $template-argument-list$@~_opt_~@ >
+      $literal-operator-id < $template-argument-list$@~_opt_~@ >
+  
   $template-name$:
       identifier
-+     $splice-template-name$
+
+  $template-argument-list$:
+      $template-argument$ ...@~_opt_~@
+      $template-argument-list$ , $template-argument$ ...@~_opt_~@
 
   $template-argument$:
       $constant-expression$
@@ -3904,31 +4013,45 @@ Modify the grammars for `$template-id$` and `$template-argument$` as follows:
       $id-expression$
       $braced-init-list$
 +     $splice-template-argument$
++
++ $splice-template-specifier$:
++     template $splice-specifier$
++
++ $splice-template-argument$:
++     $splice-specifier$
 ```
 :::
 
-Extend paragraph 1 to cover template splicers:
+Extend paragraph 2 to cover `$simple-template-id$`s and `$template-id$`s that have no component name.
 
 ::: std
-The component name of a `$simple-template-id$`, `$template-id$`, or `$template-name$` [that is an `$identifier$`]{.addu} is the first name in it. [If the `$template-name$` is a `$splice-template-name$`, the `$splice-specifier$` shall designate a concept, variable template, class template, alias template, or function template that is not a constructor template or destructor template; the `$splice-template-name$` designates the entity designated by the `$splice-specifier$`.]{.addu}
+[2]{.pnum} The component name of a [`$simple-template-id$`, `$template-id$`, or]{.rm} `$template-name$` is its `$identifier$` [the first name in it]{.rm}. [The component names of a `$simple-template-id$` are those of its `$template-name$` (if any). The component names of a `$template-id$` are those of its `$simple-template-id$`, `$operator-function-id$`, or `$literal-operator-id$`.]{.addu}
+
 :::
 
-Extend paragraph 3 of [temp.names]{.sref}:
+Add a paragraph following paragraph 2 defining the semantics of a `$splice-template-specifier$`.
+
+::: std
+::: addu
+[2+]{.pnum} A `$splice-template-specifier$` designates the same entity designated by its `$splice-specifier$`. A `$splice-template-specifier$` shall designate a concept, variable template, class template, alias template, or function template. A `$splice-template-specifier$` shall not designate a constructor template or destructor template.
+
+:::
+:::
+
+Extend and re-format paragraph 3 of [temp.names]{.sref}:
 
 ::: std
 
-[3]{.pnum} A `<` is interpreted as the delimiter of a *template-argument-list* if it follows a name that is not a *conversion-function-id* and
+[3]{.pnum} A `<` is interpreted as the delimiter of a `$template-argument-list$` if it follows [either]{.addu}
 
-* [3.1]{.pnum} that follows the keyword template or a ~ after a nested-name-specifier or in a class member access expression, or
-* [3.2]{.pnum}  for which name lookup finds the injected-class-name of a class template or finds any declaration of a template, or
-* [3.3]{.pnum} that is an unqualified name for which name lookup either finds one or more functions or finds nothing, or
-* [3.4]{.pnum} that is a terminal name in a using-declarator ([namespace.udecl]), in a declarator-id ([dcl.meaning]), or in a type-only context other than a nested-name-specifier ([temp.res]).
+* [[#.#]{.pnum} a `$splice-template-specifier$`, or]{.addu}
+* [#.#]{.pnum} a name that is not a `$conversion-function-id$` and
+  * [#.#.#]{.pnum} that follows the keyword template or a ~ after a nested-name-specifier or in a class member access expression, or
+  * [#.#.#]{.pnum}  for which name lookup finds the injected-class-name of a class template or finds any declaration of a template, or
+  * [#.#.#]{.pnum} that is an unqualified name for which name lookup either finds one or more functions or finds nothing, or
+  * [#.#.#]{.pnum} that is a terminal name in a using-declarator ([namespace.udecl]), in a declarator-id ([dcl.meaning]), or in a type-only context other than a nested-name-specifier ([temp.res]).
 
 [If the name is an identifier, it is then interpreted as a *template-name*. The keyword template is used to indicate that a dependent qualified name ([temp.dep.type]) denotes a template where an expression might appear.]{.note}
-
-::: addu
-A `<` is also interpreted as the delimiter of a `$template-argument-list$` if it follows a `$splice-template-name$`.
-:::
 
 ::: example
 ```diff
@@ -3948,13 +4071,19 @@ template<class T> void f(T* p) {
 }
 ```
 :::
+:::
+
+Extend paragraph 8 to also cover `$simple-template-id$`s containing `$splice-template-specifier$`s.
+
+::: std
+[8]{.pnum} When the `$template-name$` [or `$splice-template-specifier$`]{.addu} of a `$simple-template-id$` [names]{.rm} [designates]{.addu} a constrained non-function template or a constrained template `$template-parameter$`, and all `$template-arguments$` in the `$simple-template-id$` are non-dependent ([temp.dep.temp]), the associated contraints ([temp.constr.decl]) of the constrained template shall be satisfied ([temp.constr.constr]).
 
 :::
 
 Change paragraph 9 to allow splicing into a *concept-id*:
 
 ::: std
-[9]{.pnum} A *concept-id* is a *simple-template-id* where the *template-name* is [either]{.addu} a *concept-name* [or a *splice-template-name* whose *splice-specifier* designates a concept]{.addu}. A concept-id is a prvalue of type bool, and does not name a template specialization.
+[9]{.pnum} A _concept-id_ is a `$simple-template-id$` where [either]{.addu} the `$template-name$` is a `$concept-name$` [or the `$splice-template-specifier$` designates a concept]{.addu}. A concept-id is a prvalue of type bool, and does not name a template specialization.
 :::
 
 
@@ -4005,6 +4134,21 @@ Extend [temp.arg.template]{.sref}/1 to cover splice template arguments:
 
 ### [temp.type]{.sref} Type equivalence {-}
 
+Extend `$template-id$` equivalence as defined by paragraph 1 to cover `$splice-template-specifier$`s.
+
+::: std
+[1]{.pnum} Two `$template-id$`s are the same if
+
+* their `$template-name$`s, [`$splice-template-specifier$`s, ]{.addu} `$operator-function-id$`s, or `$literal-operator-id$`s refer to the same template, and
+* their corresponding type `$template-argument$`s are the same type, and
+* the template parameter values determined by their corresponding non-type template arguments ([temp.arg.nontype]) are template-argument-equivalent (see below), and
+* their corresponding template `$template-argument$`s refer to the same template.
+
+Two `$template-id$`s that are the same refer to the same class, function, or variable.
+
+:::
+
+
 Extend *template-argument-equivalent* to handle `std::meta::info`:
 
 ::: std
@@ -4012,10 +4156,26 @@ Extend *template-argument-equivalent* to handle `std::meta::info`:
 
 * [2.1]{.pnum} they are of integral type and their values are the same, or
 * [2.2]{.pnum} they are of floating-point type and their values are identical, or
-* [2.3]{.pnum} they are of type `std​::​nullptr_t`, or
+* [2.3]{.pnum} they are of type `std::nullptr_t`, or
 * [2.*]{.pnum} [they are of type `std::meta::info` and they compare equal, or]{.addu}
 * [2.4]{.pnum} they are of enumeration type and their values are the same, or
 * [2.5]{.pnum} [...]
+:::
+
+### [temp.deduct.guide]{.sref} Deduction guides {-}
+
+Extend paragraph 1 to clarify that `$splice-template-specifier$`s can also leverage deduction guides.
+
+::: std
+[1]{.pnum} Deduction guides are used when a `$template-name$` [or `$splice-template-specifier$`]{.addu} appears as a type specifier for a deduced class type ([dcl.type.class.deduct]). Deduction guides are not found by name lookup. Instead, when performing class template argument deduction ([over.match.class.deduct]), all reachable deduction guides declared for the class template are considered.
+
+:::
+
+Notwithstanding the above, extend paragraph 3 to clarify that `$splice-template-specifier$`s cannot themselves appear in deduction guides.
+
+::: std
+[3]{.pnum} The same restrictions apply to the `$parameter-declaration-clause$` of a deduction guide as in a function declaration ([dcl.fct]), except that a generic parameter type placeholder ([dcl.spec.auto]) shall not appear in the `$parameter-declaration-clause$` of a deduction guide. The `$simple-template-id$` shall name a class template specialization [and shall contain a `$template-name$`]{.addu}. The `$template-name$` shall be the same `$identifier$` as the `$template-name$` of the `$simple-template-id$`. A `$deduction-guide$` shall inhabit the scope to which the corresponding class template belongs and, for a member class template, have the same access. Two deduction guide declarations for the same class template shall not have equivalent `$parameter-declaration-clauses$` if either is reachable from the other.
+
 :::
 
 ### [temp.alias]{.sref} Alias templates {-}
@@ -4035,7 +4195,7 @@ Extend the grammar of `$concept-name$` to allow for splicing reflections of conc
 ```diff
   $concept-name$:
     $identifier$
-+   $splice-template-name$
++   $splice-template-specifier$
 ```
 :::
 
@@ -4045,6 +4205,12 @@ Modify paragraph 2 to account for splicing reflections of concepts:
 A `$concept-definition$` declares a concept. Its [`$concept-name$` shall be an `$identifier$`, and the]{.addu} `$identifier$` becomes a _concept-name_ referring to that concept within its scope. The optional _attribute-specifier-seq_ appertains to the concept.
 
 :::
+
+### [temp.res.general]{.sref} General {-}
+
+Disallow `$splice-template-specifier$`s from appearing in `$typename-specifier$`s.
+
+[3]{.pnum} The component names of a `$typename-specifier$` are its `$identifier$` (if any) and those of its `$nested-name-specifier$` and `$simple-template-id$` (if any). The `$simple-template-id$` shall not contain a `$splice-template-specifier$`.
 
 ### [temp.dep.expr]{.sref} Type-dependent expressions {-}
 

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3011,8 +3011,9 @@ Modify the first bullet of paragraph 3 of [basic.lookup.argdep]{.sref} as follow
 
 [3]{.pnum} ... Any `$typedef-name$`s and `$using-declaration$`s used to specify the types do not contribute to this set. The set of entities is determined in the following way:
 
-- [3.1]{.pnum} [If `T` is `std::meta::info`, its associated set of entities is the singleton containing the function `std::meta::is_type`.]{.addu} If `T` is [a]{.rm} [any other]{.addu} fundamental type, its associated set of entities is empty.
-- [3.2]{.pnum} If `T` is a class type ...
+* [[#.#]{.pnum} If `T` is `std::meta::info`, its associated set of entities consists of the function `std::meta::is_type` together with an implementation-defined set of additional entities. [For example, an implementation might augment a function to the set of associated entities to allow a namespace of implementation-provided reflection operations to be found by argument-dependent lookup.]{.note}]{.addu}
+* [#.#]{.pnum} If `T` is [a]{.rm} [any other]{.addu} fundamental type, its associated set of entities is empty.
+* [#.#]{.pnum} If `T` is a class type ...
 
 :::
 
@@ -3111,10 +3112,13 @@ Add a new paragraph before the last paragraph of [basic.fundamental]{.sref} as f
 * a bit-field,
 * a primary class template, function template, primary variable template, alias template, or concept,
 * a namespace or `$namespace-alias$`,
-* a `$base-specifier$`, or
-* a description of a declaration of a non-static data member.
+* a `$base-specifier$`,
+* a description of a declaration of a non-static data member, or
+* an implementation-defined construct not otherwise specified by this document.
 
 An expression convertible to a reflection is said to _represent_ the corresponding construct. `sizeof(std::meta::info)` shall be equal to `sizeof(void*)`.
+
+[Implementations are discouraged from representing any constructs described by this document that are not explicitly enumerated in the list above (e.g., partial template specializations, attributes, placeholder types, statements).]{.note}
 
 :::
 :::
@@ -3206,19 +3210,19 @@ void non_dependent() {
 
 ### [expr.prim.id.general]{.sref} General {-}
 
-Add a carve-out for reflection in [expr.prim.id.general]{.sref}/4:
+Add a carve-out for reflection in [expr.prim.id.general]{.sref}/4. Adjust the wording to reflect the fact that a `$reflect-expression$` operand is not formally an `$id-expression$`:
 
 ::: std
-[4]{.pnum} An `$id-expression$` that denotes a non-static data member or implicit object member function of a class can only be used:
+[4]{.pnum} [An `$id-expression$` that denotes a]{.rm} [A]{.addu} non-static data member or implicit object member function of a class can only be [used]{.rm} [denoted]{.addu}:
 
 * [4.#]{.pnum} as part of a class member access (after any implicit transformation (see above)) in which the object expression refers to the member's class or a class derived from that class, or
 
 ::: addu
-* [4.#]{.pnum} as an operand to the reflection operator ([expr.reflect]), or
+* [4.#]{.pnum} by the operand of a `$reflect-expression$` ([expr.reflect]), or
 :::
 
 * [4.#]{.pnum} to form a pointer to member ([expr.unary.op]), or
-* [4.#]{.pnum} if that id-expression denotes a non-static data member and it appears in an unevaluated operand.
+* [4.#]{.pnum} [if that]{.rm} [by an]{.addu} `$id-expression$` [denotes]{.rm} [denoting]{.addu} a non-static data member [and it appears]{.rm} in an unevaluated operand.
 :::
 
 ### [expr.prim.id.qual]{.sref} Qualified names {-}
@@ -3450,13 +3454,17 @@ consteval void g(std::meta::info r, X<false> xv) {
 
 [#]{.pnum} A `$reflect-expression$` having the form `^ $unqualified-id$` or `^ $qualified-id$` performs name lookup for the operand following `^` and produces a result as follows:
 
-* [#.#]{.pnum} If lookup finds an overload set `$S$` such that the assignment of `$S$` to an invented variable of type `const auto` ([dcl.type.auto.deduct]{.sref}) would select a unique candidate function `$F$` from `$S$`, then the result is a reflection of `$F$`. If lookup finds any other overload set, the program is ill-formed.
+* [#.#]{.pnum} If the lookup finds an overload set `$S$` such that the assignment of `&$S$` to an invented variable of type `const auto` ([dcl.type.auto.deduct]{.sref}) would select a unique candidate function `$F$` from `$S$`, then the result is a reflection of `$F$`. If the lookup finds any other overload set, the program is ill-formed.
 
-* [#.#]{.pnum} Otherwise, if lookup finds a `$typedef-name$` or a `$namespace-alias$`, then the result is a reflection of the indicated name.
+* [#.#]{.pnum} Otherwise, if the lookup finds a `$typedef-name$` or a `$namespace-alias$`, then the result is a reflection of the indicated name.
 
-* [#.#]{.pnum} Otherwise, if lookup finds a non-type template parameter, the result is a reflection of the result computed by an `$id-expression$` naming the parameter.
+* [#.#]{.pnum} Otherwise, if the lookup finds a non-type template parameter, then the result is a reflection of the result computed by an `$id-expression$` naming the parameter.
 
-* [#.#]{.pnum} Otherwise, if lookup finds a variable, structured binding, function, enumerator, type, non-static member, template, or namespace, the result is a reflection of the denoted entity.
+* [#.#]{.pnum} Otherwise, if the lookup finds a variable, structured binding, function, enumerator, type, non-static member, template, or namespace, then the result is a reflection of the denoted entity.
+
+* [#.#]{.pnum} Otherwise, if the lookup finds an implementation-defined construct not otherwise specified by this document, then the implementation may produce a reflection of the denoted construct.
+
+* [#.#]{.pnum} Otherwise, the program is ill-formed.
 
 [#]{.pnum} A `$reflect-expression$` of the form `^ $type-id$` produces a reflection of the denoted type. A `$reflect-expression$` that could be validly interpreted as either `^ $unqualified-id$` or `^ $type-id$` is interpreted as `^ $unqualified-id$`, and a `$reflect-expression$` that could be validly interpreted as `^ $qualified-id$` or `^ $type-id$` is interpreted as `^ $qualified-id$`.
 
@@ -4424,7 +4432,7 @@ struct is_reflection;
 </td></tr>
 </table>
 
-### [meta.synop] Header `<meta>` synopsis {-}
+### [meta.reflection.synop] Header `<meta>` synopsis {-}
 
 Add a new subsection in [meta]{.sref} after [type.traits]{.sref}:
 
@@ -4783,6 +4791,8 @@ namespace std::meta {
 ```
 
 [1]{.pnum} Each function, and each instantiation of each function template, specified in this header is a designated addressable function ([namespace.std]).
+
+[2]{.pnum} Values of type `std::meta::info` may represent implementation-defined constructs not otherwise specified by this document ([basic.fundamental]{.sref}). The behavior of any function specified by this section is implementation-defined when a reflection representing such a construct is provided as an argument.
 :::
 :::
 

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3172,8 +3172,31 @@ In all other cases, it is interpreted as a `$splice-expr-template-specifier$`.
 [#]{.pnum} The `typename` in a `$splice-type-specifier$` may only be omitted in a type-only context, or when the `$splice-specifier$` is preceded by `template`.
 
 ::: example
-```
-FIXME
+```cpp
+int var {};
+struct cls {};
+template<int> int t_var {};
+template<int> struct t_cls { };
+template <typename> concept always_true = requires { true; };
+
+template <auto Var, auto Cls, auto TVar, auto TCls, auto Concept>
+void dependent() {
+  { [:Var:] *var; }                        // ok: multiplication of 'var * var'.
+
+  { typename [:Cls:] *var; }               // ok: declaration of 'cls *var'
+  { template [:TVar:]<0> *var; }           // ok: multiplication of 't_var<0> * var'.
+  { template [:TCls:]<0> *var; }           // error: cannot splice type as expression.
+  { typename [:TCls:]<0> *var; }           // ok: declaration of 't_cls<0> *var'.
+  { template typename [:TCls:]<0> *var; }  // also ok.
+
+  { template [:Concept:] auto *var = 0; }  // ok: deduced placeholder type.
+};
+
+void non_dependent() {
+  dependent<^var, ^cls, ^t_var, ^t_cls, ^always_true>();
+
+  { template [:^^t_cls:]<0> *var; }        // ok in non-dependent context.
+};
 
 ```
 :::

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -37,6 +37,7 @@ Since [@P2996R7]:
 * clarified that everything in `std::meta` is addressable
 * renaming `member_offsets` to `member_offset` and changing `member_offset` members to be `ptrdiff_t` instead of `size_t`, to allow for future use with negative offsets
 * renamed the type traits from all being named `type_meow` to a more bespoke naming scheme.
+* rewrote core wording for `$consteval-only type$` and for all splicers.
 
 Since [@P2996R6]:
 
@@ -1338,16 +1339,16 @@ On Compiler Explorer: [EDG](https://godbolt.org/z/MEYd3771Y), [Clang](https://go
 
 The reflection operator produces a reflection value from a grammatical construct (its operand):
 
-> | _unary-expression_:
+> | `$unary-expression$`:
 > |       ...
 > |       `^` `::`
-> |       `^` _namespace-name_
-> |       `^` _type-id_
-> |       `^` _id-expression_
+> |       `^` `$namespace-name$`
+> |       `^` `$type-id$`
+> |       `^` `$id-expression$`
 
-The expression `^::` evaluates to a reflection of the global namespace. When the operand is a _namespace-name_ or _type-id_, the resulting value is a reflection of the designated namespace or type.
+The expression `^::` evaluates to a reflection of the global namespace. When the operand is a `$namespace-name$` or `$type-id$`, the resulting value is a reflection of the designated namespace or type.
 
-When the operand is an _id-expression_, the resulting value is a reflection of the designated entity found by lookup. This might be any of:
+When the operand is an `$id-expression$`, the resulting value is a reflection of the designated entity found by lookup. This might be any of:
 
 - a variable, static data member, or structured binding
 - a function or member function
@@ -1357,7 +1358,7 @@ When the operand is an _id-expression_, the resulting value is a reflection of t
 
 For all other operands, the expression is ill-formed. In a SFINAE context, a failure to substitute the operand of a reflection operator construct causes that construct to not evaluate to constant.
 
-Earlier revisions of this paper allowed for taking the reflection of any _cast-expression_ that could be evaluated as a constant expression, as we believed that a constant expression could be internally "represented" by just capturing the value to which it evaluated. However, the possibility of side effects from constant evaluation (introduced by this very paper) renders this approach infeasible: even a constant expression would have to be evaluated every time it's spliced. It was ultimately decided to defer all support for expression reflection, but we intend to introduce it through a future paper using the syntax `^(expr)`.
+Earlier revisions of this paper allowed for taking the reflection of any `$cast-expression$` that could be evaluated as a constant expression, as we believed that a constant expression could be internally "represented" by just capturing the value to which it evaluated. However, the possibility of side effects from constant evaluation (introduced by this very paper) renders this approach infeasible: even a constant expression would have to be evaluated every time it's spliced. It was ultimately decided to defer all support for expression reflection, but we intend to introduce it through a future paper using the syntax `^(expr)`.
 
 This paper does, however, support reflections of _values_ and of _objects_ (including subobjects). Such reflections arise naturally when iterating over template arguments.
 
@@ -2973,19 +2974,19 @@ Change the grammar for `$operator-or-punctuator$` in paragraph 1 of [lex.operato
 Modify paragraph 4.1 to cover splicing of functions:
 
 ::: std
-- [4.1]{.pnum} A function is named by an expression or conversion if it is the selected member of an overload set ([basic.lookup], [over.match], [over.over]) in an overload resolution performed as part of forming that expression or conversion, [or if it is designated by a _splice-expression_ ([expr.prim.splice]),]{.addu} unless it is a pure virtual function and either the expression is not an _id-expression_ naming the function with an explicitly qualified name or the expression forms a pointer to member ([expr.unary.op]).
+- [4.1]{.pnum} A function is named by an expression or conversion if it is the selected member of an overload set ([basic.lookup], [over.match], [over.over]) in an overload resolution performed as part of forming that expression or conversion, [or if it is designated by a `$splice-expression$` ([expr.prim.splice]),]{.addu} unless it is a pure virtual function and either the expression is not an `$id-expression$` naming the function with an explicitly qualified name or the expression forms a pointer to member ([expr.unary.op]).
 :::
 
 Modify the first sentence of paragraph 5 to cover splicing of variables:
 
 ::: std
-- [5]{.pnum} A variable is named by an expression if the expression is an _id-expression_ [or _splice-expression_ ([expr.prim.splice])]{.addu} that designates it.
+- [5]{.pnum} A variable is named by an expression if the expression is an `$id-expression$` [or `$splice-expression$` ([expr.prim.splice])]{.addu} that designates it.
 :::
 
 Modify paragraph 6 to cover splicing of structured bindings:
 
 ::: std
-- [6]{.pnum} A structured binding is odr-used if it appears as a potentially-evaluated expression[, or if a reflection of it is the operand of a potentially-evaluated _splice-expression_ ([expr.prim.splice])]{.addu}.
+- [6]{.pnum} A structured binding is odr-used if it appears as a potentially-evaluated expression[, or if a reflection representing it is the operand of a potentially-evaluated `$splice-expression$` ([expr.prim.splice])]{.addu}.
 :::
 
 Prepend before paragraph 15 of [basic.def.odr]{.sref}:
@@ -3017,19 +3018,11 @@ Modify the first bullet of paragraph 3 of [basic.lookup.argdep]{.sref} as follow
 
 ### [basic.lookup.qual.general]{.sref} General {-}
 
-FIXME. Have to handle splices in here, because they're not actually "component names". Now `$splice-namespace-specifier$` is only a namespace too.
-
-Extend [basic.lookup.qual.general]{.sref}/1-2 to cover `$splice-namespace-specifier$`:
+Extend paragraph 1 to cover `$splice-specifier$`s:
 
 ::: std
-[1]{.pnum} Lookup of an *identifier* followed by a `::` scope resolution operator considers only namespaces, types, and templates whose specializations are types. If a name, `$template-id$`, [or]{.rm} `$computed-type-specifier$`[, or `$splice-namespace-specifier$`]{.addu} is followed by a `::`, it shall designate a namespace, class, enumeration, or dependent type, and the `::` is never interpreted as a complete nested-name-specifier.
+[1]{.pnum} Lookup of an *identifier* followed by a `::` scope resolution operator considers only namespaces, types, and templates whose specializations are types. If a name, `$template-id$`, [`$splice-specifier$`,]{.addu} or `$computed-type-specifier$` is followed by a `::`, it shall designate a namespace, class, enumeration, [dependent `$splice-specifier$`,]{.addu} or dependent type, and the `::` is never interpreted as a complete nested-name-specifier.
 
-[2]{.pnum} A member-qualified name is the (unique) component name ([expr.prim.id.unqual]), if any, of
-
-* [2.1]{.pnum} an *unqualified-id* or
-* [2.2]{.pnum} a `$nested-name-specifier$` of the form `$type-name$ ::` [or]{.rm}[,]{.addu} `$namespace-name$ ::`[, or `$splice-namespace-specifier$ ::`]{.addu}
-
-in the *id-expression* of a class member access expression ([expr.ref]). [...]
 :::
 
 ### [basic.link]{.sref} Program and Linkage {-}
@@ -3040,7 +3033,7 @@ Add a bullet to paragraph 13:
 
 [13]{.pnum} A declaration `$D$` _names_ an entity `$E$` if
 
-* [13.1]{.pnum} `$D$` contains a _lambda-expression_ whose closure type is `$E$`,
+* [13.1]{.pnum} `$D$` contains a `$lambda-expression$` whose closure type is `$E$`,
 * [13.1+]{.pnum} [`$D$` contains a reflection that represents either `$E$` or a `$typedef-name$` or `$namespace-alias$` that denotes `$E$`,]{.addu}
 * [13.2]{.pnum} `$E$` is not a function or function template and `$D$` contains an *id-expression*, *type-specifier*, *nested-name-specifier*, *template-name*, or *concept-name denoting* `$E$`, or
 * [13.#]{.pnum} `$E$` is a function or function template and `$D$` contains an expression that names `$E$` ([basic.def.odr]) or an *id-expression* that refers to a set of overloads that contains `$E$`.
@@ -3061,7 +3054,7 @@ Extend the definition of _TU-local_ values and objects to include reflections:
 * [16.1a]{.pnum} it is a value or object of a TU-local type,
 * [16.1b]{.pnum} it is a reflection representing
   * [16.1b.#]{.pnum} a TU-local value or object, or
-  * [16.1b.#]{.pnum} a `$typedef-name$`, namespace alias, or base specifier introduced by an exposure, or
+  * [16.1b.#]{.pnum} a `$typedef-name$`, `$namespace-alias$`, or `$base-specifier$` introduced by an exposure, or
 :::
 * [16.2]{.pnum} it is an object of class or array type and any of its subobjects or any of the objects or functions to which its non-static data members of reference type refer is TU-local and is usable in constant expressions.
 
@@ -3084,12 +3077,12 @@ Add a new paragraph at the end of [basic.types.general]{.sref} as follows:
 
   - [#.#]{.pnum} `std::meta::info`, or
   - [#.#]{.pnum} a pointer or reference to a consteval-only type,
-  - [#.#]{.pnum} an (possibly multi-dimensional) array of a consteval-only type,
+  - [#.#]{.pnum} a (possibly multi-dimensional) array of a consteval-only type,
   - [#.#]{.pnum} a class type with a base class or non-static data member of consteval-only type,
   - [#.#]{.pnum} a function type with a return type or parameter type of consteval-only type, or
   - [#.#]{.pnum} a pointer-to-member type to a class `C` of type `M` where either `C` or `M` is a consteval-only type.
 
-[13]{.pnum} Every object of consteval-only type shall either be
+[13]{.pnum} Every object of consteval-only type shall be
 
   - [#.#]{.pnum} the object associated with a constexpr variable or a subobject thereof,
   - [#.#]{.pnum} a template parameter object ([temp.param]{.sref}) or a subobject thereof, or
@@ -3113,34 +3106,17 @@ Add a new paragraph before the last paragraph of [basic.fundamental]{.sref} as f
 * a structured binding,
 * a function,
 * an enumerator,
-* a type,
-* a `$typedef-name$`,
+* a type or `$typedef-name$`,
 * a class member,
 * a bit-field,
 * a primary class template, function template, primary variable template, alias template, or concept,
-* a namespace or namespace alias,
-* a base class specifier, or
+* a namespace or `$namespace-alias$`,
+* a `$base-specifier$`, or
 * a description of a declaration of a non-static data member.
 
-An expression convertible to a reflection is said to _represent_ the corresponding entity, alias, object, value, base class specifier, or description of a declaration of a non-static data member. `sizeof(std::meta::info)` shall be equal to `sizeof(void*)`.
+An expression convertible to a reflection is said to _represent_ the corresponding construct. `sizeof(std::meta::info)` shall be equal to `sizeof(void*)`.
 
 :::
-:::
-
-### [conv.ptr]{.sref} Pointer conversions {-}
-
-Expand paragraph 2 to disallow conversions to `void *` from pointers of consteval-only types.
-
-::: std
-[2]{.pnum} A prvalue of type "pointer to `$cv$ T`", where `T` is an object type, can be converted to a prvalue of type "pointer to `$cv$ void`". The pointer value ([basic.compound]) is unchanged by this conversion. [If `T` is a consteval-only type ([basic.types.general]), a program that necessitates this conversion is ill-formed.]{.addu}
-
-:::
-
-Expand paragraph 3 to also disallow conversions from pointers of consteval-only type to pointers to base classes that are not of consteval-only type.
-
-::: std
-A prvalue `v` of type "pointer to `$cv$ D`", where `D` is a complete class type, can be converted to a prvalue of type "pointer to `$cv$ B`", where `B` is a base class ([class.derived]) of `D`. If `B` is an inaccessible ([class.access]) or ambiguous ([class.member.lookup]) base class of `D`, [or if `D` is of consteval-only type ([basic.types.general]) and `B` is not,]{.addu} a program that necessitates this conversion is ill-formed. If `v` is a null pointer value, the result is a null pointer value. Otherwise, if `B` is a virtual base class of `D` and `v` does not point to an object whose type is similar ([conv.qual]) to `D` and that is within its lifetime or within its period of construction or destruction ([class.dtor]), the behavior is undefined. Otherwise, the result is a pointer to the base class subobject of the derived class object.
-
 :::
 
 ### [expr.prim]{.sref} Primary expressions {-}
@@ -3163,22 +3139,45 @@ Change the grammar for `$primary-expression$` in [expr.prim]{.sref} as follows:
 
 ### 7.5.4.0* [expr.prim.id.splice] Splice specifiers {-}
 
-FIXME: The wording here, and usage throughout.
-
-Add a new grammar term for convenience:
+Add a new vocabulary of nonterminals for various forms of splicers:
 
 ::: std
 ::: addu
 ```
 $splice-specifier$:
   [: $constant-expression$ :]
+
+$splice-expr-template-specifier$:
+	template $splice-specifier$
+
+$splice-type-specifier$:
+	typename@~_opt_~@ template@~_opt_~@ $splice-specifier$
 ```
 
-[1]{.pnum} The `$constant-expression$` of a `$splice-specifier$` shall be a converted constant expression ([expr.const]) contextually convertible to `std::meta::info`.
+The term _splicer_ generically refers to a `$splice-specifier$`, a `$splice-expr-template-specifier$`, or a `$splice-type-specifier$`.
 
-[2]{.pnum} Let `E` be the value of the converted `$constant-expression$`. The `$splice-specifier$` designates what `E` represents.
+[1]{.pnum} The `$constant-expression$` of a `$splice-specifier$` shall be a converted constant expression ([expr.const]) contextually convertible to `std::meta::info`. A `$splice-specifier$` designates the construct represented by the converted `$constant-expression$`, and is dependent if the converted `$constant-expression$` is value-dependent.
 
-[3]{.pnum} A `$splice-specifier$` is dependent if the converted `$constant-expression$` is value-dependent.
+[#]{.pnum} A `$splice-expr-template-specifier$` or `$splice-type-specifier$` designates the construct designated by the `$splice-specifier$`. A `$splice-expr-template-specifier$` designates either a function template a primary variable template, or a concept. A `$splice-type-specifier$` designates either a type, `$typedef-name$`, primary class template, alias template, or concept.
+
+[#]{.pnum} The form `template $splice-specifier$` is interpreted as a `$splice-type-specifier$` when
+
+* [#.#]{.pnum} it is preceded by `typename`,
+* [#.#]{.pnum} it is within a type-only context,
+* [#.#]{.pnum} it is followed by `auto` or `decltype(auto)`, or
+* [#.#]{.pnum} the `$splice-specifier$` is not dependent and designates a primary class template or alias template.
+
+In all other cases, it is interpreted as a `$splice-expr-template-specifier$`.
+
+[#]{.pnum} The `typename` in a `$splice-type-specifier$` may only be omitted in a type-only context, or when the `$splice-specifier$` is preceded by `template`.
+
+::: example
+```
+FIXME
+
+```
+:::
+
 :::
 :::
 
@@ -3209,21 +3208,18 @@ Add a production to the grammar for `$nested-name-specifier$` as follows:
       ::
       $type-name$ ::
       $namespace-name$ ::
-+     $splice-namespace-specifier$ ::
++     $splice-specifier$ ::
       $computed-type-specifier$ ::
       $nested-name-specifier$ $identifier$ ::
       $nested-name-specifier$ template@~_opt_~@ $simple-template-id$ ::
-+
-+ $splice-namespace-specifier$:
-+     $splice-specifier$
 ```
 :::
 
-Add a new paragraph restricting `$splice-namespace-specifier$`, and renumber accordingly:
+Add a new paragraph restricting `$splice-specifier$`, and renumber accordingly:
 
 ::: std
 ::: addu
-[0]{.pnum} The `$splice-specifier$` of a `$splice-namespace-specifier$` shall designate a namespace or namespace alias.
+[0]{.pnum} A `$splice-specifier$` of a `$nested-name-specifier$` either is dependent or designates a type, `$typedef-name$`, namespace, or `$namespace-alias$`.
 :::
 
 [1]{.pnum} The component names of a `$qualified-id$` are [...]
@@ -3239,13 +3235,13 @@ Clarify that a splice cannot appear in a declarative `$nested-name-specifier$`:
 * a `$qualified-id$` that is the `$id-expression$` of a `$declarator-id$`, or
 * a declarative `$nested-name-specifier$`.
 
-A declarative `$nested-name-specifier$` shall not have a `$decltype-specifier$` [or a `$splice-specifier$`]{.addu}. A declaration that uses a declarative `$nested-name-specifier$` shall be a friend declaration or inhabit a scope that contains the entity being redeclared or specialized.
+A declarative `$nested-name-specifier$` shall not have a `$computed-type-specifier$` [or a `$splice-specifier$`]{.addu}. A declaration that uses a declarative `$nested-name-specifier$` shall be a friend declaration or inhabit a scope that contains the entity being redeclared or specialized.
 :::
 
 Extend the next paragraph to also cover splices, and prefer the verb "designate" over "nominate":
 
 ::: std
-[4]{.pnum} The `$nested-name-specifier$` `​::`​ [nominates]{.rm} [designates]{.addu} the global namespace. A `$nested-name-specifier$` with a `$computed-type-specifier$` [nominates]{.rm} [designates]{.addu} the type denoted by the `$computed-type-specifier$`, which shall be a class or enumeration type. [A `$nested-name-specifier$` with a `$splice-namespace-specifier$` designates the same namespace or namespace alias as the `$splice-namespace-specifier$`.]{.addu} If a `$nested-name-specifier$` _N_ is declarative and has a `$simple-template-id$` with a template argument list _A_ that involves a template parameter, let _T_ be the template [nominated]{.rm} [designated]{.addu} by _N_ without _A_. _T_ shall be a class template.
+[3]{.pnum} The `$nested-name-specifier$` `::` [nominates]{.rm} [designates]{.addu} the global namespace. A `$nested-name-specifier$` with a `$computed-type-specifier$` [nominates]{.rm} [designates]{.addu} the type denoted by the `$computed-type-specifier$`, which shall be a class or enumeration type. [A `$nested-name-specifier$` with a `$splice-specifier$` that designates an entity itself designates the same entity. A `$nested-name-specifier$` with a `$splice-specifier$` that designates a name itself designates the entity nominated by that name.]{.addu} If a `$nested-name-specifier$` _N_ is declarative and has a `$simple-template-id$` with a template argument list _A_ that involves a template parameter, let _T_ be the template [nominated]{.rm} [designated]{.addu} by _N_ without _A_. _T_ shall be a class template.
 
 ...
 
@@ -3259,21 +3255,27 @@ Add a new subsection of [expr.prim]{.sref} following [expr.prim.req]{.sref}
 ::: addu
 **Expression Splicing   [expr.prim.splice]**
 
-FIXME: text for the template version.
-
 ```
 $splice-expression$:
    $splice-specifier$
-   template $splice-specifier$ < $template-argument-list$@~_opt_~@ >
 ```
 
-[#]{.pnum} The `$splice-specifier$` shall not designate an unnamed bit-field, a constructor or destructor, or a constructor template or destructor template.
+[#]{.pnum} The `$splice-specifier$` designates either
 
-[#]{.pnum} For a `$splice-expression$` of the form `$splice-specifier$`, let `$E$` be the object, value, or entity designated by `$splice-specifier$`.
+* [#.#]{.pnum} a value or object,
+* [#.#]{.pnum} a variable,
+* [#.#]{.pnum} a structured binding,
+* [#.#]{.pnum} a function,
+* [#.#]{.pnum} an enumerator, or
+* [#.#]{.pnum} a non-static data member.
+
+The `$splice-specifier$` shall not designate an unnamed bit-field, a constructor, or a destructor.
+
+[#]{.pnum} Let `$E$` be the construct designated by `$splice-specifier$`.
 
 * [#.#]{.pnum} If `$E$` is an object, a function, or a non-static data member, the expression is an lvalue designating `$E$`. The expression has the same type as `$E$`, and is a bit-field if and only if `$E$` is a bit-field.
 
-* [#.#]{.pnum} Otherwise, if `$E$` is a variable or a structured binding, the expression is an lvalue designating the same object as `$E$`. The expression has the same type as `$E$`, and is a bit-field if and only if `$E$` is a bit-field.
+* [#.#]{.pnum} Otherwise, if `$E$` is a variable or a structured binding, the expression is an lvalue designating the object associated with `$E$`. The expression has the same type as `$E$`, and is a bit-field if and only if `$E$` is a bit-field.
 
 * [#.#]{.pnum} Otherwise, `$E$` shall be a value or an enumerator. The expression is a prvalue whose evaluation computes `$E$` and whose type is the same as `$E$`.
 
@@ -3291,41 +3293,43 @@ Add a production to `$postfix-expression$` for splices in member access expressi
   $postfix-expression$:
     ...
     $postfix-expression$ . $template$@~_opt_~@ $id-expression$
-+   $postfix-expression$ . $template$@~_opt_~@ $splice-expression$
++   $postfix-expression$ . $splice-expression$
++   $postfix-expression$ . $splice-expr-template-specifier$
     $postfix-expression$ -> $template$@~_opt_~@ $id-expression$
-+   $postfix-expression$ -> $template$@~_opt_~@ $splice-expression$
++   $postfix-expression$ -> $splice-expression$
++   $postfix-expression$ -> $splice-expr-template-specifier$
 ```
 :::
 
 ### [expr.ref]{.sref} Class member access {-}
 
-Modify paragraph 1 to account for splices in member access expressions:
+Modify paragraph 1 to account for splices in member access expressions. Prefer the word "possibly" to "optionally" since `template` cannot precede a `splice-expression`:
 
 ::: std
-[1]{.pnum} A postfix expression followed by a dot `.` or an arrow `->`, optionally followed by the keyword template, and then followed by an _id-expression_[, or a _splice-expression_ designating a class member]{.addu}, is a postfix expression. [If the keyword `template` is used, the following unqualified name is considered to refer to a template ([temp.names]). If a `$simple-template-id$` results and is followed by a `​::`​, the _id-expression_ [or _splice-expression_]{.addu} is a qualified-id.]{.note}
+[1]{.pnum} A postfix expression followed by a dot `.` or an arrow `->`, [optionally]{.rm} [possibly]{.addu} followed by the keyword template, and then followed by an `$id-expression$` [or a splicer designating a class member]{.addu}, is a postfix expression. [If the keyword `template` is used, the following unqualified name is considered to refer to a template ([temp.names]). If a `$simple-template-id$` results and is followed by a `::`, the `$id-expression$` is a `$qualified-id$`.]{.note}
 
 :::
 
 Modify paragraph 2 to account for splices in member access expressions:
 
 ::: std
-[2]{.pnum} For the first option, if the [dot is followed by an]{.addu} `$id-expression$` [names]{.rm} [ or `$splice-expression$` designating]{.addu} a static member or an enumerator, the first expression is a discarded-value expression ([expr.context]); if the `$id-expression$` [or `$splice-expression$` designates]{.addu} [names]{.rm} a non-static data member, the first expression shall be a glvalue. For the second option (arrow), the first expression shall be a prvalue having pointer type. The expression `E1->E2` is converted to the equivalent form `(*(E1)).E2`; the remainder of [expr.ref] will address only the first option (dot).
+[2]{.pnum} [For the first option,]{.rm} [if]{.rm}[If]{.addu} the [dot is followed by an]{.addu} `$id-expression$` [names]{.rm} [ or splicer designating]{.addu} a static member or an enumerator, the first expression is a discarded-value expression ([expr.context]); if the `$id-expression$` [or splicer designates]{.addu} [names]{.rm} a non-static data member, the first expression shall be a glvalue. [For the second option (arrow), the first expression]{.rm} [A postfix expression followed by an arrow]{.addu} shall be a prvalue having pointer type. The expression `E1->E2` is converted to the equivalent form `(*(E1)).E2`; the remainder of [expr.ref] will address only [the first option (dot)]{.rm} [expressions containing a dot]{.addu}.
 :::
 
 Modify paragraph 3 to account for splices in member access expressions:
 
 ::: std
-[3]{.pnum} The postfix expression before the dot is evaluated; the result of that evaluation, together with the `$id-expression$` [or `$splice-expression$`]{.addu}, determines the result of the entire postfix expression.
+[3]{.pnum} The postfix expression before the dot is evaluated; the result of that evaluation, together with the `$id-expression$` [or splicer]{.addu}, determines the result of the entire postfix expression.
 :::
 
 Modify paragraph 4 to account for splices in member access expressions:
 
 ::: std
-[4]{.pnum} Abbreviating [`$postfix-expression$`.`$id-expression$`]{.rm} [`$postfix-expression$.EXPR`, where `EXPR` is the `$id-expression$` or `$splice-expression$` following the dot,]{.addu} as `E1.E2`, `E1` is called the `$object expression$`. [...]
+[4]{.pnum} Abbreviating [`$postfix-expression$`.`$id-expression$`]{.rm} [`$postfix-expression$.EXPR`, where `EXPR` is the `$id-expression$` or splicer following the dot,]{.addu} as `E1.E2`, `E1` is called the `$object expression$`. [...]
 
 :::
 
-Adjust the language in paragraphs 6-9 to account for splice-specifiers.
+Adjust the language in paragraphs 6-9 to account for splicers.
 
 ::: std
 
@@ -3385,21 +3389,18 @@ Add a new subsection of [expr.unary]{.sref} following [expr.delete]{.sref}
 ::: addu
 **The Reflection Operator   [expr.reflect]**
 
-FIXME: `$template-name$` and `$id-expression$` can both refer to template names, have to handle this better. See wording in the template argument parsing section.
-
 ```
 $reflect-expression$:
    ^ ::
-   ^ $nested-name-specifier$@~_opt_~@ $namespace-name$
-   ^ $nested-name-specifier$@~_opt_~@ $template-name$
-   ^ $nested-name-specifier$@~_opt_~@ $concept-name$
+   ^ $unqualified-id$
+   ^ $qualified-id$
    ^ $type-id$
-   ^ $id-expression$
+   ^ $pack-index-expression$
 ```
 
 [#]{.pnum} The unary `^` operator, called the _reflection operator_, yields a prvalue of type `std::meta::info` ([basic.fundamental]{.sref}).
 
-[#]{.pnum} A _reflect-expression_ is parsed as the longest possible sequence of tokens that could syntactically form a _reflect-expression_.
+[#]{.pnum} A `$reflect-expression$` is parsed as the longest possible sequence of tokens that could syntactically form a `$reflect-expression$`.
 
 [#]{.pnum}
 
@@ -3422,30 +3423,21 @@ consteval void g(std::meta::info r, X<false> xv) {
 ```
 :::
 
-[#]{.pnum} When applied to `::`, the reflection operator produces a reflection for the global namespace.
-When applied to a `$namespace-name$`, the reflection operator produces a reflection for the indicated namespace or namespace alias.
+[#]{.pnum} A `$reflect-expression$` having the form `^ ::` produces a reflection of the global namespace.
 
-[#]{.pnum} When applied to a `$template-name$`, the reflection operator produces a reflection for the indicated template.
+[#]{.pnum} A `$reflect-expression$` having the form `^ $unqualified-id$` or `^ $qualified-id$` performs name lookup for the operand following `^` and produces a result as follows:
 
-[#]{.pnum} When applied to a `$concept-name$`, the reflection operator produces a reflection for the indicated concept.
+* [#.#]{.pnum} If lookup finds an overload set `$S$` such that the assignment of `$S$` to an invented variable of type `const auto` ([dcl.type.auto.deduct]{.sref}) would select a unique candidate function `$F$` from `$S$`, then the result is a reflection of `$F$`. If lookup finds any other overload set, the program is ill-formed.
 
-[#]{.pnum} When applied to a `$typedef-name$`, the reflection operator produces a reflection of the indicated `$typedef-name$`. When applied to any other `$type-id$`, the reflection operator produces a reflection of the indicated type.
+* [#.#]{.pnum} Otherwise, if lookup finds a `$typedef-name$` or a `$namespace-alias$`, then the result is a reflection of the indicated name.
 
-[#]{.pnum} When applied to an `$id-expression$`, the reflection operator produces a reflection as follows:
+* [#.#]{.pnum} Otherwise, if lookup finds a non-type template parameter, the result is a reflection of the result computed by an `$id-expression$` naming the parameter.
 
-* [#.#]{.pnum} When applied to an enumerator, the reflection operator produces a reflection of the enumerator designated by the operand.
+* [#.#]{.pnum} Otherwise, if lookup finds a variable, structured binding, function, enumerator, type, non-static member, template, or namespace, the result is a reflection of the denoted entity.
 
-* [#.#]{.pnum} Otherwise, when applied to an overload set `S`, if the assignment of `S` to an invented variable of type `const auto` ([dcl.type.auto.deduct]{.sref}) would select a unique candidate function `F` from `S`, the result is a reflection of `F`. Otherwise, the expression `^S` is ill-formed.
+[#]{.pnum} A `$reflect-expression$` of the form `^ $type-id$` produces a reflection of the denoted type. A `$reflect-expression$` that could be validly interpreted as either `^ $unqualified-id$` or `^ $type-id$` is interpreted as `^ $unqualified-id$`, and a `$reflect-expression$` that could be validly interpreted as `^ $qualified-id$` or `^ $type-id$` is interpreted as `^ $qualified-id$`.
 
-* [#.#]{.pnum} Otherwise, when applied to one of
-
-  * [#.#.#]{.pnum} a non-type template parameter of non-class and non-reference type or
-  * [#.#.#]{.pnum} a `$pack-index-expression$` of non-class and non-reference type
-
-  the reflection operator produces a reflection of the value computed by the operand.
-
-* [#.#]{.pnum} Otherwise, the reflection operator produces a reflection of the variable, function, or non-static member designated by the operand.
-The `$id-expression$` is not evaluated.
+[#]{.pnum} A `$reflect-expression$` having the form `^ $pack-index-expression$` produces a reflection of the result computed by the `$pack-index-expression$`.
 
 ::: example
 ```cpp
@@ -3469,25 +3461,25 @@ constexpr auto r = ^std::vector;  // OK
 Extend [expr.eq]{.sref}/2 to also handle `std::meta::info`:
 
 ::: std
-[2]{.pnum} The converted operands shall have arithmetic, enumeration, pointer, or pointer-to-member type, or [type]{.rm} [one of the types `std::meta::info` or ]{.addu} `std​::​nullptr_t`. The operators `==` and `!=` both yield `true` or `false`, i.e., a result of type `bool`. In each case below, the operands shall have the same type after the specified conversions have been applied.
+[2]{.pnum} The converted operands shall have arithmetic, enumeration, pointer, or pointer-to-member type, [type `std::meta::info`,]{.addu} or type `std::nullptr_t`. The operators `==` and `!=` both yield `true` or `false`, i.e., a result of type `bool`. In each case below, the operands shall have the same type after the specified conversions have been applied.
 
 :::
 
 Add a new paragraph between [expr.eq]{.sref}/5 and /6:
 
 ::: std
-[5]{.pnum} Two operands of type `std​::​nullptr_t` or one operand of type `std​::​nullptr_t` and the other a null pointer constant compare equal.
+[5]{.pnum} Two operands of type `std::nullptr_t` or one operand of type `std::nullptr_t` and the other a null pointer constant compare equal.
 
 ::: addu
 [*]{.pnum} If both operands are of type `std::meta::info`, comparison is defined as follows:
 
 * [*.#]{.pnum} If one operand is a null reflection value, then they compare equal if and only if the other operand is also a null reflection value.
 * [*.#]{.pnum} Otherwise, if one operand represents a `$template-id$` referring to a specialization of an alias template, then they compare equal if and only if the other operand represents the same `$template-id$` ([temp.type]).
-* [*.#]{.pnum} Otherwise, if one operand represents a namespace alias or a `$typedef-name$`, then they compare equal if and only if the construct represented by the other operand represents the same kind of construct, shares the same name, is declared within the same enclosing scope, and aliases the same underlying entity.
+* [*.#]{.pnum} Otherwise, if one operand represents a `$namespace-alias$` or a `$typedef-name$`, then they compare equal if and only if the construct represented by the other operand represents the same kind of construct, shares the same name, is declared within the same enclosing scope, and aliases the same underlying entity.
 * [*.#]{.pnum} Otherwise, if one operand represents a value, then they compare equal if and only if the other operand represents a template-argument-equivalent value ([temp.type]{.sref}).
 * [*.#]{.pnum} Otherwise, if one operand represents an object, then they compare equal if and only if the other operand represents the same object.
 * [*.#]{.pnum} Otherwise, if one operand represents an entity, then they compare equal if and only if the other operand represents the same entity.
-* [*.#]{.pnum} Otherwise, if one operand represents a base class specifier, then they compare equal if and only if the other operand represents the same base class specifier.
+* [*.#]{.pnum} Otherwise, if one operand represents a `$base-specifier$`, then they compare equal if and only if the other operand represents the same `$base-specifier$`.
 * [*.#]{.pnum} Otherwise, both operands `O@~_1_~@` and `O@~_2_~@` represent descriptions of declarations of non-static data members: Let `C@~_1_~@` and `C@~_2_~@` be invented class types such that each `C@~_k_~@` has a single non-static data member having the properties described by `O@~_k_~@`. The operands compare equal if and only if the data members of `C@~_1_~@` and `C@~_2_~@` would be declared with the same type or `$typedef-name$`, name (if any), `$alignment-specifiers$` (if any), width, and attributes.
 :::
 
@@ -3497,10 +3489,29 @@ Add a new paragraph between [expr.eq]{.sref}/5 and /6:
 
 ### [expr.const]{.sref} Constant Expressions {-}
 
+Modify paragraph 15 to disallow returning non-consteval-only pointers and references to consteval-only objects from constant expressions.
+
+::: std
+[15]{.pnum} A _constant-expression_ is either a glvalue core constant expression that [\ ]{.addu}
+
+* [#.#]{.pnum} refers to an entity that is a permitted result of a constant expression[, and]{.addu}
+* [[#.#]{.pnum} is of consteval-only type if the entity designated by the expression is of consteval-only type,]{.addu}
+
+or a prvalue core constant expression whose value satisfies the following constraints:
+
+* [#.#]{.pnum} if the value is an object of class type, each non-static data member of reference type refers to an entity that is a permitted result of a constant expression [and has consteval-only type if the entity has consteval-only type]{.addu},
+* [#.#]{.pnum} if the value is an object of scalar type, it does not have an indeterminate or erroneous value ([basic.indet]),
+* [#.#]{.pnum} if the value is of pointer type, it is a pointer to an object of static storage duration, a pointer past the end of such an object ([expr.add]), a pointer to a non-immediate function, or a null pointer value,
+* [[#.#]{.pnum} if the value is a pointer to an object of consteval-only type, or a pointer past the end of such an object, then the prvalue is also of consteval-only type,]{.addu}
+* [#.#]{.pnum} if the value is of pointer-to-member-function type, it does not designate an immediate function, and
+* [#.#]{.pnum} if the value is an object of class or array type, each subobject satisfies these constraints for the value.
+
+:::
+
 Modify (and clean up) the definition of _immediate-escalating_ to also apply to expressions of consteval-only type.
 
 ::: std
-[18]{.pnum} A[n]{.rm} [potentially-evalauted]{.addu} expression or conversion is _immediate-escalating_ if it is [not]{.rm} [neither]{.addu} initially in an immediate function context [nor a subexpression of an immediate invocation,]{.addu} and it [is]{.rm} either
+[18]{.pnum} A[n]{.rm} [potentially-evaluated]{.addu} expression or conversion is _immediate-escalating_ if it is [not]{.rm} [neither]{.addu} initially in an immediate function context [nor a subexpression of an immediate invocation,]{.addu} and it [is]{.rm} either
 
 * [#.#]{.pnum} [a potentially-evaluated]{.rm} [is an]{.addu} `$id-expression$` that denotes an immediate function[,]{.addu} [that is not a subexpression of an immediate invocation, or]{.rm}
 * [#.#]{.pnum} [is]{.addu} an immediate invocation that is not a constant expression[, or]{.addu} [and is not a subexpression of an immediate invocation.]{.rm}
@@ -3616,7 +3627,7 @@ consteval int *not_constant() {
 constexpr bool b4 = [] {
   int *p = not_constant();          // error: not_constant() produces a declaration
                                     // in an immediate-escalated function, but is
-                                    // not plainly constant-evalauted.
+                                    // not plainly constant-evaluated.
   delete p;
   return true;
 }();
@@ -3626,35 +3637,26 @@ constexpr bool b4 = [] {
 [24]{.pnum} The _evaluation context_ is a set of points within the program that determines which declarations are found by certain expressions used for reflection. During the evaluation of a manifestly constant-evaluated expression `$M$`, the evaluation context of an evaluation `$E$` comprises the union of
 
 * [#.#]{.pnum} the instantiation context of `$M$` ([module.context]), and
-* [#.#]{.pnum} the injected points corresponding to any injected declarations ([expr.const]) produced by evaluations sequenced before `$E$`.
+* [#.#]{.pnum} the injected points corresponding to any injected declarations ([expr.const]) produced by evaluations sequenced before `$E$` ([intro.execution]).
 
 :::
 :::
 
 ### [dcl.typedef]{.sref} The `typedef` specifier {-}
 
-Account for `$splice-template-speciifer$`s in paragraph 3.
+Account for `$splice-type-speciifer$`s in paragraph 3.
 
 ::: std
-[3]{.pnum} A `$simple-template-id$` is only a `$typedef-name$` if its `$template-name$` [or `$splice-template-specifier$` designate]{.addu} [names]{.rm} an alias template or a template `$template-parameter$`.
+[3]{.pnum} A `$simple-template-id$` is only a `$typedef-name$` if its `$template-name$` [or `$splice-type-specifier$` designates]{.addu} [names]{.rm} an alias template or a template `$template-parameter$`.
 
 :::
 
 ### [dcl.type.simple]{.sref} Simple type specifiers {-}
 
-Extend the grammar for `$simple-type-specifier$` and `$computed-type-specifier$` as follows:
+Extend the grammar for `$computed-type-specifier$` as follows:
 
 ::: std
 ```diff
-  $simple-type-specifier$:
-    $nested-name-specifier$@~_opt_~@ $type-name$
-    $nested-name-specifier$ template $simple-template-id$
-    $computed-type-specifier$
-    $placeholder-type-specifier$
-    $nested-name-specifier$@~_opt_~@ $template-name$
-+   $splice-template-specifier$
-    ...
-
   $computed-type-specifier$:
      $decltype-specifier$
      $pack-index-specifier$
@@ -3662,10 +3664,25 @@ Extend the grammar for `$simple-type-specifier$` and `$computed-type-specifier$`
 ```
 :::
 
-Modify paragraph 3 to indicate that a `$splice-template-specifier$` can be deduced.
+Add a restriction to paragrpah 2 disallowing splicers from appearing after nested name specifiers.
 
 ::: std
-[3]{.pnum} A `$placeholder-type-specifier$` is a placeholder for a type to be deduced ([dcl.spec.auto]). [The `$simple-template-id$` in a `$type-specifier$` of the form `$nested-name-specifier$ template $simple-template-id$` shall not contain a `$splice-template-specifier$`.]{.addu} A `$type-specifier$` of the form `typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ $template-name$` [or `$splice-template-specifier$`]{.addu} is a placeholder for a deduced class type ([dcl.type.class.deduct]). The `$nested-name-specifier$`, if any, shall be non-dependent and the `$template-name$` [or `$splice-template-specifier$`]{.addu} shall [name]{.rm} [designate]{.addu} a deducible template. A _deducible template_ is either a class template or is an alias template whose `$defining-type-id$` is of the form
+[2]{.pnum} The component names of a `$simple-type-specifier$` are those of its `$nested-name-specifier$`, `$type-name$`, `$simple-template-id$`, `$template-name$`, and/or `$type-constraint$` (if it is a `$placeholder-type-specifier$`). The component name of a `$type-name$` is the first name in it. [The `$simple-template-id$` in a `$type-specifier$` of the form `$nested-name-specifier$ template $simple-template-id$` shall not contain a splicer.]{.addu}
+
+:::
+
+Indicate that a `$splice-type-specifier$` can be a placeholder for a deduced class type.
+
+::: std
+[3]{.pnum} A `$placeholder-type-specifier$` is a placeholder for a type to be deduced ([dcl.spec.auto]). A `$type-specifier$` [of the form `typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ $template-name$`]{.rm} is a placeholder for a deduced class type ([dcl.type.class.deduct]) [if it]{.addu}
+
+:::addu
+* is of the form `typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ $template-name$`, or
+* consists of a `$splice-type-specifier$` that designates a class template or alias template.
+
+:::
+
+The `$nested-name-specifier$`, if any, shall be non-dependent and the `$template-name$` [or `$splice-type-specifier$`]{.addu} shall [name]{.rm} [designate]{.addu} a deducible template. A _deducible template_ is either a class template or is an alias template whose `$defining-type-id$` is of the form
 
 ```cpp
 typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ template@~_opt_~@ $simple-template-id$
@@ -3675,7 +3692,7 @@ where the `$nested-name-specifier$` (if any) is non-dependent and the `$template
 
 :::
 
-Add a row to [tab:dcl.type.simple] to cover the `$splice-template-specifier$` production.
+Add a row to [tab:dcl.type.simple] to cover the `$splice-type-specifier$` production.
 
 ::: std
 <center>Table 17: `$simple-type-specifier$`s and the types they specify [tab:dcl.type.simple]</center>
@@ -3687,25 +3704,8 @@ Add a row to [tab:dcl.type.simple] to cover the `$splice-template-specifier$` pr
 |`$pack-index-specifier$`|the type as defined in [dcl.type.pack.index]|
 |`$placeholder-type-specifier$`|the type as defined in [dcl.spec.auto]|
 |`$template-name$`|the type as defined in [dcl.type.class.deduct]|
-|[`$splice-template-specifier$`]{.addu}|[the type as defined in [dcl.type.class.deduct]]{.addu}|
+|[`$splice-type-specifier$`]{.addu}|[the type as defined in [dcl.type.class.deduct]]{.addu}|
 |`...`|...|
-:::
-
-### 9.2.9* [dcl.type.splice] Type splicing {-}
-
-Add a new subsection of [dcl.type]{.sref} following [dcl.type.class.deduct]{.sref}.
-
-::: std
-::: addu
-```diff
-+  $splice-type-specifier$
-+      typename@~_opt_~@ $splice-specifier$
-```
-
-[#]{.pnum} The `typename` may be omitted only within a type-only context ([temp.res.general]{.sref}).
-
-[#]{.pnum} The `$splice-specifier$` shall designate a type. The type designated by the `$splice-type-specifier$` is the same type designated by the `$splice-specifier$`.
-:::
 :::
 
 ### [dcl.init.general]{.sref} Initializers (General) {-}
@@ -3740,14 +3740,16 @@ If a program calls for the default-initialization of an object of a const-qualif
 Add a bullet to paragraph 9 of [dcl.fct]{.sref} to allow for reflections of abominable function types:
 
 ::: std
-[9]{.pnum} A function type with a _cv-qualifier-seq_ or a _ref-qualifier_ (including a type named by _typedef-name_ ([dcl.typedef], [temp.param])) shall appear only as:
+[9]{.pnum} A function type with a `$cv-qualifier-seq$` or a `$ref-qualifier$` (including a type named by `$typedef-name$` ([dcl.typedef], [temp.param])) shall appear only as:
 
-* [9.1]{.pnum} the function type for a non-static member function,
-* [9.2]{.pnum} ...
-* [9.5]{.pnum} the _type-id_ of a _template-argument_ for a _type-parameter_ ([temp.arg.type])[.]{.rm}[,]{.addu}
+* [#.#]{.pnum} the function type for a non-static member function,
+* [#.#]{.pnum} the function type to which a pointer to member refers,
+* [#.#]{.pnum} the top-level function type of a function typedef declaration or `$alias-declaration$`,
+* [#.#]{.pnum} the `$type-id$` in the default argument of a `$type-parameter$` ([temp.param]),
+* [#.#]{.pnum} the `$type-id$` of a `$template-argument$` for a `$type-parameter$` ([temp.arg.type])[.]{.rm}[, or]{.addu}
 
 ::: addu
-* [9.6]{.pnum} the operand of a _reflect-expression_ ([expr.reflect]).
+* [9.6]{.pnum} the operand of a `$reflect-expression$` ([expr.reflect]).
 :::
 
 :::
@@ -3758,7 +3760,7 @@ Change paragraph 2 of [dcl.fct.def.delete]{.sref} to allow for reflections of de
 
 ::: std
 
-[2]{.pnum} A program that refers to a deleted function implicitly or explicitly, other than to declare it [or to use as the operand of the reflection operator]{.addu}, is ill-formed.
+[2]{.pnum} A program that refers to a deleted function implicitly or explicitly, other than to declare it [or to use as the operand of the reflection operator ([expr.reflect])]{.addu}, is ill-formed.
 :::
 
 ### [enum.udecl]{.sref} The `using enum` declaration {-}
@@ -3773,32 +3775,26 @@ Extend the grammar for `$using-enum-declarator$` as follows:
   $using-enum-declarator$:
      $nested-name-specifier$@~_opt_~@ $identifier$
      $nested-name-specifier$@~_opt_~@ $simple-template-id$
-+    $splice-specifier$
++    $splice-type-specifier$
 ```
 :::
 
-Modify paragraph 1 of [enum.udecl]{.sref} as follows:
+Modify paragraph 1 to handle splicers:
 
 ::: std
 
-[1]{.pnum} A `$using-enum-declarator$` [that is not a `$splice-specifier$`]{.addu} names the set of declarations found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}) for the `$using-enum-declarator$`. The `$using-enum-declarator$` shall designate a non-dependent type with a reachable `$enum-specifier$`.
+[1]{.pnum} [A `using-enum-declarator` of the form `$splice-type-specifier$` is considered in a type-only context, and designates the same construct designated by the splicer. Any other]{.addu} [A]{.rm} `$using-enum-declarator$` names the set of declarations found by type-only lookup ([basic.lookup.general]) for the `$using-enum-declarator$` ([basic.lookup.unqual], [basic.lookup.qual]). The `$using-enum-declarator$` shall designate a non-dependent type with a reachable `$enum-specifier$`.
 :::
 
 ### [namespace.alias]{.sref} Namespace alias {-}
 
-Add a production to the grammar for `$qualified-namespace-specifier$` as follows:
+Add a production to the grammar for `$namespace-alias-definition$` as follows:
 
 ::: std
 ```diff
-  $namespace-alias$:
-      $identifier$
-
   $namespace-alias-definition$:
       namespace $identifier$ = $qualified-namespace-specifier$
-
-  $qualified-namespace-specifier$:
-      $nested-name-specifier$@~_opt_~@ $namespace-name$
-+     $splice-specifier$
++     namespace $identifier$ = $splice-specifier$
 ```
 :::
 
@@ -3806,25 +3802,25 @@ Add the following prior to paragraph 1, and renumber accordingly:
 
 ::: std
 :::addu
-[0]{.pnum} If a `$qualified-namespace-specifier$` is a `$splice-specifier$`, the `$splice-specifier$` shall designate a namespace or namespace alias; the `$qualified-namespace-specifier$` designates the same namespace or namespace alias designated by the `$splice-specifier$`. Otherwise, the `$qualified-namespace-specifier$` designates the namespace found by lookup ([basic.lookup.unqual]{.sref}, [basic.lookup.qual]{.sref}).
+[0]{.pnum} A `$splice-specifier$` appearing in a `$namespace-alias-definition$` shall designate a namespace or `$namespace-alias$`.
 :::
 :::
 
-Prefer the verb "designate" for `$qualified-namespace-specifiers$` in the paragraph that immediately follows:
+Prefer the verb "designate" in the paragraph that immediately follows:
 
 ::: std
-[2]{.pnum} The `$identifier$` in a `$namespace-alias-definition$` becomes a `$namespace-alias$` and denotes the namespace [denoted]{.rm} [designated]{.addu} by the `$qualified-namespace-specifier$`.
+[2]{.pnum} The `$identifier$` in a `$namespace-alias-definition$` becomes a `$namespace-alias$` and denotes the namespace [denoted]{.rm} [designated]{.addu} by the `$qualified-namespace-specifier$` [or `$splice-specifier$`]{.addu}.
 :::
 
 ### [namespace.udir]{.sref} Using namespace directive {-}
 
-Use `$qualified-namespace-specifier$` in the grammar for `$using-directive$`:
+Add `$splice-specifier$` to the grammar for `$using-directive$`:
 
 ::: std
 ```diff
   $using-directive$:
--    $attribute-specifier-seq$@~_opt_~@ using namespace $nested-name-specifier$@~_opt_~@ $namespace-name$
-+    $attribute-specifier-seq$@~_opt_~@ using namespace $qualified-namespace-specifier$
+      $attribute-specifier-seq$@~_opt_~@ using namespace $nested-name-specifier$@~_opt_~@ $namespace-name$
++     $attribute-specifier-seq$@~_opt_~@ using namespace $splice-specifier$
 ```
 :::
 
@@ -3832,7 +3828,7 @@ Add the following prior to the first paragraph of [namespace.udir]{.sref}, and r
 
 ::: std
 ::: addu
-[0]{.pnum} The `$qualified-namespace-specifier$` shall neither contain a dependent `$nested-name-specifier$` nor a dependent `$splice-specifier$`.
+[0]{.pnum} The `$splice-specifier$`, if any, designates a namespace or `$namespace-alias$`. Neither the `$nested-name-specifier$` nor the `$splice-specifier$` shall be dependent.
 :::
 
 [1]{.pnum} A `$using-directive$` shall not appear in class scope, but may appear in namespace scope or in block scope.
@@ -3887,13 +3883,13 @@ Change a sentence in paragraph 4 of [dcl.attr.grammar]{.sref} as follows:
 
 ### [module.global.frag] Global module fragment {-}
 
-Extend the caveat in paragraph 3.7 to also apply to `$splice-template-specifier$`s.
+Extend the caveat in paragraph 3.7 to also apply to `$splice-type-specifier$`s.
 
 ::: std
 In this determination, it is unspecified
 
 * [3.6]{.pnum} whether a reference to an `$alias-declaration$`, `typedef` declaration, `$using-declaration$`, or `$namespace-alias-definition$` is replaced by the declarations they name prior to this determination,
-* [#.#]{.pnum} whether a `$simple-template-id$` that does denote a dependent type and whose `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} an alias template is replaced by its denoted type prior to this determination,
+* [#.#]{.pnum} whether a `$simple-template-id$` that does not denote a dependent type and whose `$template-name$` [or `$splice-type-specifier$`]{.addu} [names]{.rm} [designates]{.addu} an alias template is replaced by its denoted type prior to this determination,
 * [#.#]{.pnum} ...
 
 :::
@@ -3912,21 +3908,21 @@ Modify the definition of reachability to account for injected declarations:
 
 ### [class.pre] Preamble {-}
 
-Disallow a `$slice-template-specifier$` from appearing in a declaration of a `$class-name$` in paragraph 1.
+Disallow splicers from appearing in a declaration of a `$class-name$` in paragraph 1.
 
 ::: std
 ...
 
-A class declaration where the `$class-name$` in the `$class-head-name$` is a `$simple-template-id$` shall be an explicit specialization ([temp.expl.spec]) or a partial specialization ([temp.spec.partial]). [The `$simple-template-id$` shall not contain a `$splice-template-specifier$`.]{.addu} A `$class-specifier$` whose `$class-head$` omits the `$class-head-name$` defines an _unnamed class_.
+A class declaration where the `$class-name$` in the `$class-head-name$` is a `$simple-template-id$` shall be an explicit specialization ([temp.expl.spec]) or a partial specialization ([temp.spec.partial]). [The `$simple-template-id$` shall not contain a splicer.]{.addu} A `$class-specifier$` whose `$class-head$` omits the `$class-head-name$` defines an _unnamed class_.
 
 :::
 
 ### [class.name] Class names {-}
 
-Cover `$splice-template-specifier$s in paragraph 5.
+Cover `$splice-type-specifier$s in paragraph 5.
 
 ::: std
-[5]{.pnum} A `$simple-template-id$` is only a `$class-name$` if its `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} a class template.
+[5]{.pnum} A `$simple-template-id$` is only a `$class-name$` if its `$template-name$` [or `$splice-type-specifier$`]{.addu} [names]{.rm} [designates]{.addu} a class template.
 
 :::
 
@@ -3943,19 +3939,19 @@ Extend paragraph 5, and modify note 3, to clarify the existence of subobjects co
 
 ### [over.match.class.deduct]{.sref} Class template argument deduction {-}
 
-Extend paragraph 1 to work with `$splice-template-specifier$`s.
+Extend paragraph 1 to work with `$splice-type-specifier$`s.
 
 ::: std
-[1]{.pnum} When resolving a placeholder for a deduced class type ([dcl.type.class.deduct]) where the `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} a primary class template `C`, a set of functions and function templates, called the guides of `C`, is formed comprising:
+[1]{.pnum} When resolving a placeholder for a deduced class type ([dcl.type.class.deduct]) where the `$template-name$` [or `$splice-type-specifier$`]{.addu} [names]{.rm} [designates]{.addu} a primary class template `C`, a set of functions and function templates, called the guides of `C`, is formed comprising:
 
 * [#.#]{.pnum} ...
 
 :::
 
-Extend paragraph 3 to also cover `$splice-template-specifier$`s.
+Extend paragraph 3 to also cover `$splice-type-specifier$`s.
 
 :::std
-[3]{.pnum} When resolving a placeholder for a deduced class type ([dcl.type.simple]) where the `$template-name$` [or `$splice-template-specifier$`]{.addu} [names]{.rm} [designates]{.addu} an alias template `A`, the `$defining-type-id$` of `A` must be of the form
+[3]{.pnum} When resolving a placeholder for a deduced class type ([dcl.type.simple]) where the `$template-name$` [or `$splice-type-specifier$`]{.addu} [names]{.rm} [designates]{.addu} an alias template `A`, the `$defining-type-id$` of `A` must be of the form
 
 ```cpp
 typename@~_opt_~@ $nested-name-specifier$@~_opt_~@ template@~_opt_~@ $simple-template-id$
@@ -3970,7 +3966,7 @@ as specified in [dcl.type.simple]. The guides of `A` are the set of functions or
 Add built-in operator candidates for `std::meta::info` to [over.built]{.sref}:
 
 ::: std
-[16]{.pnum} For every `T`, where `T` is a pointer-to-member type[, `std::meta::info`,]{.addu} or `std​::​nullptr_t`, there exist candidate operator functions of the form
+[16]{.pnum} For every `T`, where `T` is a pointer-to-member type[, `std::meta::info`,]{.addu} or `std::nullptr_t`, there exist candidate operator functions of the form
 ```cpp
 bool operator==(T, T);
 bool operator!=(T, T);
@@ -3979,21 +3975,35 @@ bool operator!=(T, T);
 
 ### [temp.param]{.sref} Template parameters {-}
 
-Extend the last sentence of paragraph 4 to disallow splicing concepts in template parameter declarations.
+Extend the grammar for `$type-constraint$` to include `$splice-type-specifier$`.
 
 ::: std
-[4]{.pnum} ... The concept designated by a type-constraint shall be a type concept ([temp.concept]) [that is not a `$splice-template-specifier$`]{.addu}.
+```diff
+  $type-constraint$:
+      $nested-name-specifier$@~_opt_~@ $concept-name$
+      $nested-name-specifier$@~_opt_~@ $concept-name$ < $template-argument-list$@~_opt_~@>
++     $splice-type-specifier$
+```
+:::
+
+Add a paragraph after paragraph 3 to restrict the type splicers that form `$type-constraint$`s.
+
+::: std
+::: addu
+[3+]{.pnum} A non-dependent `$splice-type-specifier$` only forms a `$type-constraint$` when it designates a concept. A `$type-constraint$` of the form `$splice-type-specifier$` shall not appear in a `$type-parameter$`.
+:::
 :::
 
 ### [temp.names]{.sref} Names of template specializations {-}
 
-Introduce `$splice-template-specifier$` and `$splice-template-argument$` nonterminals. Extend `$simple-template-id$` and `$template-argument$` to leverage these.
+Extend `$simple-template-id$` and `$template-argument$` to leverage splicers.
 
 ::: std
 ```diff
   $simple-template-id$:
       $template-name$ < $template-argument-list$@~_opt_~@ >
-+     $splice-template-specifier$ < $template-argument-list$@~_opt_~@ >
++     $splice-expr-template-specifier$ < $template-argument-list$@~_opt_~@ >
++     $splice-type-specifier$ < $template-argument-list$@~_opt_~@ >
 
   $template-id$:
       $simple-template-id$
@@ -4012,12 +4022,6 @@ Introduce `$splice-template-specifier$` and `$splice-template-argument$` nonterm
       $type-id$
       $id-expression$
       $braced-init-list$
-+     $splice-template-argument$
-+
-+ $splice-template-specifier$:
-+     template $splice-specifier$
-+
-+ $splice-template-argument$:
 +     $splice-specifier$
 ```
 :::
@@ -4029,22 +4033,13 @@ Extend paragraph 2 to cover `$simple-template-id$`s and `$template-id$`s that ha
 
 :::
 
-Add a paragraph following paragraph 2 defining the semantics of a `$splice-template-specifier$`.
-
-::: std
-::: addu
-[2+]{.pnum} A `$splice-template-specifier$` designates the same entity designated by its `$splice-specifier$`. A `$splice-template-specifier$` shall designate a concept, variable template, class template, alias template, or function template. A `$splice-template-specifier$` shall not designate a constructor template or destructor template.
-
-:::
-:::
-
 Extend and re-format paragraph 3 of [temp.names]{.sref}:
 
 ::: std
 
 [3]{.pnum} A `<` is interpreted as the delimiter of a `$template-argument-list$` if it follows [either]{.addu}
 
-* [[#.#]{.pnum} a `$splice-template-specifier$`, or]{.addu}
+* [[#.#]{.pnum} a `$splice-expr-template-specifier$` or `$splice-type-specifier$`, or]{.addu}
 * [#.#]{.pnum} a name that is not a `$conversion-function-id$` and
   * [#.#.#]{.pnum} that follows the keyword template or a ~ after a nested-name-specifier or in a class member access expression, or
   * [#.#.#]{.pnum}  for which name lookup finds the injected-class-name of a class template or finds any declaration of a template, or
@@ -4073,17 +4068,17 @@ template<class T> void f(T* p) {
 :::
 :::
 
-Extend paragraph 8 to also cover `$simple-template-id$`s containing `$splice-template-specifier$`s.
+Extend paragraph 8 to also cover `$simple-template-id$`s containing `$splice-expr-template-specifier$`s.
 
 ::: std
-[8]{.pnum} When the `$template-name$` [or `$splice-template-specifier$`]{.addu} of a `$simple-template-id$` [names]{.rm} [designates]{.addu} a constrained non-function template or a constrained template `$template-parameter$`, and all `$template-arguments$` in the `$simple-template-id$` are non-dependent ([temp.dep.temp]), the associated contraints ([temp.constr.decl]) of the constrained template shall be satisfied ([temp.constr.constr]).
+[8]{.pnum} When the `$template-name$` [or splicer]{.addu} of a `$simple-template-id$` [names]{.rm} [designates]{.addu} a constrained non-function template or a constrained template `$template-parameter$`, and all `$template-arguments$` in the `$simple-template-id$` are non-dependent ([temp.dep.temp]), the associated contraints ([temp.constr.decl]) of the constrained template shall be satisfied ([temp.constr.constr]).
 
 :::
 
 Change paragraph 9 to allow splicing into a *concept-id*:
 
 ::: std
-[9]{.pnum} A _concept-id_ is a `$simple-template-id$` where [either]{.addu} the `$template-name$` is a `$concept-name$` [or the `$splice-template-specifier$` designates a concept]{.addu}. A concept-id is a prvalue of type bool, and does not name a template specialization.
+[9]{.pnum} A _concept-id_ is a `$simple-template-id$` where [either]{.addu} the `$template-name$` is a `$concept-name$` [or the `$splice-expr-template-specifier$` designates a concept]{.addu}. A concept-id is a prvalue of type `bool`, and does not name a template specialization. A concept-id evaluates to `true` if the concept's normalized `$constraint-expression$` ([temp.constr.decl]) is satisfied ([temp.constr.constr]) by the specified template arguments and `false` otherwise.
 :::
 
 
@@ -4093,7 +4088,7 @@ Adjust paragraph 3 of [temp.arg.general] to not apply to splice template argumen
 
 ::: std
 
-[3]{.pnum} [A `$template-argument$` of the form `$splice-specifier$` is interpreted as a `$splice-template-argument$`.]{.addu} In a `$template-argument$` [that is not a `$splice-template-argument$`]{.addu}, an ambiguity between a `$type-id$` and an expression is resolved to a `$type-id$`, regardless of the form of the corresponding `$template-parameter$`.
+[3]{.pnum} In a `$template-argument$` [that is not a `$splice-specifier$`]{.addu}, an ambiguity between a `$type-id$` and an expression is resolved to a `$type-id$`, regardless of the form of the corresponding `$template-parameter$`.
 
 ::: example2
 ```diff
@@ -4104,8 +4099,8 @@ Adjust paragraph 3 of [temp.arg.general] to not apply to splice template argumen
     f<int()>();       // int() is a type-id: call the first f()
 
 +   constexpr int x = 42;
-+   f<[:^int:]>();    // splice-template-argument: calls the first f()
-+   f<[:^x:]>();      // splice-template-argument: calls the second f()
++   f<[:^int:]>();    // splice-specifier: calls the first f()
++   f<[:^x:]>();      // splice-specifier: calls the second f()
   }
 ```
 :::
@@ -4117,29 +4112,25 @@ Adjust paragraph 3 of [temp.arg.general] to not apply to splice template argumen
 Extend [temp.arg.type]{.sref}/1 to cover splice template arguments:
 
 ::: std
-[1]{.pnum} A `$template-argument$` for a `$template-parameter$` which is a type shall [either]{.addu} be a `$type-id$` [or a `$splice-template-argument$` whose `$splice-specifier$` designates a type]{.addu}.
+[1]{.pnum} A `$template-argument$` for a `$template-parameter$` which is a type shall [either]{.addu} be a `$type-id$` [or a `$splice-specifier$` that is either dependent or designates a type]{.addu}.
 :::
-
-### [temp.arg.nontype]{.sref} Template non-type arguments {-}
-
-TODO: splice-specifier shall designate a value or something.
 
 ### [temp.arg.template]{.sref} Template template arguments {-}
 
 Extend [temp.arg.template]{.sref}/1 to cover splice template arguments:
 
 ::: std
-[1]{.pnum} A `$template-argument$` for a template `$template-parameter$` shall be the name of a class template or an alias template, expressed as `$id-expression$`[, or a `$splice-template-argument$` whose `$splice-specifier$` designates a template]{.addu}.
+[1]{.pnum} A `$template-argument$` for a template `$template-parameter$` shall be [the name of]{.rm} a class template or an alias template, expressed as [an]{.addu} `$id-expression$` [or a (possibly dependent) splicer]{.addu}. Only primary templates are considered when matching the template argument with the corresponding parameter; partial specializations are not considered even if their parameter lists match that of the template template parameter.
 :::
 
 ### [temp.type]{.sref} Type equivalence {-}
 
-Extend `$template-id$` equivalence as defined by paragraph 1 to cover `$splice-template-specifier$`s.
+Extend `$template-id$` equivalence as defined by paragraph 1 to cover splicers.
 
 ::: std
 [1]{.pnum} Two `$template-id$`s are the same if
 
-* their `$template-name$`s, [`$splice-template-specifier$`s, ]{.addu} `$operator-function-id$`s, or `$literal-operator-id$`s refer to the same template, and
+* their `$template-name$`s, [`$splice-expr-template-specifier$`s, `$splice-type-specifier$`s, ]{.addu} `$operator-function-id$`s, or `$literal-operator-id$`s refer to the same template, and
 * their corresponding type `$template-argument$`s are the same type, and
 * the template parameter values determined by their corresponding non-type template arguments ([temp.arg.nontype]) are template-argument-equivalent (see below), and
 * their corresponding template `$template-argument$`s refer to the same template.
@@ -4157,21 +4148,21 @@ Extend *template-argument-equivalent* to handle `std::meta::info`:
 * [2.1]{.pnum} they are of integral type and their values are the same, or
 * [2.2]{.pnum} they are of floating-point type and their values are identical, or
 * [2.3]{.pnum} they are of type `std::nullptr_t`, or
-* [2.*]{.pnum} [they are of type `std::meta::info` and they compare equal, or]{.addu}
+* [2.*]{.pnum} [they are of type `std::meta::info` and their values are the same, or]{.addu}
 * [2.4]{.pnum} they are of enumeration type and their values are the same, or
 * [2.5]{.pnum} [...]
 :::
 
 ### [temp.deduct.guide]{.sref} Deduction guides {-}
 
-Extend paragraph 1 to clarify that `$splice-template-specifier$`s can also leverage deduction guides.
+Extend paragraph 1 to clarify that `$splice-type-specifier$`s can also leverage deduction guides.
 
 ::: std
-[1]{.pnum} Deduction guides are used when a `$template-name$` [or `$splice-template-specifier$`]{.addu} appears as a type specifier for a deduced class type ([dcl.type.class.deduct]). Deduction guides are not found by name lookup. Instead, when performing class template argument deduction ([over.match.class.deduct]), all reachable deduction guides declared for the class template are considered.
+[1]{.pnum} Deduction guides are used when a `$template-name$` [or `$splice-type-specifier$`]{.addu} appears as a type specifier for a deduced class type ([dcl.type.class.deduct]). Deduction guides are not found by name lookup. Instead, when performing class template argument deduction ([over.match.class.deduct]), all reachable deduction guides declared for the class template are considered.
 
 :::
 
-Notwithstanding the above, extend paragraph 3 to clarify that `$splice-template-specifier$`s cannot themselves appear in deduction guides.
+Notwithstanding the above, extend paragraph 3 to clarify that `$splice-type-specifier$`s cannot themselves appear in deduction guides.
 
 ::: std
 [3]{.pnum} The same restrictions apply to the `$parameter-declaration-clause$` of a deduction guide as in a function declaration ([dcl.fct]), except that a generic parameter type placeholder ([dcl.spec.auto]) shall not appear in the `$parameter-declaration-clause$` of a deduction guide. The `$simple-template-id$` shall name a class template specialization [and shall contain a `$template-name$`]{.addu}. The `$template-name$` shall be the same `$identifier$` as the `$template-name$` of the `$simple-template-id$`. A `$deduction-guide$` shall inhabit the scope to which the corresponding class template belongs and, for a member class template, have the same access. Two deduction guide declarations for the same class template shall not have equivalent `$parameter-declaration-clauses$` if either is reachable from the other.
@@ -4187,30 +4178,14 @@ Extend paragraph 2 to enable reflection of alias template specializations.
 
 :::
 
-### [temp.concept]{.sref} Concept definitions {-}
-
-Extend the grammar of `$concept-name$` to allow for splicing reflections of concepts:
-
-::: std
-```diff
-  $concept-name$:
-    $identifier$
-+   $splice-template-specifier$
-```
-:::
-
-Modify paragraph 2 to account for splicing reflections of concepts:
-
-::: std
-A `$concept-definition$` declares a concept. Its [`$concept-name$` shall be an `$identifier$`, and the]{.addu} `$identifier$` becomes a _concept-name_ referring to that concept within its scope. The optional _attribute-specifier-seq_ appertains to the concept.
-
-:::
-
 ### [temp.res.general]{.sref} General {-}
 
-Disallow `$splice-template-specifier$`s from appearing in `$typename-specifier$`s.
+Disallow `$splice-type-specifier$`s from appearing in `$typename-specifier$`s, since splicers can't follow `$nested-name-specifier$`s.
 
-[3]{.pnum} The component names of a `$typename-specifier$` are its `$identifier$` (if any) and those of its `$nested-name-specifier$` and `$simple-template-id$` (if any). The `$simple-template-id$` shall not contain a `$splice-template-specifier$`.
+::: std
+[3]{.pnum} The component names of a `$typename-specifier$` are its `$identifier$` (if any) and those of its `$nested-name-specifier$` and `$simple-template-id$` (if any). [The `$simple-template-id$` shall not contain a splicer.]{.addu}
+
+:::
 
 ### [temp.dep.expr]{.sref} Type-dependent expressions {-}
 
@@ -4239,7 +4214,10 @@ Add a new paragraph at the end of [temp.dep.expr]{.sref}:
 ::: std
 ::: addu
 
-[9]{.pnum} A `$primary-expression$` of the form `$splice-specifier$` or `template $splice-specifier$  < $template-argument-list$@~_opt_~@ >` is type-dependent if the `$splice-specifier$` is value-dependent or if the optional `$template-argument-list$` contains a value-dependent non-type or template argument, or a dependent type argument.
+[9]{.pnum} A `$primary-expression$` of the form `$splice-specifier$` or `$splice-expr-template-specifier$ < $template-argument-list$@~_opt_~@ >` is type-dependent if
+
+* [#.#]{.pnum} the `$splice-specifier$` or `$splice-expr-template-specifier$` is dependent, or
+* [#.#]{.pnum} the optional `$template-argument-list$` contains a dependent type argument, a value-dependent non-type argument, a dependent template template argument, or a dependent `$splice-specifier$`.
 
 :::
 :::
@@ -4265,16 +4243,19 @@ alignof ( type-id )
 noexcept ( expression )
 ```
 
-[A `$reflect-expression$` is value-dependent if the operand of the reflection operator is a type-dependent or value-dependent expression or if that operand is a dependent `$type-id$`, a dependent `$namespace-name$`, or a dependent `$template-name$`.]{.addu}
+[A `$reflect-expression$` is value-dependent if the operand following `^` is a dependent name, names a dependent type, or contains a dependent `$pack-index-expression$`.]{.addu}
 :::
 
 
-Add a new paragraph after [temp.dep.constexpr]{.sref}/4:
+Add a new paragraph after [temp.dep.constexpr]{.sref}/5:
 
 ::: std
 ::: addu
 
-[6]{.pnum} A `$primary-expression$` of the form `$splice-specifier$` or `template $splice-specifier$  < $template-argument-list$@~_opt_~@ >` is value-dependent if the `$constant-expression$` is value-dependent or if the optional `$template-argument-list$` contains a value-dependent non-type or template argument, or a dependent type argument.
+[6]{.pnum} A `$primary-expression$` of the form `$splice-specifier$` or `$splice-expr-template-specifier$ < $template-argument-list$@~_opt_~@ >` is value-dependent if
+
+* [#.#]{.pnum} the `$splice-specifier$` or `$splice-expr-template-specifier$` is dependent, or
+* [#.#]{.pnum} the optional `$template-argument-list$` contains a dependent type argument, a value-dependent non-type argument, a dependent template template argument, or a dependent `$splice-specifier$`.
 
 :::
 :::
@@ -4860,7 +4841,7 @@ consteval bool has_identifier(info r);
 * [#.#]{.pnum} Otherwise, if `r` represents a `$typedef-name$`, then `true` when the `$typedef-name$` is an identifier.
 * [#.#]{.pnum} Otherwise, if `r` represents a class type `$C$`, then `true` when either `$C$` has a typdef name for linkage purposes ([dcl.typedef]) or the `$class-name$` introduced by the declaration of `$C$` is an identifier.
 * [#.#]{.pnum} Otherwise, if `r` represents a variable, then `true` if `r` does not represent a variable template specialization.
-* [#.#]{.pnum} Otherwise, if `r` represents a structured binding, enumerator, non-static data member, template, namespace, or namespace alias, then `true`.
+* [#.#]{.pnum} Otherwise, if `r` represents a structured binding, enumerator, non-static data member, template, namespace, or `$namespace-alias$`, then `true`.
 * [#.#]{.pnum} Otherwise, if `r` represents a base class specifier, then `true` if `has_identifier(type_of(r))`.
 * [#.#]{.pnum} Otherwise if `r` represents a description of a declaration of a non-static data member, then letting `$o$` be a `data_member_options_t` value such that `data_member_spec(type_of(r), $o$) == $r$`, then `true` if `$o$.name` contains a value.
 * [#.#]{.pnum} Otherwise, `false`.
@@ -4878,7 +4859,7 @@ consteval u8string_view u8identifier_of(info r);
 
 * [#.#]{.pnum} If `r` represents a literal operator or literal operator template, then the `$ud-suffix$` of the operator or operator template.
 * [#.#]{.pnum} Otherwise, if `r` represents a class type, then either the typedef name for linkage purposes or the identifier introduced by the declaration of the represented type.
-* [#.#]{.pnum} Otherwise, if `r` represents an entity, `$typedef-name$`, or namespace alias, then the identifier introduced by the declaration of what is represented by `r`.
+* [#.#]{.pnum} Otherwise, if `r` represents an entity, `$typedef-name$`, or `$namespace-alias$`, then the identifier introduced by the declaration of what is represented by `r`.
 * [#.#]{.pnum} Otherwise, if `r` represents a base class specifier, then the identifier introduced by the declaration of the type of the base class.
 * [#.#]{.pnum} Otherwise (if `r` represents a description of a declaration of a non-static data member), then letting `$o$` be a `data_member_options_t` value such that `data_member_spec(type_of(r), $o$) == $r$`, then the `string` or `u8string` contents of `$o$.name.$contents$` encoded with `$E$`.
 
@@ -5027,7 +5008,7 @@ the specialization is instantiated.
 consteval bool is_namespace(info r);
 ```
 
-[#]{.pnum} *Returns*: `true` if `r` represents a namespace or namespace alias. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a namespace or `$namespace-alias$`. Otherwise, `false`.
 
 ```cpp
 consteval bool is_variable(info r);
@@ -5043,7 +5024,7 @@ consteval bool is_type(info r);
 consteval bool is_type_alias(info r);
 consteval bool is_namespace_alias(info r);
 ```
-[#]{.pnum} *Returns*: `true` if `r` represents a `$typedef-name$` or namespace alias, respectively [An instantiation of an alias template is a `$typedef-name$`]{.note}. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `r` represents a `$typedef-name$` or `$namespace-alias$`, respectively [An instantiation of an alias template is a `$typedef-name$`]{.note}. Otherwise, `false`.
 
 ```cpp
 consteval bool is_function(info r);
@@ -5190,7 +5171,7 @@ static_assert(value_of(^x) == reflect_value(0)); // OK, likewise
 consteval info parent_of(info r);
 ```
 
-[#]{.pnum} *Constant When*: `r` represents a variable, structured binding, function, enumerator, class, class member, bit-field, template, namespace or namespace alias (other than `::`), `$typedef-name$`, or base class specifier.
+[#]{.pnum} *Constant When*: `r` represents a variable, structured binding, function, enumerator, class, class member, bit-field, template, namespace or `$namespace-alias$` (other than `::`), `$typedef-name$`, or base class specifier.
 
 [#]{.pnum} *Returns*: A reflection of the class, function, or namespace that is the target scope ([basic.scope.scope]) of the first declaration of what is represented by `r`.
 
@@ -5198,7 +5179,7 @@ consteval info parent_of(info r);
 consteval info dealias(info r);
 ```
 
-[#]{.pnum} *Returns*: If `r` represents a `$typedef-name$` or namespace alias _A_, then a reflection representing the entity named by _A_. Otherwise, `r`.
+[#]{.pnum} *Returns*: If `r` represents a `$typedef-name$` or `$namespace-alias$` _A_, then a reflection representing the entity named by _A_. Otherwise, `r`.
 
 [#]{.pnum}
 
@@ -5256,7 +5237,7 @@ consteval vector<info> members_of(info r);
 * a function whose constraints (if any) are satisfied,
 * a non-static data member,
 * a namespace, or
-* a namespace alias.
+* a `$namespace-alias$`.
 
 [Counterexamples of representable members include: injected class names, partial template specializations, friend declarations, and static assertions.]{.note}
 


### PR DESCRIPTION
- Rewrite and unify the splicer grammars in one place. Overhaul template splicer grammar and handling.
- Rewrite grammar for _reflect-expression_ in terms of lookup (Daveed confirmed). Also fixes some minor wording bugs (e.g., a reflection of a non-type template parameter can yield an object in addition to a value).
- Get rid of `splice-namespace-qualifier`, `splice-template-argument` - it's just `splice-specifier`.
- Rewrite handling of CTAD, deduced placeholder types (i.e., `Concept auto var = value`).
- More careful attention to distinction between names and entities: Lift `*splice-specifier` out of `template-name` and `concept-name`, into `simple-template-id` and `type-constraint`.
- Apply changes discussed for _consteval-only types_ (i.e., immediate-escalation, consteval-erased pointers not being permitted results of constant expressions, etc).
- Splicers, much like `computed-type-specifier`s, are not component names.
- Some QoL changes - prefer the word "construct" in lieu of giant lists of "entity, object, value, base specifier",. etc in some places; introduce the term "splicer" to generically refer to a `splice-specifer`, `splice-expr-template-specifier`, or `splice-type-specifier`.
- Lots of formatting nits (e.g., _word_ vs `$word$`).

And then a lot of other changes spiral out from there.