### PR TITLE
Audit id-expression. Fix "struct to struct of arrays" example.

### DIFF
--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2024-12-10" />
+  <meta name="dcterms.date" content="2024-12-11" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -565,7 +565,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2024-12-10</td>
+    <td>2024-12-11</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -741,6 +741,9 @@ Traits<span></span></a></li>
 <ul>
 <li><a href="#language" id="toc-language"><span class="toc-section-number">5.1</span> Language<span></span></a>
 <ul>
+<li><a href="#intro.defs-terms-and-definitions" id="toc-intro.defs-terms-and-definitions"><span>3
+<span>[intro.defs]</span></span> Terms and
+definitions<span></span></a></li>
 <li><a href="#lex.phases-phases-of-translation" id="toc-lex.phases-phases-of-translation"><span>5.2
 <span>[lex.phases]</span></span> Phases of
 translation<span></span></a></li>
@@ -786,11 +789,17 @@ dependence<span></span></a></li>
 <li><a href="#expr.prim-primary-expressions" id="toc-expr.prim-primary-expressions"><span>7.5
 <span>[expr.prim]</span></span> Primary
 expressions<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
+<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.4.2
+<span>[expr.prim.id.unqual]</span></span> Unqualified
+names<span></span></a></li>
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
+<li><a href="#expr.prim.lambda.capture-captures" id="toc-expr.prim.lambda.capture-captures"><span>7.5.5.3
+<span>[expr.prim.lambda.capture]</span></span>
+Captures<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
 Expression splicing<span></span></a></li>
 <li><a href="#expr.post.general-general" id="toc-expr.post.general-general"><span>7.6.1.1
@@ -818,10 +827,16 @@ specifier<span></span></a></li>
 <li><a href="#dcl.type.simple-simple-type-specifiers" id="toc-dcl.type.simple-simple-type-specifiers"><span>9.2.9.3
 <span>[dcl.type.simple]</span></span> Simple type
 specifiers<span></span></a></li>
+<li><a href="#dcl.type.decltype-decltype-specifiers" id="toc-dcl.type.decltype-decltype-specifiers"><span>9.2.9.6
+<span>[dcl.type.decltype]</span></span> Decltype
+specifiers<span></span></a></li>
 <li><a href="#dcl.type.splice-type-splicing" id="toc-dcl.type.splice-type-splicing">[dcl.type.splice] Type
 splicing<span></span></a></li>
 <li><a href="#dcl.fct-functions" id="toc-dcl.fct-functions"><span>9.3.4.6 <span>[dcl.fct]</span></span>
 Functions<span></span></a></li>
+<li><a href="#dcl.fct.default-default-arguments" id="toc-dcl.fct.default-default-arguments"><span>9.3.4.7
+<span>[dcl.fct.default]</span></span> Default
+arguments<span></span></a></li>
 <li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.4.1
 <span>[dcl.init.general]</span></span> Initializers
 (General)<span></span></a></li>
@@ -870,6 +885,9 @@ function<span></span></a></li>
 <li><a href="#over.match.class.deduct-class-template-argument-deduction" id="toc-over.match.class.deduct-class-template-argument-deduction"><span>12.2.2.9
 <span>[over.match.class.deduct]</span></span> Class template argument
 deduction<span></span></a></li>
+<li><a href="#over.over-address-of-an-overload-set" id="toc-over.over-address-of-an-overload-set"><span class="toc-section-number">5.1.1</span> <span>12.3
+<span>[over.over]</span></span> Address of an overload
+set<span></span></a></li>
 <li><a href="#over.built-built-in-operators" id="toc-over.built-built-in-operators"><span>12.5
 <span>[over.built]</span></span> Built-in
 operators<span></span></a></li>
@@ -890,6 +908,9 @@ arguments<span></span></a></li>
 <li><a href="#temp.arg.template-template-template-arguments" id="toc-temp.arg.template-template-template-arguments"><span>13.4.4
 <span>[temp.arg.template]</span></span> Template template
 arguments<span></span></a></li>
+<li><a href="#temp.constr.normal-constraint-normalization" id="toc-temp.constr.normal-constraint-normalization"><span>13.5.4
+<span>[temp.constr.normal]</span></span> Constraint
+normalization<span></span></a></li>
 <li><a href="#temp.type-type-equivalence" id="toc-temp.type-type-equivalence"><span>13.6
 <span>[temp.type]</span></span> Type equivalence<span></span></a></li>
 <li><a href="#temp.deduct.guide-deduction-guides" id="toc-temp.deduct.guide-deduction-guides"><span>13.7.2.3
@@ -2021,25 +2042,25 @@ how other accesses work. This is instead proposed in <span class="citation" data
 <div class="sourceCode" id="cb23"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;meta&gt;</span></span>
 <span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;array&gt;</span></span>
 <span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, std<span class="op">::</span><span class="dt">size_t</span> N<span class="op">&gt;</span></span>
-<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> struct_of_arrays_impl;</span>
-<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> make_struct_of_arrays<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info type,</span>
-<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>                                     std<span class="op">::</span>meta<span class="op">::</span>info N<span class="op">)</span> <span class="op">-&gt;</span> std<span class="op">::</span>meta<span class="op">::</span>info <span class="op">{</span></span>
-<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> old_members <span class="op">=</span> nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members <span class="op">=</span> <span class="op">{}</span>;</span>
-<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> old_members<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> type_array <span class="op">=</span> substitute<span class="op">(^^</span>std<span class="op">::</span>array, <span class="op">{</span>type_of<span class="op">(</span>member<span class="op">)</span>, N <span class="op">})</span>;</span>
-<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> mem_descr <span class="op">=</span> data_member_spec<span class="op">(</span>type_array, <span class="op">{.</span>name <span class="op">=</span> identifier_of<span class="op">(</span>member<span class="op">)})</span>;</span>
-<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a>    new_members<span class="op">.</span>push_back<span class="op">(</span>mem_descr<span class="op">)</span>;</span>
-<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb23-16"><a href="#cb23-16" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> define_aggregate<span class="op">(</span></span>
-<span id="cb23-17"><a href="#cb23-17" aria-hidden="true" tabindex="-1"></a>    substitute<span class="op">(^^</span>struct_of_arrays_impl, <span class="op">{</span>type, N<span class="op">})</span>,</span>
-<span id="cb23-18"><a href="#cb23-18" aria-hidden="true" tabindex="-1"></a>    new_members<span class="op">)</span>;</span>
-<span id="cb23-19"><a href="#cb23-19" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> struct_of_arrays_impl <span class="op">=</span> <span class="op">[]</span> <span class="kw">consteval</span> <span class="op">{</span></span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> impl;</span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> old_members <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>T<span class="op">)</span>;</span>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members <span class="op">=</span> <span class="op">{}</span>;</span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> old_members<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> array_type <span class="op">=</span> substitute<span class="op">(^^</span>std<span class="op">::</span>array, <span class="op">{</span></span>
+<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>        type_of<span class="op">(</span>member<span class="op">)</span>,</span>
+<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>meta<span class="op">::</span>reflect_value<span class="op">(</span>N<span class="op">)</span>,</span>
+<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">})</span>;</span>
+<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> mem_descr <span class="op">=</span> data_member_spec<span class="op">(</span>array_type, <span class="op">{.</span>name <span class="op">=</span> identifier_of<span class="op">(</span>member<span class="op">)})</span>;</span>
+<span id="cb23-16"><a href="#cb23-16" aria-hidden="true" tabindex="-1"></a>    new_members<span class="op">.</span>push_back<span class="op">(</span>mem_descr<span class="op">)</span>;</span>
+<span id="cb23-17"><a href="#cb23-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb23-18"><a href="#cb23-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>meta<span class="op">::</span>define_aggregate<span class="op">(^^</span>impl, new_members<span class="op">)</span>;</span>
+<span id="cb23-19"><a href="#cb23-19" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span>
 <span id="cb23-20"><a href="#cb23-20" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb23-21"><a href="#cb23-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
-<span id="cb23-22"><a href="#cb23-22" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> struct_of_arrays <span class="op">=</span> <span class="op">[:</span> make_struct_of_arrays<span class="op">(^^</span>T, <span class="op">^^</span>N<span class="op">)</span> <span class="op">:]</span>;</span></code></pre></div>
+<span id="cb23-22"><a href="#cb23-22" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> struct_of_arrays <span class="op">=</span> <span class="op">[:</span> struct_of_arrays_impl<span class="op">&lt;</span>T, N<span class="op">&gt;</span> <span class="op">:]</span>;</span></code></pre></div>
 </blockquote>
 </div>
 <p>Example:</p>
@@ -2064,7 +2085,7 @@ how other accesses work. This is instead proposed in <span class="citation" data
 <code class="sourceCode cpp">nonstatic_data_members_of</code> and
 <code class="sourceCode cpp">define_aggregate</code> is put to good
 use.</p>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/5nsqY1vxz">EDG</a>, <a href="https://godbolt.org/z/veEq6ozes">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/jWrPGhn5s">EDG</a>, <a href="https://godbolt.org/z/7PcYrY7eq">Clang</a>.</p>
 <h2 data-number="3.11" id="parsing-command-line-options-ii"><span class="header-section-number">3.11</span> Parsing Command-Line Options
 II<a href="#parsing-command-line-options-ii" class="self-link"></a></h2>
 <p>Now that we’ve seen a couple examples of using <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>define_aggregate</code>
@@ -4938,6 +4959,22 @@ reflection <em>designates</em> that source construct. For instance,
 <code class="sourceCode default">[: ^^int :]</code> designates the type
 <code class="sourceCode default">int</code>. ]</span></p>
 <h2 data-number="5.1" id="language"><span class="header-section-number">5.1</span> Language<a href="#language" class="self-link"></a></h2>
+<h3 class="unnumbered" id="intro.defs-terms-and-definitions"><span>3 <a href="https://wg21.link/intro.defs">[intro.defs]</a></span> Terms and
+definitions<a href="#intro.defs-terms-and-definitions" class="self-link"></a></h3>
+<p>Add <code class="sourceCode cpp"><em>splice-specifier</em></code> to
+the list of template argument forms in definition 3.5.</p>
+<div class="std">
+<blockquote>
+<p><strong><span class="marginalizedparent"><a class="marginalized" href="#pnum_5" id="pnum_5">(3.5)</a></span>
+argument</strong></p>
+<p>⟨template instantiation⟩
+<code class="sourceCode cpp"><em>constant-expression</em></code>,
+<code class="sourceCode cpp"><em>type-id</em></code>, <span class="rm" style="color: #bf0303"><del>or</del></span>
+<code class="sourceCode cpp"><em>id-expression</em></code><span class="addu">, or
+<code class="sourceCode cpp"><em>splice-specifier</em></code></span> in
+the comma-separated list bounded by the angle brackets</p>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="lex.phases-phases-of-translation"><span>5.2
 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span> Phases of
 translation<a href="#lex.phases-phases-of-translation" class="self-link"></a></h3>
@@ -4951,7 +4988,7 @@ program constructs in a translation unit. ]</span></p>
 follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_5" id="pnum_5">7-8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_6" id="pnum_6">7-8</a></span>
 Whitespace characters separating tokens are no longer significant. Each
 preprocessing token is converted into a token (<span>5.6 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). The
 resulting tokens constitute a translation unit and are syntactically and
@@ -5023,7 +5060,7 @@ any instantiation. Given two semantically sequenced program constructs,
 whether one <em>semantically follows</em> the other is determined as
 follows:</span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_6" id="pnum_6">(7.8-1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_7" id="pnum_7">(7.8-1)</a></span>
 If both constructs are within the
 <code class="sourceCode cpp"><em>member-specification</em></code> of a
 class <code class="sourceCode cpp">C</code> (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
@@ -5033,7 +5070,7 @@ context of <code class="sourceCode cpp">C</code> but the other (call it
 <code class="sourceCode cpp"><em>Y</em></code>) is not, then
 <code class="sourceCode cpp"><em>X</em></code> semantically follows
 <code class="sourceCode cpp"><em>Y</em></code>.</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_7" id="pnum_7">(7-8.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_8" id="pnum_8">(7-8.1)</a></span>
 Otherwise, if the syntactic endpoint of the tokens that describe one
 such construct (call it <code class="sourceCode cpp"><em>X</em></code>)
 occurs lexically after the syntactic endpoint of the tokens that
@@ -5058,7 +5095,7 @@ instantiation can be perfomed will be considered in a context where all
 plainly constant-evaluated expressions resulting from that instantiation
 have been evaluated exactly once.<span> — <em>end
 note</em> ]</span></span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_8" id="pnum_8">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_9" id="pnum_9">8</a></span>
 All external entity references are resolved. […]</p>
 </blockquote>
 </div>
@@ -5069,13 +5106,13 @@ Preprocessing tokens<a href="#lex.pptoken-preprocessing-tokens" class="self-link
 <div class="std">
 <blockquote>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_9" id="pnum_9">4</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_10" id="pnum_10">4</a></span>
 If the input stream has been parsed into preprocessing tokens up to a
 given character:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_10" id="pnum_10">(4.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_11" id="pnum_11">(4.1)</a></span>
 …</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_11" id="pnum_11">(4.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_12" id="pnum_12">(4.2)</a></span>
 Otherwise, if the next three characters are
 <code class="sourceCode cpp"><span class="op">&lt;::</span></code> and
 the subsequent character is neither
@@ -5085,7 +5122,7 @@ the subsequent character is neither
 treated as a preprocessing token by itself and not as the first
 character of the alternative token
 <code class="sourceCode cpp"><span class="op">&lt;:</span></code>.</p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_12" id="pnum_12">(4.3)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_13" id="pnum_13">(4.3)</a></span>
 Otherwise, if the next three characters are
 <code class="sourceCode cpp"><span class="op">[::</span></code> and the
 subsequent character is not
@@ -5102,7 +5139,7 @@ preprocessing token
 <code class="sourceCode cpp"><span class="op">:]</span></code> cannot be
 composed from digraphs.<span> — <em>end
 note</em> ]</span></span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_13" id="pnum_13">(4.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">(4.4)</a></span>
 …</p></li>
 </ul></li>
 </ul>
@@ -5140,7 +5177,7 @@ one. Add “template parameters” and
 collectively subsume “packs”.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_14" id="pnum_14">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">3</a></span>
 An <em>entity</em> is a <span class="rm" style="color: #bf0303"><del>value, object, reference</del></span> <span class="addu">variable,</span> structured binding, function, enumerator,
 type, <span class="addu">type alias</span>, <span class="rm" style="color: #bf0303"><del>class</del></span> <span class="addu">non-static data</span> member, bit-field, template,
 template specialization, namespace, <span class="addu">namespace alias,
@@ -5153,10 +5190,10 @@ utilize it for the definition of a name “denoting” an entity. Type
 aliases are now entities, so also modify accordingly.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_15" id="pnum_15">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">5</a></span>
 Every name is introduced by a <em>declaration</em>, which is a</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_16" id="pnum_16">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(5.1)</a></span>
 <code class="sourceCode cpp"><em>name-declaration</em></code>,
 <code class="sourceCode cpp"><em>block-declaration</em></code>, or
 <code class="sourceCode cpp"><em>member-declaration</em></code>
@@ -5165,7 +5202,7 @@ Every name is introduced by a <em>declaration</em>, which is a</p>
 </ul>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_17" id="pnum_17">(5.14)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">(5.14)</a></span>
 implicit declaration of an injected-class-name (<span>11.1 <a href="https://wg21.link/class.pre">[class.pre]</a></span>).</li>
 </ul>
 <p><span class="addu">The <em>underlying entity</em> of an entity is
@@ -5188,7 +5225,7 @@ note</em> ]</span></span></span></p>
 the variable, not the associated object.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_18" id="pnum_18">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">6</a></span>
 A <em>variable</em> is introduced by the declaration of a reference
 other than a non-static data member or of an object. <span class="rm" style="color: #bf0303"><del>The variable’s name, if any, denotes the
 reference or object.</del></span></p>
@@ -5200,7 +5237,7 @@ and definitions<a href="#basic.def-declarations-and-definitions" class="self-lin
 are now entities.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_19" id="pnum_19">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">1</a></span>
 […] A declaration of an entity <span class="rm" style="color: #bf0303"><del>or
 <span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <code class="sourceCode cpp"><em>X</em></code> is a redeclaration of
@@ -5217,25 +5254,25 @@ to the list of declarations in paragraph 2, just before
 <code class="sourceCode cpp"><em>using-declaration</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_20" id="pnum_20">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">2</a></span>
 Each entity declared by a
 <code class="sourceCode cpp"><em>declaration</em></code> is also
 <em>defined</em> by that declaration unless:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_21" id="pnum_21">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(2.1)</a></span>
 it declares a function without specifying the function’s body (<span>9.5
 <a href="https://wg21.link/dcl.fct.def">[dcl.fct.def]</a></span>),</li>
 </ul>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_22" id="pnum_22">(2.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(2.10)</a></span>
 it is an <code class="sourceCode cpp"><em>alias-declaration</em></code>
 (<span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.typedef]</a></span>),</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_23" id="pnum_23">(2.11-)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(2.11-)</a></span>
 it is a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 (<span>9.8.3 <a href="https://wg21.link/namespace.alias">[namespace.alias]</a></span>),</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_24" id="pnum_24">(2.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">(2.11)</a></span>
 it is a <code class="sourceCode cpp"><em>using-declaration</em></code>
 (<span>9.9 <a href="https://wg21.link/namespace.udecl">[namespace.udecl]</a></span>),</li>
 </ul>
@@ -5245,12 +5282,73 @@ it is a <code class="sourceCode cpp"><em>using-declaration</em></code>
 <h3 class="unnumbered" id="basic.def.odr-one-definition-rule"><span>6.3
 <a href="https://wg21.link/basic.def.odr">[basic.def.odr]</a></span>
 One-definition rule<a href="#basic.def.odr-one-definition-rule" class="self-link"></a></h3>
+<p>Add <code class="sourceCode cpp"><em>splice-expression</em></code>s
+to the set of potential results of an expression in paragarph 3.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">3</a></span>
+An expression or conversion is <em>potentially evaluated</em> unless it
+is an unevaluated operand (<span>7.2.3 <a href="https://wg21.link/expr.context">[expr.context]</a></span>), a
+subexpression thereof, or a conversion in an initialization or
+conversion sequence in such a context. The set of <em>potential
+results</em> of an expression
+<code class="sourceCode cpp"><em>E</em></code> is defined as
+follows:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">(3.1)</a></span>
+If <code class="sourceCode cpp"><em>E</em></code> is an
+<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.4
+<a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>)
+<span class="addu">or a
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+([expr.prim.splice])</span>, the set contains only
+<code class="sourceCode cpp"><em>E</em></code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">(3.2)</a></span>
+[…]</li>
+</ul>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>This set is a
+(possibly-empty) set of
+<code class="sourceCode cpp"><em>id-expression</em></code>s <span class="addu">and
+<code class="sourceCode cpp"><em>splice-expression</em></code>s</span>,
+each of which is either <code class="sourceCode cpp"><em>E</em></code>
+or a subexpression of
+<code class="sourceCode cpp"><em>E</em></code>.<span> — <em>end
+note</em> ]</span></span></p>
+</blockquote>
+</div>
+<p>Break bullet 4.1 into sub-bullets, modify it to cover splicing of
+functions, and replace [basic.lookup] with [over.pre] since the
+canonical definition of “overload set” is relocated there by this
+proposal:</p>
+<div class="std">
+<blockquote>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">(4.1)</a></span>
+A function is named by an expression or conversion if it is the selected
+member of an overload set (<span class="rm" style="color: #bf0303"><del>[basic.pre]</del></span> <span class="addu">[over.pre]</span>, [over.match], [over.over]) in an
+overload resolution performed as part of forming that expression or
+conversion, unless it is a pure virtual function and <span class="rm" style="color: #bf0303"><del>either</del></span> the expression<span class="addu"> </span></p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(4.1.1)</a></span>
+is not an <code class="sourceCode cpp"><em>id-expression</em></code>
+naming the function with an explicitly qualified name<span class="addu">,</span></li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(4.1.2)</a></span>
+is not a
+<code class="sourceCode cpp"><em>splice-expression</em></code>,</span>
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(4.1.3)</a></span>
+<span class="rm" style="color: #bf0303"><del>the expression</del></span>
+forms a pointer to member ([expr.unary.op]).</li>
+</ul></li>
+</ul>
+</blockquote>
+</div>
 <p>Modify the first sentence of paragraph 5 to cover splicing of
 variables:</p>
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_25" id="pnum_25">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">5</a></span>
 A variable is named by an expression if the expression is an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code>
@@ -5262,7 +5360,7 @@ A variable is named by an expression if the expression is an
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">6</a></span>
 A structured binding is <span class="rm" style="color: #bf0303"><del>odr-used if it appears as a
 potentially-evaluated</del></span> <span class="addu">named by an</span>
 expression <span class="addu">if that expression is either an</span>
@@ -5277,7 +5375,7 @@ it is named by a potentially-evaluated expression.</span></li>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_27" id="pnum_27">15pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">15pre</a></span>
 If a class <code class="sourceCode cpp">C</code> is defined in a
 translation unit as a result of a call to a specialization of <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>define_aggregate</code>
 and another translation unit contains a definition of
@@ -5288,7 +5386,7 @@ ill-formed; a diagnostic is required only if
 a prior definition is reachable at the point where a later definition
 occurs.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_28" id="pnum_28">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">15</a></span>
 For any <span class="addu">other</span> definable item
 <code class="sourceCode cpp">D</code> with definitions in multiple
 translation units,</p>
@@ -5309,7 +5407,7 @@ through” aliases, and clarify that objects are not entities in bullet
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">(15.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">(15.5)</a></span>
 In each such definition, corresponding names, looked up according to
 <span>6.5 <a href="https://wg21.link/basic.lookup">[basic.lookup]</a></span>, shall
 <span class="rm" style="color: #bf0303"><del>refer to</del></span> <span class="addu">denote</span> the same entity, after overload resolution
@@ -5317,9 +5415,9 @@ In each such definition, corresponding names, looked up according to
 matching of partial template specialization (<span>13.10.4 <a href="https://wg21.link/temp.over">[temp.over]</a></span>), except that
 a name can refer to
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(15.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">(15.5.1)</a></span>
 a non-volatile const object […], or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(15.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">(15.5.2)</a></span>
 a reference with internal or no linkage initialized with a constant
 expression such that the reference refers to the same <span class="rm" style="color: #bf0303"><del>entity</del></span> <span class="addu">object or function</span> in all definitions of
 <code class="sourceCode cpp"><em>D</em></code>.</li>
@@ -5333,12 +5431,12 @@ also factor into ODR.</p>
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(15.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(15.10)</a></span>
 In each such definition, the overloaded operators referred to, the
 implicit calls to conversion functions, constructors, operator new
 functions and operator delete functions, shall refer to the same
 function.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(15.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">(15.11)</a></span>
 In each such definition, a default argument used by an (implicit or
 explicit) function call or a default template argument used by an
 (implicit or explicit)
@@ -5359,7 +5457,7 @@ ODR.</p>
 <blockquote>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_34" id="pnum_34">(15.11+)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">(15.11+)</a></span>
 In each such definition, corresponding
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s
 ([expr.reflect]) compute equivalent values (<span>7.6.10 <a href="https://wg21.link/expr.eq">[expr.eq]</a></span>).</li>
@@ -5374,7 +5472,7 @@ instead of a
 <code class="sourceCode cpp"><em>typedef-name</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_35" id="pnum_35">(4.2)</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">(4.2)</a></span>
 one declares a type (not a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>) and the other declares a variable,
 non-static data member other than an anonymous union (<span>11.5.2 <a href="https://wg21.link/class.union.anon">[class.union.anon]</a></span>),
@@ -5387,7 +5485,7 @@ General<a href="#basic.lookup.general-general" class="self-link"></a></h3>
 “overload set” given in [over.pre], rather than define it here.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_36" id="pnum_36">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">1</a></span>
 […] If the declarations found by name lookup all denote functions or
 function templates, the declarations <span class="rm" style="color: #bf0303"><del>are said to</del></span> form an <span class="rm" style="color: #bf0303"><del><em>overload
 set</em></del></span> <span class="addu">overload set (<span>12.1 <a href="https://wg21.link/over.pre">[over.pre]</a></span>)</span>.
@@ -5398,7 +5496,7 @@ Otherwise, […]</p>
 a declaration to account for the removal of instantiation units.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_37" id="pnum_37">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">2</a></span>
 A program point <code class="sourceCode cpp"><em>P</em></code> is said
 to follow any declaration <span class="addu">with which it is
 semantically sequenced (<span>5.2 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span>)</span>
@@ -5410,7 +5508,7 @@ is before <code class="sourceCode cpp"><em>P</em></code>.</p>
 <p>Adjust paragraph 4 since type aliases are now entities.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_38" id="pnum_38">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">4</a></span>
 In certain contexts, only certain kinds of declarations are included.
 After any such restriction, any declarations of classes or enumerations
 are discarded if any other declarations are found.</p>
@@ -5435,13 +5533,13 @@ Argument-dependent name lookup<a href="#basic.lookup.argdep-argument-dependent-n
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_39" id="pnum_39">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">3</a></span>
 … Any <code class="sourceCode cpp"><em>typedef-name</em></code>s and
 <code class="sourceCode cpp"><em>using-declaration</em></code>s used to
 specify the types do not contribute to this set. The set of entities is
 determined in the following way:</p>
 <ul>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_40" id="pnum_40">(3.1)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">(3.1)</a></span>
 If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 ([meta.reflection.synop]), its associated set of entities is the
 singleton containing the enumeration type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>operators</code>
@@ -5452,11 +5550,11 @@ type is a type alias, so an explicit rule is needed to associate calls
 whose arguments are reflections with the namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>.<span>
 — <em>end note</em> ]</span></span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_41" id="pnum_41">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">(3.2)</a></span>
 If <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> fundamental type, its associated set of entities is
 empty.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_42" id="pnum_42">(3.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(3.3)</a></span>
 If <code class="sourceCode cpp">T</code> is a class type …</p></li>
 </ul>
 </blockquote>
@@ -5467,7 +5565,7 @@ General<a href="#basic.lookup.qual.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_43" id="pnum_43">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">1</a></span>
 Lookup of an <em>identifier</em> followed by a
 <code class="sourceCode cpp"><span class="op">::</span></code> scope
 resolution operator considers only namespaces, types, and templates
@@ -5497,7 +5595,7 @@ renumber accordingly:</p>
 <span id="cb104-3"><a href="#cb104-3" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb104-4"><a href="#cb104-4" aria-hidden="true" tabindex="-1"></a><em>splice-specialization-specifier</em>:</span>
 <span id="cb104-5"><a href="#cb104-5" aria-hidden="true" tabindex="-1"></a>  <em>splice-specifier</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub> &gt;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_44" id="pnum_44">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">1</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> shall be
 a converted constant expression of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -5508,11 +5606,11 @@ converted
 represents a construct <code class="sourceCode cpp"><em>X</em></code> is
 said to <em>designate</em> either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_45" id="pnum_45">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">(1.1)</a></span>
 the underlying entity of <code class="sourceCode cpp"><em>X</em></code>
 if <code class="sourceCode cpp"><em>X</em></code> is an entity
 (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_46" id="pnum_46">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">(1.2)</a></span>
 <code class="sourceCode cpp"><em>X</em></code> otherwise.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>A
@@ -5521,12 +5619,12 @@ dependent if the converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
 value-dependent ([temp.dep.splice]).<span> — <em>end
 note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_47" id="pnum_47">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">2</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
 non-dependent
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 shall designate a template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_48" id="pnum_48">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">3</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>A
 <code class="sourceCode cpp"><span class="op">&lt;</span></code>
 following a
@@ -5558,26 +5656,28 @@ when it appears in a type-only context (<span>13.3 <a href="https://wg21.link/te
 </div>
 <h3 class="unnumbered" id="basic.link-program-and-linkage"><span>6.6 <a href="https://wg21.link/basic.link">[basic.link]</a></span> Program and
 Linkage<a href="#basic.link-program-and-linkage" class="self-link"></a></h3>
-<p>Add a bullet to paragraph 13:</p>
+<p>Add a bullet to paragraph 13 and handle
+<code class="sourceCode cpp"><em>splice-expression</em></code>s in the
+existing bullets:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_49" id="pnum_49">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">13</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>names</em> an entity <code class="sourceCode cpp"><em>E</em></code>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_50" id="pnum_50">(13.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">(13.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a
 <code class="sourceCode cpp"><em>lambda-expression</em></code> whose
 closure type is <code class="sourceCode cpp"><em>E</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_51" id="pnum_51">(13.1+)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(13.1+)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code>
 contains a
 <code class="sourceCode cpp"><em>reflect-expression</em></code> or a
 manifestly constant-evaluated expression of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 that represents
 <code class="sourceCode cpp"><em>E</em></code>,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_52" id="pnum_52">(13.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(13.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not a function or
 function template and <code class="sourceCode cpp"><em>D</em></code>
 contains an <code class="sourceCode cpp"><em>id-expression</em></code>,
@@ -5585,14 +5685,18 @@ contains an <code class="sourceCode cpp"><em>id-expression</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>template-name</em></code>, or
 <code class="sourceCode cpp"><em>concept-name</em></code> denoting
-<code class="sourceCode cpp"><em>E</em></code>, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_53" id="pnum_53">(13.3)</a></span>
+<code class="sourceCode cpp"><em>E</em></code> <span class="addu">or a
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+designating <code class="sourceCode cpp"><em>E</em></code></span>,
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(13.3)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a function or function
 template and <code class="sourceCode cpp"><em>D</em></code> contains an
 expression that names <code class="sourceCode cpp"><em>E</em></code>
 ([basic.def.odr]) or an
-<code class="sourceCode cpp"><em>id-expression</em></code> that refers
-to a set of overloads that contains
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>
+that refers to a set of overloads that contains
 <code class="sourceCode cpp"><em>E</em></code>.</li>
 </ul>
 </blockquote>
@@ -5603,11 +5707,11 @@ explicitly TU-local.</p>
 <blockquote>
 <p>An entity is <em>TU-local</em> if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_54" id="pnum_54">(15.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(15.1)</a></span>
 a type, function, variable, or template that […]</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_55" id="pnum_55">(15.1+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(15.1+)</a></span>
 a type alias or a namespace alias,</span> TODO</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_56" id="pnum_56">(15.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">(15.2)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -5620,29 +5724,29 @@ also TU-local ]</span></p>
 to include reflections:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_57" id="pnum_57">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">16</a></span>
 A value or object is <em>TU-local</em> if</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_58" id="pnum_58">(16.0)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(16.0)</a></span>
 it is of TU-local type,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_59" id="pnum_59">(16.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(16.1)</a></span>
 it is, or is a pointer to, a TU-local function or the object associated
 with a TU-local variable, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_60" id="pnum_60">(16.1+)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(16.1+)</a></span>
 it is a reflection representing either
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_61" id="pnum_61">(16.1+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">(16.1+.1)</a></span>
 a TU-local value or object, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_62" id="pnum_62">(16.1+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">(16.1+.2)</a></span>
 a direct base class relationship introduced by an exposure, or</li>
 </ul></li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_63" id="pnum_63">(16.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(16.2)</a></span>
 it is an object of class or array type and any of its subobjects or any
 of the objects or functions to which its non-static data members of
 reference type refer is TU-local and is usable in constant
@@ -5656,7 +5760,7 @@ General<a href="#basic.types.general-general" class="self-link"></a></h3>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_64" id="pnum_64">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">9</a></span>
 Arithmetic types (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>),
 enumeration types, pointer types, pointer-to-member types (<span>6.8.4
 <a href="https://wg21.link/basic.compound">[basic.compound]</a></span>),
@@ -5671,18 +5775,18 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">12</a></span>
 A type is <em>consteval-only</em> if it is either <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or a type compounded from a consteval-only type ([basic.compound]).
 Every object of consteval-only type shall be</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(12.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">(12.1)</a></span>
 the object associated with a constexpr variable or a subobject
 thereof,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(12.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(12.2)</a></span>
 a template parameter object (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>) or a
 subobject thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(12.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(12.3)</a></span>
 an object whose lifetime begins and ends during the evaluation of a
 manifestly constant-evaluated expression.</li>
 </ul>
@@ -5696,7 +5800,7 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">17 - 1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">17 - 1</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
@@ -5773,7 +5877,7 @@ shall be equal to <code class="sourceCode cpp"><span class="kw">sizeof</span><sp
 <span id="cb106-44"><a href="#cb106-44" aria-hidden="true" tabindex="-1"></a>    <span class="co">// represents a data member description</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">17 - 2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">17 - 2</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>Implementations are
 discouraged from representing any constructs described by this document
 that are not explicitly enumerated in the list above (e.g., partial
@@ -5790,10 +5894,24 @@ determine the identity of a non-static data member.</p>
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(1.1)</a></span>
 A <em>glvalue</em> is an expression whose evaluation determines the
 identity of an object<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>or</del></span> function<span class="addu">,
 or non-static data member</span>.</li>
+</ul>
+</blockquote>
+</div>
+<p>Account for move-eligible
+<code class="sourceCode cpp"><em>splice-expression</em></code>s in
+bullet 4.1 of Note 3.</p>
+<div class="std">
+<blockquote>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">(4.1)</a></span>
+a move-eligible
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>
+([expr.prim.id.unqual]),</li>
 </ul>
 </blockquote>
 </div>
@@ -5804,18 +5922,44 @@ Context dependence<a href="#expr.context-context-dependence" class="self-link"><
 to the list of unevaluated operands in paragraph 1.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">1</a></span>
 In some contexts, <em>unevaluated operands</em> appear ([expr.prim.req],
 [expr.typeid], [expr.sizeof], [expr.unary.noexcept], <span class="addu">[expr.reflect],</span> [temp.pre], [temp.concept]). An
 unevaluated operand is not evaluated.</p>
 </blockquote>
 </div>
+<p>Add <code class="sourceCode cpp"><em>splice-expression</em></code> to
+the list of expressions in paragraph 2.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">2</a></span>
+In some contexts, an expression only appears for its side effects. Such
+an expression is called a <em>discarded-value expression</em>. The
+array-to-pointer and function-to-pointer standard conversions are not
+applied. The lvalue-to-rvalue conversion is applied if and only if the
+expression is a glvalue of volatile-qualified type and it is one of the
+following:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">(2.1)</a></span>
+<code class="sourceCode cpp"><span class="op">(</span> <em>expression</em> <span class="op">)</span></code>,
+where <code class="sourceCode cpp"><em>expression</em></code> is one of
+these expressions,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">(2.2)</a></span>
+<code class="sourceCode cpp"><em>id-expression</em></code>
+([expr.prim.id]),</li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">(2.2+)</a></span>
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+([expr.prim.splice]),</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">(2.3)</a></span>
+[…]</li>
+</ul>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="expr.prim-primary-expressions"><span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> Primary
 expressions<a href="#expr.prim-primary-expressions" class="self-link"></a></h3>
-<p>Change the grammar for
-<code class="sourceCode cpp"><em>primary-expression</em></code> in
-<span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span>
-as follows:</p>
+<p>Add <code class="sourceCode cpp"><em>splice-expression</em></code> to
+the grammar for
+<code class="sourceCode cpp"><em>primary-expression</em></code>:</p>
 <div class="std">
 <blockquote>
 <div>
@@ -5831,7 +5975,7 @@ as follows:</p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
 <p>Modify paragraph 2 to avoid transforming non-static members into
@@ -5839,28 +5983,28 @@ implicit member accesses when named as operands to
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">2</a></span>
 If an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><em>E</em></code> denotes a non-static
 non-type member of some class <code class="sourceCode cpp">C</code> at a
-point where the current class (<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
+point where the current class (<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
 <code class="sourceCode cpp">X</code> and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(2.1)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is potentially evaluated
 or <code class="sourceCode cpp">C</code> is
 <code class="sourceCode cpp">X</code> or a base class of
 <code class="sourceCode cpp">X</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(2.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not the
 <code class="sourceCode cpp"><em>id-expression</em></code> of a class
 member access expression (<span>7.6.1.5 <a href="https://wg21.link/expr.ref">[expr.ref]</a></span>), and</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(2.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">(2.3)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not the
 <code class="sourceCode cpp"><em>id-expression</em></code> of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]), and</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(2.4)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> is a
 <code class="sourceCode cpp"><em>qualified-id</em></code>,
 <code class="sourceCode cpp"><em>E</em></code> is not the
@@ -5873,7 +6017,57 @@ transformed into a class member access expression using <code class="sourceCode 
 as the object expression.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.4.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
+Unqualified names<a href="#expr.prim.id.unqual-unqualified-names" class="self-link"></a></h3>
+<p>Modify paragraph 4 to allow
+<code class="sourceCode cpp"><em>splice-expression</em></code>s to be
+move-eligible:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">4</a></span>
+An <em>implicitly movable entity</em> is a variable of automatic storage
+duration that is either a non-volatile object or an rvalue reference to
+a non-volatile object type. In the following contexts, <span class="rm" style="color: #bf0303"><del>an</del></span> <span class="addu">a
+(possibly parenthesized)</span>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+([expr.prim.splice])
+<code class="sourceCode cpp"><em>E</em></code></span> is
+<em>move-eligible</em>:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(4.1)</a></span>
+If <span class="rm" style="color: #bf0303"><del>the
+<span><code class="sourceCode default"><em>id-expression</em></code></span>
+(possibly parenthesized)</del></span> <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> is an
+operand of a
+<code class="sourceCode cpp"><span class="cf">return</span></code>
+([stmt.return]) or
+<code class="sourceCode cpp"><span class="kw">co_return</span></code>
+([stmt.return.coroutine]) statement, and names an implicitly movable
+entity declared in the body or
+<code class="sourceCode cpp"><em>parameter-declaration-clause</em></code>
+of the innermost enclosing function or
+<code class="sourceCode cpp"><em>lambda-expression</em></code>, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(4.2)</a></span>
+if <span class="rm" style="color: #bf0303"><del>the
+<span><code class="sourceCode default"><em>id-expression</em></code></span>
+(possibly parenthesized)</del></span> <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> is
+the operand of a
+<code class="sourceCode cpp"><em>throw-expression</em></code>
+([expr.throw]) and names an implicitly movable entity that belongs to a
+scope that does not contain the
+<code class="sourceCode cpp"><em>compound-statement</em></code> of the
+innermost
+<code class="sourceCode cpp"><em>lambda-expression</em></code>,
+<code class="sourceCode cpp"><em>try-block</em></code>, or
+<code class="sourceCode cpp"><em>function-try-block</em></code> (if any)
+whose <code class="sourceCode cpp"><em>compound-statement</em></code> or
+<code class="sourceCode cpp"><em>ctor-initializer</em></code> contains
+the <code class="sourceCode cpp"><em>throw-expression</em></code>.</li>
+</ul>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -5902,7 +6096,7 @@ well as an example:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">1+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">1+</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 that is not followed by
@@ -5938,7 +6132,7 @@ is preceded by
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -5966,15 +6160,15 @@ being redeclared or specialized.</p>
 cover splices, and prefer the verb “designate” over “nominate”:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">3</a></span>
 <span class="addu">The entity designated by a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 determined as follows:</span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(3.1)</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <code class="sourceCode cpp"><span class="op">::</span></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace.<span class="addu"> </span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(3.2)</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 with a
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
@@ -5984,7 +6178,7 @@ type <span class="rm" style="color: #bf0303"><del>denoted</del></span>
 <span class="addu">designated</span> by the
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>,
 which shall be a class or enumeration type.<span class="addu"> </span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">(3.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(3.3)</a></span>
 For a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of the form <code class="sourceCode cpp"><em>splice-specifier</em> <span class="op">::</span></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
@@ -5992,7 +6186,7 @@ designate a class or enumeration type or a namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">(3.4)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(3.4)</a></span>
 For a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of the form <code class="sourceCode cpp">template<sub><em>opt</em></sub> <em>splice-specialization-specifier</em> <span class="op">::</span></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -6013,7 +6207,7 @@ designates <code class="sourceCode cpp"><em>S</em></code> if
 the type denoted by <code class="sourceCode cpp"><em>S</em></code> if
 <code class="sourceCode cpp"><em>T</em></code> is an alias
 template.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(3.5)</a></span>
 If a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <em>N</em> is declarative and has a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> with a
@@ -6021,7 +6215,7 @@ template argument list <em>A</em> that involves a template parameter,
 let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nominated</del></span> <span class="addu">designated</span> by <em>N</em> without <em>A</em>.
 <em>T</em> shall be a class template.
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">(3.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(3.5.1)</a></span>
 If <code class="sourceCode cpp"><em>A</em></code> is the template
 argument list (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>) of the
 corresponding <code class="sourceCode cpp"><em>template-head</em></code>
@@ -6031,7 +6225,7 @@ corresponding <code class="sourceCode cpp"><em>template-head</em></code>
 <code class="sourceCode cpp"><em>H</em></code> shall be equivalent to
 the <code class="sourceCode cpp"><em>template-head</em></code> of
 <code class="sourceCode cpp"><em>T</em></code> (<span>13.7.7.2 <a href="https://wg21.link/temp.over.link">[temp.over.link]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(3.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(3.5.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>N</em></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the partial specialization (<span>13.7.6
 <a href="https://wg21.link/temp.spec.partial">[temp.spec.partial]</a></span>)
 of <code class="sourceCode cpp"><em>T</em></code> whose template
@@ -6039,7 +6233,7 @@ argument list is equivalent to
 <code class="sourceCode cpp"><em>A</em></code> (<span>13.7.7.2 <a href="https://wg21.link/temp.over.link">[temp.over.link]</a></span>);
 the program is ill-formed if no such partial specialization exists.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(3.6)</a></span>
 Any other
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the entity <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> by its
 <code class="sourceCode cpp"><em>type-name</em></code>,
@@ -6051,10 +6245,49 @@ not declarative, the entity shall not be a template.</li>
 </ul>
 </blockquote>
 </div>
+<h3 class="unnumbered" id="expr.prim.lambda.capture-captures"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.lambda.capture">[expr.prim.lambda.capture]</a></span>
+Captures<a href="#expr.prim.lambda.capture-captures" class="self-link"></a></h3>
+<p>Modify bullet 7.1 as follows:</p>
+<div class="std">
+<blockquote>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(7.1)</a></span>
+An <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>
+that names a local entity potentially references that entity; an
+<code class="sourceCode cpp"><em>id-expression</em></code> that names
+one or more non-static class members and does not form a pointer to
+member ([expr.unary.op]) potentially references <code class="sourceCode cpp"><span class="op">*</span><span class="kw">this</span></code>.</li>
+</ul>
+</blockquote>
+</div>
+<p>Modify paragraph 11 (and note 7 which follows):</p>
+<div class="std">
+<blockquote>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">11</a></span>
+An <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>
+within the
+<code class="sourceCode cpp"><em>compound-statement</em></code> of a
+<code class="sourceCode cpp"><em>lambda-expression</em></code> that is
+an odr-use of an entity captured by copy is transformed into an access
+to the corresponding unnamed data member of the closure type.</p>
+<p><span class="note7"><span>[ <em>Note 7:</em> </span>An
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>
+that is not an odr-use refers to the original entity, never to a member
+of the closure type. However, such an
+<code class="sourceCode cpp"><em>id-expression</em></code> can still
+cause the implicit capture of the entity.<span> — <em>end
+note</em> ]</span></span></p></li>
+</ul>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -6062,7 +6295,7 @@ not declarative, the entity shall not be a template.</li>
 <div class="sourceCode" id="cb110"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
 <span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
 <span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -6088,22 +6321,22 @@ never interpreted as part of a
 <span id="cb111-13"><a href="#cb111-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">// [:^^int:] forms part of a type, not a splice-expression</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 let <code class="sourceCode cpp"><em>S</em></code> be the construct
 designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(2.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(2.1)</a></span>
 If <code class="sourceCode cpp"><em>S</em></code> is an object, a
-function, or a non-static data member, the expression is an lvalue
-designating <code class="sourceCode cpp"><em>S</em></code>. The
-expression has the same type as
-<code class="sourceCode cpp"><em>S</em></code>, and is a bit-field if
-and only if <code class="sourceCode cpp"><em>S</em></code> is a
-bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(2.2)</a></span>
+function, a function template, or a non-static data member, the
+expression is an lvalue designating
+<code class="sourceCode cpp"><em>S</em></code>. The expression has the
+same type as <code class="sourceCode cpp"><em>S</em></code>, and is a
+bit-field if and only if <code class="sourceCode cpp"><em>S</em></code>
+is a bit-field.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(2.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 variable or a structured binding,
 <code class="sourceCode cpp"><em>S</em></code> shall either have static
@@ -6119,15 +6352,15 @@ is a bit-field.</p>
 designating a variable or structured binding of reference type will be
 adjusted to a non-reference type (<span>7.2.2 <a href="https://wg21.link/expr.type">[expr.type]</a></span>).<span>
 — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(2.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a value
 or an enumerator, the expression is a prvalue that computes
 <code class="sourceCode cpp"><em>S</em></code> and whose type is the
 same as <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(2.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(2.4)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -6140,46 +6373,46 @@ shall designate a template. Let
 any) of the
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>T</em></code> is a primary variable
 template or function template, the expression is an lvalue referring to
 the same object or function associated with
 <code class="sourceCode cpp"><em>S</em></code>. The expression has the
 same type as <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>T</em></code> is a
 concept, the expression is a prvalue that computes the same boolean
 value as the <code class="sourceCode cpp"><em>concept-id</em></code>
 formed by <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(3.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(3.3)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 2:</em> </span>Access checking of
 class members occurs during lookup, and therefore does not pertain to
 splicing.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">4</a></span>
 A <code class="sourceCode cpp"><em>splice-expression</em></code> that
 designates a non-static data member or implicit object member function
 of a class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(4.1)</a></span>
 as part of a class member access in which the object expression refers
 to the member’s class or a class derived from that class,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(4.2)</a></span>
 to form a pointer to member (<span>7.6.2.2 <a href="https://wg21.link/expr.unary.op">[expr.unary.op]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(4.3)</a></span>
 if that <code class="sourceCode cpp"><em>splice-expression</em></code>
 denotes a non-static data member and it appears in an unevaluated
 operand.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 3:</em> </span>The implicit
-transformation (<span>7.5.5 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
+transformation (<span>7.5.4 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
 an <code class="sourceCode cpp"><em>id-expression</em></code> denoting a
 non-static member becomes a class member access does not apply to a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">5</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code>
 that designates a function or function template, overload resolution is
 performed (<span>12.2 <a href="https://wg21.link/over.match">[over.match]</a></span>,
@@ -6216,7 +6449,7 @@ access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -6242,7 +6475,7 @@ and is followed by a
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">2</a></span>
 For <span class="rm" style="color: #bf0303"><del>the first option, if
 the</del></span> <span class="addu">a dot that is followed by an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or
@@ -6265,7 +6498,7 @@ the remainder of [expr.ref] will address only <span class="rm" style="color: #bf
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">3</a></span>
 The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -6277,7 +6510,7 @@ determines the result of the entire postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">4</a></span>
 Abbreviating
 <code class="sourceCode cpp"><em>postfix-expression</em></code>.<code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="addu">or <code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span><em>splice-expression</em></code></span>
@@ -6292,11 +6525,11 @@ Explicitly add a fallback to paragraph 7 that makes other cases
 ill-formed.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">7</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="addu">designates
 an entity that</span> is declared to have type “reference to
 <code class="sourceCode cpp">T</code>”, then
@@ -6311,13 +6544,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(7.2)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
@@ -6336,15 +6569,15 @@ member, then the type of
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 “<em>cq12</em> <em>vq12</em>
 <code class="sourceCode cpp">T</code>”.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(7.3)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> is an overload set, […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(7.4)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(7.5)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
@@ -6352,10 +6585,10 @@ ill-formed.</p></li>
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(7.6)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(7.6)</a></span>
 Otherwise, the program is ill-formed.</span></p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">8</a></span>
 If <code class="sourceCode cpp">E2</code> is <span class="addu">an
 <code class="sourceCode cpp"><em>id-expression</em></code>
 denoting</span> a non-static member, the program is ill-formed if the
@@ -6363,7 +6596,7 @@ class of which <code class="sourceCode cpp">E2</code> <span class="rm" style="co
 <a href="https://wg21.link/class.member.lookup">[class.member.lookup]</a></span>)
 of the naming class (<span>11.8.3 <a href="https://wg21.link/class.access.base">[class.access.base]</a></span>)
 of <code class="sourceCode cpp">E2</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -6379,7 +6612,7 @@ to the grammar for
 paragraph 1:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb113"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -6396,13 +6629,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -6412,7 +6645,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -6423,7 +6656,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -6447,7 +6680,7 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a>   ^^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
 <span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a>   ^^ <em>type-id</em></span>
 <span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>   ^^ <em>id-expression</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -6457,7 +6690,7 @@ described by this document can also be represented by reflections, and
 can appear as operands of
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">2</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 parsed as the longest possible sequence of tokens that could
 syntactically form a
@@ -6478,7 +6711,7 @@ syntactically form a
 <span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">3</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> that
 could be validly interpreted as <code class="sourceCode cpp"><span class="op">^^</span> <em>template-name</em></code>
 is never interpreted as <code class="sourceCode cpp"><span class="op">^^</span> <em>id-expression</em></code>,
@@ -6486,7 +6719,7 @@ and is interpreted as
 <code class="sourceCode cpp"><span class="op">^^</span> <em>type-id</em></code>
 if and only if the operand refers to the current instantiation
 ([temp.dep.type]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">4</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <span class="op">::</span></code>
 represents the global namespace. A
@@ -6494,7 +6727,7 @@ represents the global namespace. A
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>qualified-namespace-specifier</em></code>
 is interpreted as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">5</a></span>
 If lookup of the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 unambiguously finds a
@@ -6502,54 +6735,54 @@ unambiguously finds a
 the <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the namespace alias declared by that
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">6</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the namespace denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">7</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>
 represents the primary class template, function template, primary
 variable template, or alias template denoted by the
 <code class="sourceCode cpp"><em>template-name</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">8</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></code>
 represents the concept denoted by the
 <code class="sourceCode cpp"><em>concept-name</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">9</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form
 <code class="sourceCode cpp"><span class="op">^^</span> <em>type-id</em></code>
 is interpreted as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(9.1)</a></span>
 If the <code class="sourceCode cpp"><em>type-id</em></code> is a
 <code class="sourceCode cpp"><em>typedef-name</em></code> that was
 introduced by the declaration of a template parameter, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the type denoted by that
 <code class="sourceCode cpp"><em>typedef-name</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(9.2)</a></span>
 Otherwise, if the <code class="sourceCode cpp"><em>type-id</em></code>
 is any other <code class="sourceCode cpp"><em>typedef-name</em></code>,
 the <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the type alias associated with that
 <code class="sourceCode cpp"><em>typedef-name</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(9.3)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the type denoted by the
 <code class="sourceCode cpp"><em>type-id</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">10</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>id-expression</em></code>
 is interpreted as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(10.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(10.1)</a></span>
 If the <code class="sourceCode cpp"><em>id-expression</em></code>
 denotes an overload set <code class="sourceCode cpp"><em>S</em></code>
 and overload resolution for the expression
@@ -6558,14 +6791,15 @@ determines a unique function
 <code class="sourceCode cpp"><em>F</em></code> (<span>12.3 <a href="https://wg21.link/over.over">[over.over]</a></span>), the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents <code class="sourceCode cpp"><em>F</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(10.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(10.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
-variable, structured binding, enumerator, or non-static data member or
-member function, the
+variable or structured binding not captured by an enclosing
+<code class="sourceCode cpp"><em>lambda-expression</em></code>, an
+enumerator, or a non-static data member or member function, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents that entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(10.3)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 ill-formed. <span class="note"><span>[ <em>Note 2:</em> </span>This
@@ -6605,7 +6839,7 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <p>Extend paragraph 2 to also handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
 pointer-to-member type, <span class="addu">type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>.
@@ -6623,33 +6857,33 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between paragraphs 5 and 6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">5</a></span>
 Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">5+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">5+</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(5+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(5+.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(5+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(5+.2)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a value that is
 template-argument-equivalent (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(5+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(5+.3)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(5+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(5+.4)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(5+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(5+.5)</a></span>
 Otherwise, if one operand represents a direct base class relationship,
 then they compare equal if and only if the other operand represents the
 same direct base class relationship.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(5+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(5+.6)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -6660,7 +6894,7 @@ data member descriptions represented by
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -6677,19 +6911,37 @@ Otherwise, the result of each of the operators is unspecified.</p>
 </div>
 <h3 class="unnumbered" id="expr.const-constant-expressions"><span>7.7 <a href="https://wg21.link/expr.const">[expr.const]</a></span> Constant
 Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3>
+<p>Modify paragraph 10 to mention
+<code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">10</a></span>
+During the evaluation of an expression
+<code class="sourceCode cpp"><em>E</em></code> as a core constant
+expression, all
+<code class="sourceCode cpp"><em>id-expression</em></code>s<span class="addu">,
+<code class="sourceCode cpp"><em>splice-expression</em></code>s,</span>
+and uses of <code class="sourceCode cpp"><span class="op">*</span><span class="kw">this</span></code>
+that refer to an object or reference whose lifetime did not begin with
+the evaluation of <code class="sourceCode cpp"><em>E</em></code> are
+treated as referring to a specific instance of taht object or reference
+whose lifetime and that of all subobjects (including all union members)
+includes the entire constant evaluation. […]</p>
+</blockquote>
+</div>
 <p>Modify paragraph 15 to disallow returning non-consteval-only pointers
 and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">15</a></span>
 A <em>constant expression</em> is either a glvalue core constant
 expression <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> that
 <span class="addu"> </span></p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(15.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(15.1)</a></span>
 refers to an <span class="rm" style="color: #bf0303"><del>entity</del></span> <span class="addu">object or function</span> that is a permitted result of a
 constant expression<span class="addu">, and</span></p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(15.2)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(15.2)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> designates a function
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>)
 or an object whose complete object is of consteval-only type, then
@@ -6714,34 +6966,34 @@ type,</span></p>
 <p>or a prvalue core constant expression whose value satisfies the
 following constraints:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(15.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(15.3)</a></span>
 if the value is an object of class type, each non-static data member of
 reference type refers to an <span class="rm" style="color: #bf0303"><del>entity</del></span> <span class="addu">object or function</span> that is a permitted result of a
 constant expression, <span class="addu">and if the object or function is
 of consteval-only type, or is the subobject of such an object, then so
 is the value,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(15.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(15.4)</a></span>
 if the value is an object of scalar type, it does not have an
 indeterminate or erroneous value (<span>6.7.4 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(15.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(15.5)</a></span>
 if the value is of pointer type, <span class="addu">then: </span>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(15.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(15.5.1)</a></span>
 it is a pointer to an object of static storage duration<span class="rm" style="color: #bf0303"><del>,</del></span> <span class="addu">or</span>
 a pointer past the end of such an object (<span>7.6.6 <a href="https://wg21.link/expr.add">[expr.add]</a></span>), <span class="addu">and if the complete object of that object is of
 consteval-only type then so is that pointer,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(15.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(15.5.2)</a></span>
 <span class="addu">it is</span> a pointer to a non-immediate function,
 <span class="addu">and if that function is of consteval-only type then
 so is that pointer,</span> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(15.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(15.5.3)</a></span>
 <span class="addu">it is</span> a null pointer value,</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(15.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(15.6)</a></span>
 if the value is of pointer-to-member-function type, it does not
 designate an immediate function, <span class="addu">and if that function
 is of consteval-only type then so is that value,</span> and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(15.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(15.7)</a></span>
 if the value is an object of class or array type, each subobject
 satisfies these constraints for the value.</li>
 </ul>
@@ -6751,22 +7003,24 @@ satisfies these constraints for the value.</li>
 in paragraph 18 to also apply to expressions of consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">18</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it is <span class="rm" style="color: #bf0303"><del>either</del></span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(18.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(18.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">an</span>
-<code class="sourceCode cpp"><em>id-expression</em></code> that denotes
-an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that is not a subexpression of an immediate
-invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(18.2)</a></span>
+<code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>
+that <span class="rm" style="color: #bf0303"><del>denotes</del></span>
+<span class="addu">designates</span> an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that
+is not a subexpression of an immediate invocation, or</del></span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(18.2)</a></span>
 an immediate invocation that is not a constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(18.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(18.3)</a></span>
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>).</span></li>
 </ul>
 </blockquote>
@@ -6777,18 +7031,18 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">21pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">21pre</a></span>
 A non-dependent expression or conversion is <em>plainly
 constant-evaluated</em> if it is not in a complete-class context
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 and is either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(21pre.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(21pre.1)</a></span>
 the <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 (<span>9.1 <a href="https://wg21.link/dcl.pre">[dcl.pre]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(21pre.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(21pre.2)</a></span>
 an initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
@@ -6811,22 +7065,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">21</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(21.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(21.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(21.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(21.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -6848,7 +7102,7 @@ injecting declarations and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">22</a></span>
 The evaluation of an expression can introduce one or more <em>injected
 declarations</em>. Each such declaration has an associated
 <em>synthesized point</em> which follows the last non-synthesized
@@ -6857,17 +7111,17 @@ evaluation is said to <em>produce</em> the declaration.</p>
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to synthesized points (<span>10.7 <a href="https://wg21.link/module.reach">[module.reach]</a></span>).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">23</a></span>
 The program is ill-formed if the evaluation of a manifestly
 constant-evaluated expression
 <code class="sourceCode cpp"><em>M</em></code> produces an injected
 declaration <code class="sourceCode cpp"><em>D</em></code> and
 either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(23.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(23.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a plainly
 constant-evaluated expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(23.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(23.2)</a></span>
 the target scope of <code class="sourceCode cpp"><em>D</em></code> is
 not semantically sequenced with
 <code class="sourceCode cpp"><em>M</em></code> (<span>5.2 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span>).</li>
@@ -6875,20 +7129,20 @@ not semantically sequenced with
 <p>Furthermore, the program is ill-formed, no diagnostic required,
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(23.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(23.3)</a></span>
 an evaluation
 <code class="sourceCode cpp"><em>E</em><sub><em>1</em></sub></code>
 produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> during the evaluation of
 a manifestly constant-evaluated expression
 <code class="sourceCode cpp"><em>M</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(23.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(23.4)</a></span>
 a second evaluation
 <code class="sourceCode cpp"><em>E</em><sub><em>2</em></sub></code>
 computes a reflection of <code class="sourceCode cpp"><em>D</em></code>
 during the same evaluation of
 <code class="sourceCode cpp"><em>M</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(23.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(23.5)</a></span>
 <code class="sourceCode cpp"><em>E</em><sub><em>1</em></sub></code> is
 unsequenced with
 <code class="sourceCode cpp"><em>E</em><sub><em>2</em></sub></code>
@@ -6929,7 +7183,7 @@ unsequenced with
 <span id="cb118-31"><a href="#cb118-31" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ill-formed, no diagnostic required</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines the behavior of certain functions used for reflection
 ([meta.reflection]). During the evaluation of a manifestly
@@ -6938,11 +7192,11 @@ constant-evaluated expression
 of an evaluation <code class="sourceCode cpp"><em>E</em></code>
 comprises the union of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> (<span>10.6 <a href="https://wg21.link/module.context">[module.context]</a></span>),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(24.2)</a></span>
 the synthesized points corresponding to any injected declarations
 produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> (<span>6.9.1 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>).</li>
@@ -6957,7 +7211,7 @@ with its associated type from paragraph 8 (type aliases are entities
 now).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">8</a></span>
 If the <code class="sourceCode cpp"><em>decl-specifier-seq</em></code>
 contains the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -6975,7 +7229,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 specifier now introduces an entity.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">1</a></span>
 Declarations containing the
 <code class="sourceCode cpp"><em>decl-specifier</em></code>
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7018,7 +7272,7 @@ a <code class="sourceCode cpp"><em>typedef-name</em></code> <span class="rm" sty
 <code class="sourceCode cpp"><em>typedef-name</em></code> does not
 introduce a new type the way a class declaration (<span>11.3 <a href="https://wg21.link/class.name">[class.name]</a></span>) or enum
 declaration (<span>9.7.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">2</a></span>
 A <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span> can also be <span class="rm" style="color: #bf0303"><del>introduced</del></span> <span class="addu">declared</span> by an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>. The
@@ -7056,7 +7310,7 @@ to accommodate
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -7064,10 +7318,10 @@ is a placeholder for a type to be deduced ([dcl.spec.auto]). A
 is a placeholder for a deduced class type ([dcl.type.class.deduct])
 <span class="addu">if it either </span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(3.1)</a></span>
 is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(3.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(3.2)</a></span>
 is of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>
 and the <code class="sourceCode cpp"><em>splice-specifier</em></code>
@@ -7160,6 +7414,39 @@ the types they specify [tab:dcl.type.simple]
 </table>
 </blockquote>
 </div>
+<h3 class="unnumbered" id="dcl.type.decltype-decltype-specifiers"><span>9.2.9.6 <a href="https://wg21.link/dcl.type.decltype">[dcl.type.decltype]</a></span>
+Decltype specifiers<a href="#dcl.type.decltype-decltype-specifiers" class="self-link"></a></h3>
+<p>Add a bullet after bullet 1.3 to apply to
+<code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
+For an expression <code class="sourceCode cpp"><em>E</em></code>, the
+type denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
+is defined as follows:</p>
+<p>[…]</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(1.3)</a></span>
+otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
+unparenthesized
+<code class="sourceCode cpp"><em>id-expression</em></code> or an
+unparenthesized class member access ([expr.ref]), <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
+is the type of the entity named by
+<code class="sourceCode cpp"><em>E</em></code>. If there is no such
+entity, the program is ill-formed;</li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(1.3+)</a></span>
+otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
+unparenthesized
+<code class="sourceCode cpp"><em>splice-expression</em></code>, <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
+is the type of the entity, object, or value named by
+<code class="sourceCode cpp"><em>E</em></code>;</span></li>
+</ul>
+<p>[…]</p>
+<p>The operand of the
+<code class="sourceCode cpp"><span class="kw">decltype</span></code>
+specifier is an unevaluated operand.</p>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="dcl.type.splice-type-splicing">[dcl.type.splice] Type splicing<a href="#dcl.type.splice-type-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of (<span>9.2.9 <a href="https://wg21.link/dcl.type">[dcl.type]</a></span>) following
 (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>).</p>
@@ -7170,7 +7457,7 @@ the types they specify [tab:dcl.type.simple]
 <div class="sourceCode" id="cb122"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
 <span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specifier</em></span>
 <span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -7199,7 +7486,7 @@ within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.gen
 <span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> alias <span class="op">=</span> <span class="op">[:^^</span>S<span class="op">::</span>type<span class="op">:]</span>;    <span class="co">// OK, type-only context</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>,
@@ -7209,7 +7496,7 @@ concept. The
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -7222,12 +7509,12 @@ shall designate a primary class template or an alias template. Let
 any) of the
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>T</em></code> is a primary class
 template, the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(3.2)</a></span>
 Otherwise if <code class="sourceCode cpp"><em>T</em></code> is an alias
 template, the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
@@ -7242,7 +7529,7 @@ designates the type denoted by
 clear about the entity being referred to.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
@@ -7253,9 +7540,28 @@ type <span class="rm" style="color: #bf0303"><del>named</del></span>
 <span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>)) shall
 appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(9.1)</a></span>
 […]</li>
 </ul>
+</blockquote>
+</div>
+<h3 class="unnumbered" id="dcl.fct.default-default-arguments"><span>9.3.4.7 <a href="https://wg21.link/dcl.fct.default">[dcl.fct.default]</a></span>
+Default arguments<a href="#dcl.fct.default-default-arguments" class="self-link"></a></h3>
+<p>Modify paragraph 9 to allow reflections of non-static data members to
+appear in default function arguments.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">9</a></span>
+A default argument is evaluated each time the function is called with no
+argument for the corresponding parameter.</p>
+<p>[…]</p>
+<p>A non-static member shall not appear in a default argument unless it
+appears as the
+<code class="sourceCode cpp"><em>id-expression</em></code> of a class
+member access expression ([expr.ref]) <span class="addu">or
+<code class="sourceCode cpp"><em>reflect-expression</em></code>
+([expr.reflect])</span> or unless it is used to form a pointer to member
+([expr.unary.op]).</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
@@ -7266,46 +7572,46 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>),
 the object is initialized to the value obtained by converting the
 integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -7313,7 +7619,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -7322,26 +7628,26 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
 type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -7350,7 +7656,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -7364,7 +7670,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 a <code class="sourceCode cpp"><em>reflect-expression</em></code>
@@ -7393,7 +7699,7 @@ follows:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">1</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> of
 the form
@@ -7421,7 +7727,7 @@ in paragraph 1, and clarify that such declarations declare a “namespace
 alias” (which is now an entity as per [basic.pre]).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">1</a></span>
 A
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 declares <span class="rm" style="color: #bf0303"><del>an alternative
@@ -7449,7 +7755,7 @@ this will fall out from the “underlying entity” of the namespace alias
 defined below:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -7463,7 +7769,7 @@ note:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">2+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">2+</a></span>
 The underlying entity (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>) of the
 namespace alias is the namespace either denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
@@ -7491,14 +7797,14 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
 any, designates a namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> and
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 not be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -7562,7 +7868,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -7586,7 +7892,7 @@ Deprecated attribute<a href="#dcl.attr.deprecated-deprecated-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">2</a></span>
 The attribute may be applied to the declaration of a class, a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, a variable, a non-static data
 member, a function, a namespace, an enumeration, an enumerator, a
@@ -7600,7 +7906,7 @@ Maybe unused attribute<a href="#dcl.attr.unused-maybe-unused-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">2</a></span>
 The attribute may be applied to the declaration of a class, <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, variable (including a structured
 binding declaration), structured binding, non-static data member,
@@ -7611,6 +7917,41 @@ function, enumeration, or enumerator, or to an
 </div>
 <h3 class="unnumbered" id="module.global.frag-global-module-fragment"><span>10.4 <a href="https://wg21.link/module.global.frag">[module.global.frag]</a></span>
 Global module fragment<a href="#module.global.frag-global-module-fragment" class="self-link"></a></h3>
+<p>Extend bullet 3.1 to include
+<code class="sourceCode cpp"><em>splice-specifier</em></code>s that
+designate <code class="sourceCode cpp"><em>D</em></code>. Separately
+account for
+<code class="sourceCode cpp"><em>splice-specifier</em></code>s that
+might have a
+<code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
+designating a specialization.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">3</a></span>
+A declaration <code class="sourceCode cpp"><em>D</em></code> is
+<em>decl-reachable</em> from a declaration
+<code class="sourceCode cpp"><em>S</em></code> in the same translation
+unit if</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(3.1)</a></span>
+<code class="sourceCode cpp"><em>D</em></code> does not declare a
+function or function template and
+<code class="sourceCode cpp"><em>S</em></code> contains an
+<code class="sourceCode cpp"><em>id-expression</em></code>,
+<code class="sourceCode cpp"><em>namespace-name</em></code>,
+<code class="sourceCode cpp"><em>type-name</em></code>,
+<code class="sourceCode cpp"><em>template-name</em></code>, or
+<code class="sourceCode cpp"><em>concept-name</em></code> naming
+<code class="sourceCode cpp"><em>D</em></code> <span class="addu">or a
+<code class="sourceCode cpp"><em>splice-specifier</em></code> or
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+designating <code class="sourceCode cpp"><em>D</em></code></span>,
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(3.2)</a></span>
+[…]</li>
+</ul>
+</blockquote>
+</div>
 <p>Specify in paragraph 3 that it is unspecified whether spliced types
 are replaced by their designated types, and renumber accordingly. Add an
 additional bullet further clarifying that it is unspecified whether any
@@ -7619,7 +7960,7 @@ splice specifier is replaced.</p>
 <blockquote>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7628,22 +7969,22 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>template-name</em></code> names an
 alias template is replaced by its denoted type prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(3.8)</a></span>
 whether a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 that does not <span class="rm" style="color: #bf0303"><del>denote</del></span> <span class="addu">designate</span> a dependent type is replaced by its <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> type prior to this determination, <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(3.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(3.9)</a></span>
 whether a non-value-dependent constant expression is replaced by the
 result of constant evaluation prior to this determination<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(3.10)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(3.10)</a></span>
 whether a <code class="sourceCode cpp"><em>splice-specifier</em></code>
 that is not dependent is replaced by the construct that it designates
 prior to this determination.</span></li>
@@ -7656,23 +7997,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 a synthesized point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 synthesized point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 (<span>10.4 <a href="https://wg21.link/module.global.frag">[module.global.frag]</a></span>),
 appears in a translation unit that is reachable from
@@ -7688,7 +8029,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -7713,7 +8054,7 @@ member description</em>:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">29+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">29+</a></span>
 A <em>data member description</em> is a quintuple
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -7722,19 +8063,19 @@ A <em>data member description</em> is a quintuple
 <code class="sourceCode cpp"><em>NUA</em></code>) describing the
 potential declaration of a nonstatic data member where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(29+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(29+.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a type or type
 alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(29+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(29+.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is an
 <code class="sourceCode cpp"><em>identifier</em></code> or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(29+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(29+.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is an alignment or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(29+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(29+.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is a bit-field width or
 <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(29+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(29+.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is a boolean
 value.</li>
 </ul>
@@ -7744,14 +8085,14 @@ components are same types, same identifiers, and equal values.</p>
 <p><span>[ <em>Note 4:</em> </span>The components of a data member
 description describe a data member such that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(29+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(29+.6)</a></span>
 its type is specified using the type or type alias given by
 <code class="sourceCode cpp"><em>T</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(29+.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(29+.7)</a></span>
 it is declared with the name given by
 <code class="sourceCode cpp"><em>N</em></code> if <code class="sourceCode cpp"><em>N</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise unnamed,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(29+.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(29+.8)</a></span>
 it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>
 (<span>9.12.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
@@ -7759,11 +8100,11 @@ it is declared with the
 if <code class="sourceCode cpp"><em>A</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise declared without an
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(29+.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(29+.9)</a></span>
 it is a bit-field (<span>11.4.10 <a href="https://wg21.link/class.bit">[class.bit]</a></span>) with the
 width given by <code class="sourceCode cpp"><em>W</em></code> if <code class="sourceCode cpp"><em>W</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise not a bit-field,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(29+.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">(29+.10)</a></span>
 it is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
 (<span>9.12.12 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
 if <code class="sourceCode cpp"><em>NUA</em></code> is
@@ -7786,7 +8127,7 @@ note</em> ]</span></p>
 General<a href="#class.derived.general-general" class="self-link"></a></h3>
 <p>Introduce the term “direct base class relationship” to paragraph
 2.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>class-or-decltype</em></code> are those
 of its
@@ -7833,7 +8174,7 @@ resolution, and add a note explaining the expressions that form overload
 sets.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">2</a></span>
 <span class="addu">An <em>overload set</em> is a set of declarations
 that each denote a function or function template. Using these
 declarations as a starting point, the process of <em>overload
@@ -7862,14 +8203,14 @@ General<a href="#over.match.general-general" class="self-link"></a></h3>
 in all contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">3</a></span>
 If a best viable function exists and is unique, overload resolution
 succeeds and produces it as the result. Otherwise overload resolution
 fails and the invocation is ill-formed. When overload resolution
 succeeds, and the best viable function is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither
 designated in a manner exempt from access rules nor</span> accessible in
 the context in which it is used, the program is ill-formed.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">4</a></span>
 Overload resolution results in a <em>usable candidate</em> if overload
 resolution succeeds and the selected candidate is either not a function
 (<span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>), or is a
@@ -7884,7 +8225,7 @@ to named function<a href="#over.call.func-call-to-named-function" class="self-li
 splices of function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
 Of interest in [over.call.func] are only those function calls in which
 the <code class="sourceCode cpp"><em>posfix-expression</em></code>
 ultimately contains an
@@ -7912,7 +8253,7 @@ qualified function calls and unqualified function calls.</p>
 designating member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">2</a></span>
 In qualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -7955,7 +8296,7 @@ in the normalized member function call as the implied object argument
 designating non-member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">3</a></span>
 In unqualified function calls, the function is named by a
 <code class="sourceCode cpp"><em>primary-expression</em></code>. <span class="addu">If that
 <code class="sourceCode cpp"><em>primary-expression</em></code> is a
@@ -7980,7 +8321,7 @@ augmented by the addition of an implied function argument as in a
 qualified function call. If the current class is, or is derived from,
 <code class="sourceCode cpp">T</code>, and the keyword
 <code class="sourceCode cpp"><span class="kw">this</span></code>
-(<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
+(<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
 refers to it, then the implied object argument is <code class="sourceCode cpp"><span class="op">(*</span><span class="kw">this</span><span class="op">)</span></code>.
 Otherwise, a contrived object of type
 <code class="sourceCode cpp">T</code> becomes the implied object
@@ -7995,7 +8336,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">1</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -8005,7 +8346,7 @@ where the <code class="sourceCode cpp"><em>template-name</em></code>
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -8014,7 +8355,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">3</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -8029,13 +8370,37 @@ The guides of <code class="sourceCode cpp">A</code> are the set of
 functions or function templates formed as follows. …</p>
 </blockquote>
 </div>
+<h3 data-number="5.1.1" id="over.over-address-of-an-overload-set"><span class="header-section-number">5.1.1</span> <span>12.3 <a href="https://wg21.link/over.over">[over.over]</a></span> Address of an
+overload set<a href="#over.over-address-of-an-overload-set" class="self-link"></a></h3>
+<p>Remove the explicit references to
+<code class="sourceCode cpp"><em>id-expression</em></code>s from
+paragraph 1 to allow taking the address of an overload set specified by
+a <code class="sourceCode cpp"><em>splice-expression</em></code>:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">1</a></span>
+An <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span>
+whose terminal name</del></span> <span class="addu">expression
+that</span> refers to an overload set
+<code class="sourceCode cpp"><em>S</em></code> and that appears without
+arguments is resolved to a function, a pointer to function, or a pointer
+to member function for a specific function that is chosen from a set of
+functions selected from <code class="sourceCode cpp"><em>S</em></code>
+determined based on the target type required in the context (if any), as
+described below. […]</p>
+<p>The <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
+<span class="addu">expression</span> can be preceded by the
+<code class="sourceCode cpp"><span class="op">&amp;</span></code>
+operator.</p>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="over.built-built-in-operators"><span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span> Built-in
 operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 <p>Add built-in operator candidates for <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -8046,16 +8411,28 @@ there exist candidate operator functions of the form</p>
 </div>
 <h3 class="unnumbered" id="temp.param-template-parameters"><span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span> Template
 parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
-<p>Extend the grammar for
+<p>Extend <code class="sourceCode cpp"><em>type-parameter</em></code> to
+permit <code class="sourceCode cpp"><em>splice-specifier</em></code>s as
+default template arguments for template template parameters. Also extend
+the grammar for
 <code class="sourceCode cpp"><em>type-constraint</em></code> to include
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb132"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>  <em>type-constraint</em>:</span>
-<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
-<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub>&gt;</span>
-<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em></span></span></code></pre></div>
+<div class="sourceCode" id="cb132"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a>  <em>type-parameter</em>:</span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a>      <em>type-parameter-key</em> ...<sub><em>opt</em></sub> <em>identifier</em><sub><em>opt</em></sub></span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>      <em>type-parameter-key</em> <em>identifier</em><sub><em>opt</em></sub> = <em>type-id</em></span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>      <em>type-constraint</em> ...<sub><em>opt</em></sub> <em>identifier</em><sub><em>opt</em></sub></span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>      <em>type-constraint</em> <em>identifier</em><sub><em>opt</em></sub> = <em>type-id</em></span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>      <em>template-head</em> <em>type-parameter-key</em> ...<sub><em>opt</em></sub> <em>identifier</em><sub><em>opt</em></sub></span>
+<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a>      <em>template-head</em> <em>type-parameter-key</em> <em>identifier</em><sub><em>opt</em></sub> = <em>id-expression</em></span>
+<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>template-head</em> <em>type-parameter-key</em> <em>identifier</em><sub><em>opt</em></sub> = <em>splice-template-argument</em></span></span>
+<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>  <em>type-constraint</em>:</span>
+<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
+<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>      <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em> &lt; <em>template-argument-list</em><sub><em>opt</em></sub>&gt;</span>
+<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a><span class="va">+     <em>splice-type-specifier</em></span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -8065,7 +8442,7 @@ parameters<a href="#temp.param-template-parameters" class="self-link"></a></h3>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">3+</a></span>
 A non-dependent
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
 forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
@@ -8101,32 +8478,32 @@ and add it as a production for
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">(3.1)</a></span>
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
 either appears in a type-only context or is preceded by
 <code class="sourceCode cpp"><span class="kw">template</span></code> or
 <code class="sourceCode cpp"><span class="kw">typename</span></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -8166,7 +8543,7 @@ disambiguation in paragraph 4 also applies to the parsing of
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">4</a></span>
 When parsing a
 <code class="sourceCode cpp"><em>template-argument-list</em></code>, the
 first non-nested
@@ -8195,27 +8572,27 @@ cast).<span> — <em>end note</em> ]</span></span></p>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">7</a></span>
 A <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is <em>valid</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(7.1)</a></span>
 there are at most as many arguments as there are parameters or a
 parameter is a template parameter pack (<span>13.7.4 <a href="https://wg21.link/temp.variadic">[temp.variadic]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(7.2)</a></span>
 there is an argument for each non-deducible non-pack parameter that does
 not have a default
 <code class="sourceCode cpp"><em>template-argument</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(7.3)</a></span>
 each <code class="sourceCode cpp"><em>template-argument</em></code>
 matches the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>
 (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(7.4)</a></span>
 substitution of each template argument into the following template
 parameters (if any) succeeds, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(7.5)</a></span>
 if the <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is non-dependent, the associated constraints are satisfied as specified
@@ -8232,7 +8609,7 @@ shall be valid unless it names a function template specialization
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or the
 <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
@@ -8252,7 +8629,7 @@ of the constrained template shall be satisfied (<span>13.5.2 <a href="https://wg
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">111)</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">111)</a></span>
 A <code class="sourceCode cpp"><span class="op">&gt;</span></code> that
 encloses the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>,
@@ -8274,7 +8651,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>template-argument</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">1</a></span>
 There are <span class="rm" style="color: #bf0303"><del>three</del></span> <span class="addu">four</span> forms of
 <code class="sourceCode cpp"><em>template-argument</em></code>, <span class="addu">three of which</span> correspond<span class="rm" style="color: #bf0303"><del>ing</del></span> to the three forms of
 <code class="sourceCode cpp"><em>template-parameter</em></code>: type,
@@ -8295,7 +8672,7 @@ declared by the template in its
 in paragraph 3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -8330,7 +8707,7 @@ form of the corresponding
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">9</a></span>
 When a <code class="sourceCode cpp"><em>simple-template-id</em></code>
 <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -8347,7 +8724,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -8369,7 +8746,7 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
@@ -8378,11 +8755,11 @@ for the variable x in the invented declaration</p>
 <div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">2</a></span>
 The value of a non-type <em>template-parameter</em>
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">3</a></span>
 Otherwise, a temporary variable</p>
 <div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
@@ -8394,7 +8771,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be <span class="rm" style="color: #bf0303"><del>the name
@@ -8408,33 +8785,50 @@ not considered even if their parameter lists match that of the template
 template parameter.</p>
 </blockquote>
 </div>
+<h3 class="unnumbered" id="temp.constr.normal-constraint-normalization"><span>13.5.4 <a href="https://wg21.link/temp.constr.normal">[temp.constr.normal]</a></span>
+Constraint normalization<a href="#temp.constr.normal-constraint-normalization" class="self-link"></a></h3>
+<p>Include a reference to
+<code class="sourceCode cpp"><em>splice-expression</em></code>s in Note
+1.</p>
+<div class="std">
+<blockquote>
+<p><span class="note1"><span>[ <em>Note 1:</em> </span>Normalization of
+<code class="sourceCode cpp"><em>constraint-expression</em></code>s is
+performed when determining the associated constraints
+([temp.constr.constr]) of a declaration and when evaluating the value of
+an <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
+<code class="sourceCode cpp"><em>splice-expression</em></code></span>
+that names a concept specialization ([expr.prim.id] <span class="addu">,
+[expr.prim.splice]</span>)<span> — <em>end note</em> ]</span></span></p>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="temp.type-type-equivalence"><span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span> Type
 equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <p>Extend paragraph 1 to also define the “sameness” of
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s</span>
 are the same if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(1.1)</a></span>
 their <code class="sourceCode cpp"><em>template-name</em></code>s,
 <code class="sourceCode cpp"><em>operator-function-id</em></code>s,
 <span class="rm" style="color: #bf0303"><del>or</del></span>
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>s<span class="addu">, or
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s</span>
 refer to the same template, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(1.2)</a></span>
 their corresponding type
 <code class="sourceCode cpp"><em>template-argument</em></code>s are the
 same type, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(1.3)</a></span>
 the template parameter values determined by their corresponding non-type
 template arguments (<span>13.4.3 <a href="https://wg21.link/temp.arg.nontype">[temp.arg.nontype]</a></span>)
 are template-argument-equivalent (see below), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(1.4)</a></span>
 their corresponding template
 <code class="sourceCode cpp"><em>template-argument</em></code>s refer to
 the same template.</li>
@@ -8448,23 +8842,23 @@ that are the same refer to the same class, function, or variable.</p>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -8476,7 +8870,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -8515,7 +8909,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When a</del></span> <span class="addu">A</span>
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">that</span> refers to the specialization of an alias
 template<span class="rm" style="color: #bf0303"><del>, it is equivalent
@@ -8542,22 +8936,22 @@ be elided from a
 non-dependent contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">4</a></span>
 A qualified or unqualified name is said to be in a
 <code class="sourceCode cpp"><em>type-only context</em></code> if it is
 the terminal name of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(4.1)</a></span>
 a <code class="sourceCode cpp"><em>typename-specifier</em></code>,
 <code class="sourceCode cpp"><em>type-requirement</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>elaborated-type-specifier</em></code>,
 <code class="sourceCode cpp"><em>class-or-decltype</em></code>, <span class="addu"><code class="sourceCode cpp"><em>using-enum-declarator</em></code></span>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.2)</a></span>
 […]
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(4.4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.4.6)</a></span>
 <code class="sourceCode cpp"><em>parameter-declaration</em></code> of a
 (non-type)
 <code class="sourceCode cpp"><em>template-parameter</em></code>.</li>
@@ -8602,7 +8996,7 @@ Dependent types<a href="#temp.dep.type-dependent-types" class="self-link"></a></
 paragraph 7.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">7</a></span>
 An initializer is dependent if any constituent expression (<span>6.9.1
 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>)
 of the initializer is type-dependent. A placeholder type
@@ -8621,18 +9015,18 @@ definition to apply to
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">8</a></span>
 A placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 is dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">(8.1)</a></span>
 it has a dependent initializer, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(8.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(8.2)</a></span>
 it has a dependent
 <code class="sourceCode cpp"><em>template-name</em></code> or a
 dependent <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(8.3)</a></span>
 it refers to an alias template that is a member of the current
 instantiation and whose
 <code class="sourceCode cpp"><em>defining-type-id</em></code> is
@@ -8646,28 +9040,28 @@ and substitution (<span>13.7.8 <a href="https://wg21.link/temp.alias">[temp.alia
 paragraph 10:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">10</a></span>
 A type is dependent if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(10.1)</a></span>
 a template parameter,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(10.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(10.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(10.11)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> in which
 either the template name is a template parameter or any of the template
 arguments is a dependent type or an expression that is type-dependent or
 value-dependent or is a pack expansion,<sup>121</sup></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(10.12)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(10.12)</a></span>
 a <code class="sourceCode cpp"><em>pack-index-specifier</em></code>,
 <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(10.13)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(10.13)</a></span>
 denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>expression</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is
 type-dependent<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(10.14)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(10.14)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> in
 which either the
@@ -8705,16 +9099,16 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is type-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(9.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(9.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -8730,10 +9124,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -8761,16 +9155,16 @@ or a value-dependent or type-dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is value-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(6.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(6.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -8789,7 +9183,7 @@ and renumber accordingly.</p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent splice specifiers [temp.dep.splice]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if its converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
@@ -8799,7 +9193,7 @@ or <code class="sourceCode cpp"><em>splice-scope-specifier</em></code>
 is dependent if its
 <code class="sourceCode cpp"><em>splice-template-argument</em></code> is
 dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> T, <span class="kw">auto</span> NS, <span class="kw">auto</span> C, <span class="kw">auto</span> V<span class="op">&gt;</span></span>
@@ -8831,7 +9225,7 @@ Explicit specialization<a href="#temp.expl.spec-explicit-specialization" class="
 to be used like incompletely-defined classes.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">9</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 that <span class="rm" style="color: #bf0303"><del>names</del></span>
@@ -8849,7 +9243,7 @@ General<a href="#temp.deduct.general-general" class="self-link"></a></h3>
 in paragraph 2:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">2</a></span>
 When an explicit template argument list is specified, if the given
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -8870,7 +9264,7 @@ the same as parameter types that are specified using
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(4.3)</a></span>
 If <code class="sourceCode cpp">P</code> is a class and
 <code class="sourceCode cpp">P</code> has the form
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code></span>,
@@ -8902,7 +9296,7 @@ template argument might also be a
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">20</a></span>
 If <code class="sourceCode cpp">P</code> has a form that contains <code class="sourceCode cpp"><span class="op">&lt;</span>i<span class="op">&gt;</span></code>,
 and if the type of <code class="sourceCode cpp">i</code> differs from
 the type of the corresponding template parameter of the template named
@@ -8927,7 +9321,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -8945,24 +9339,24 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const]).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">4</a></span>
 […] Next, the semantics of the code sequence are determined by the
 <em>Constraints</em>, <em>Mandates</em>, <span class="addu"><em>Constant
 When</em>,</span> <em>Preconditions</em>, <em>Effects</em>,
@@ -8978,7 +9372,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -8986,7 +9380,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -8995,14 +9389,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not return reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -9434,11 +9828,11 @@ synopsis</strong></p>
 <span id="cb146-331"><a href="#cb146-331" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb146-332"><a href="#cb146-332" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb146-333"><a href="#cb146-333" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">2</a></span>
 The behavior of any function specified in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 implementation-defined when a reflection of a construct not otherwise
@@ -9468,7 +9862,7 @@ definition, the specialization is implicitly instantiated.</p>
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">3</a></span>
 Any function in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>
 that whose return type is
@@ -9497,7 +9891,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb149-3"><a href="#cb149-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb149-4"><a href="#cb149-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -9750,10 +10144,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -9761,11 +10155,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">5</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -9780,14 +10174,14 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> is an unnamed entity other than
 a class that has a typedef name for linkage purposes (<span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.typedef]</a></span>), then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -9796,14 +10190,14 @@ either the <code class="sourceCode cpp"><em>class-name</em></code> of
 <code class="sourceCode cpp"><em>C</em></code> has a typedef name for
 linkage purposes. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -9811,20 +10205,20 @@ function template, then
 template, operator function template, or conversion function template.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents variable
 or a type alias, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.8)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -9835,37 +10229,37 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 </ul>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, then the identifier introduced by the declaration of that
 entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>
 or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>,
 respectively.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(4.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -9879,21 +10273,21 @@ identifier <code class="sourceCode cpp"><em>N</em></code> encoded with
 </ul>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a data member
 description, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or direct base class relationship that was
 introduced by a declaration, implementations should return a value
@@ -9912,7 +10306,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or
@@ -9920,7 +10314,7 @@ direct base class relationship that is public, protected, or private,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -9928,7 +10322,7 @@ function or a direct base class relationship that is virtual. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -9936,7 +10330,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -9944,7 +10338,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -9953,7 +10347,7 @@ deleted function ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -9961,7 +10355,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -9976,7 +10370,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -9993,7 +10387,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -10007,7 +10401,7 @@ for which <code class="sourceCode cpp"><em>W</em></code> is not <code class="sou
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -10015,7 +10409,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -10024,7 +10418,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -10033,7 +10427,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -10043,7 +10437,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -10054,7 +10448,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -10063,7 +10457,7 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -10073,7 +10467,7 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">17</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -10082,20 +10476,20 @@ introduced within the scope of the entity represented by
 <code class="sourceCode cpp">r</code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">19</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity whose
@@ -10103,7 +10497,7 @@ underlying entity is a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb176-2"><a href="#cb176-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias or
@@ -10112,7 +10506,7 @@ namespace alias, respectively <span class="note"><span>[ <em>Note
 alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -10120,7 +10514,7 @@ alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -10135,7 +10529,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb179-7"><a href="#cb179-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb179-8"><a href="#cb179-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb179-9"><a href="#cb179-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -10145,14 +10539,14 @@ operator, a copy assignment operator, a move assignment operator, or a
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">26</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -10169,7 +10563,7 @@ is
 <span id="cb181-7"><a href="#cb181-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb181-8"><a href="#cb181-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb181-9"><a href="#cb181-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -10178,7 +10572,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">28</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -10187,14 +10581,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -10205,7 +10599,7 @@ Otherwise,
 <span id="cb185-3"><a href="#cb185-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-4"><a href="#cb185-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-5"><a href="#cb185-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -10213,19 +10607,19 @@ namespace member, non-static data member, static member, or direct base
 class relationship, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">33</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, direct base
 class relationship, or data member description.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">34</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then a reflection of the type of what is
 represented by <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -10240,11 +10634,11 @@ Otherwise, for a data member description
 a reflection of the type
 <code class="sourceCode cpp"><em>T</em></code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -10260,33 +10654,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(37.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(37.1)</a></span>
 either an object or variable, usable in constant expressions from some
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(37.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(37.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(37.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(37.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">38</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(38.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(38.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(38.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(38.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">(38.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(38.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -10302,13 +10696,13 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>), type
 alias, or direct base class relationship.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">40</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a direct member of an anonymous union,
 then a reflection representing the innermost enclosing anonymous union.
@@ -10316,10 +10710,10 @@ Otherwise, a reflection of the class, function, or namespace that is the
 target scope ([basic.scope.scope]) of the first declaration of what is
 represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">41</a></span>
 <em>Returns</em>: A reflection representing the underlying entity of
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">42</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">42</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb194"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -10331,15 +10725,15 @@ represented by <code class="sourceCode cpp">r</code>.</p>
 </div>
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">43</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">44</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">44</a></span>
 <em>Returns</em>: A reflection of the primary template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">45</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">45</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb196"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -10363,11 +10757,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a class type that is complete from some
 point in the evaluation context or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -10390,7 +10784,7 @@ members-of-representable,</li>
 members-of-representable members include: injected class names, partial
 template specializations, friend declarations, and static
 assertions.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-reachable</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -10401,7 +10795,7 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">4</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -10416,10 +10810,10 @@ but the order of namespace members is unspecified. <span class="note"><span>[ <
 members. Implicitly-declared special members appear after any
 user-declared members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">6</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -10429,70 +10823,70 @@ relationships are indexed in the order in which the corresponding base
 classes appear in the <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">8</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_variable<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">10</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_nonstatic_data_member<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">11</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">12</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">13</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">18</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">19</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">20</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -10507,22 +10901,22 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or direct base class
 relationship other than a virtual base class of an abstract class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the offset in bits
 from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, direct base class relationship, or data
@@ -10530,7 +10924,7 @@ member description. If <code class="sourceCode cpp">dealias<span class="op">(</s
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a data member
@@ -10548,7 +10942,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing a type, object, variable, non-static data
 member that is not a bit-field, direct base class relationship, or data
@@ -10556,21 +10950,21 @@ member description. If <code class="sourceCode cpp">dealias<span class="op">(</s
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">(8.1)</a></span>
 If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, variable, or object, then the alignment requirement
 of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(8.4)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10580,7 +10974,7 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 The value <code class="sourceCode cpp"><em>A</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, unnamed bit-field, direct base class
@@ -10588,7 +10982,7 @@ relationship, or data member description. If <code class="sourceCode cpp">dealia
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field or unnamed bit-field with
 width <code class="sourceCode cpp"><em>W</em></code>, or a data member
@@ -10606,32 +11000,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from some point in the evaluation
 context and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -10639,7 +11033,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -10647,7 +11041,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -10655,58 +11049,58 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">7</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a pointer type, then a
 pointer value pointing to the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(7.2)</a></span>
 Otherwise, a pointer-to-member value designating the entity represented
 by <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value that
 <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value that <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">10</a></span>
 <em>Returns</em>: the value that <code class="sourceCode cpp">r</code>
 represents converted to <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -10724,40 +11118,40 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb215-5"><a href="#cb215-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">8</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span><code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">..&gt;</span></code>
 is not instantiated.<span> — <em>end note</em> ]</span></span></p>
 </div>
@@ -10770,32 +11164,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is neither a reference type nor an array type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, is the address of or refers to an object or function that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -10803,37 +11197,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or function that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -10846,7 +11240,7 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">name_type</code> are consteval-only types
 ([basic.types.general]), and are not a structural types
@@ -10869,12 +11263,12 @@ The classes <code class="sourceCode cpp">data_member_options</code> and
 <span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -10895,64 +11289,64 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp">cv <em>T</em></code>
 where <code class="sourceCode cpp"><em>T</em></code> is either an object
 type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(4.3)</a></span>
 otherwise, if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">(4.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(4.5.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">(4.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(4.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">(4.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(4.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(4.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(4.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10961,10 +11355,10 @@ does not contain a value.</li>
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type or type alias
 represented by <code class="sourceCode cpp">type</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
@@ -10972,23 +11366,23 @@ or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</spa
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 is empty,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 is empty,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 is empty, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">6</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>. Certain other
@@ -11000,7 +11394,7 @@ query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
@@ -11008,7 +11402,7 @@ description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">8</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -11016,7 +11410,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">(8.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -11033,18 +11427,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(8.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(8.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(8.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -11058,7 +11452,7 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">9</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -11069,26 +11463,26 @@ values such that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(10.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">(10.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -11101,28 +11495,28 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(10.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">(10.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or type alias represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(10.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(10.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(10.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(10.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">(10.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(10.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">(10.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(10.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -11134,18 +11528,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(10.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(10.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(10.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(10.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -11155,10 +11549,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -11177,7 +11571,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11198,7 +11592,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb229-13"><a href="#cb229-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-14"><a href="#cb229-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-15"><a href="#cb229-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -11224,7 +11618,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11245,7 +11639,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -11254,7 +11648,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TYPE</em></code>
@@ -11263,7 +11657,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11347,12 +11741,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb233"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb234"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -11364,17 +11758,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type</code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11384,7 +11778,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11411,7 +11805,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb235-15"><a href="#cb235-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb235-16"><a href="#cb235-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb235-17"><a href="#cb235-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -11433,7 +11827,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -11445,7 +11839,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11465,7 +11859,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11482,7 +11876,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11498,7 +11892,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11514,7 +11908,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11540,14 +11934,14 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause with signature <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>to<span class="op">&lt;</span>vector<span class="op">&gt;(</span>r<span class="op">)</span> <span class="op">==</span> vector<span class="op">{^^</span>T<span class="op">...}</span></code>
@@ -11556,7 +11950,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11576,7 +11970,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb241-9"><a href="#cb241-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb241-10"><a href="#cb241-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb241-11"><a href="#cb241-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb242"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -11598,14 +11992,14 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
 defined in this clause with the signature <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 value <code class="sourceCode cpp">I</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em></code>
 defined in this clause with the signature <code class="sourceCode cpp">info<span class="op">(</span><span class="dt">size_t</span>, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
@@ -11627,7 +12021,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -11635,27 +12029,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -2043,24 +2043,27 @@ how other accesses work. This is instead proposed in <span class="citation" data
 <span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;array&gt;</span></span>
 <span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
-<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> struct_of_arrays_impl <span class="op">=</span> <span class="op">[]</span> <span class="kw">consteval</span> <span class="op">{</span></span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> struct_of_arrays_impl <span class="op">{</span></span>
 <span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> impl;</span>
 <span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> old_members <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>T<span class="op">)</span>;</span>
-<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members <span class="op">=</span> <span class="op">{}</span>;</span>
-<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> old_members<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> array_type <span class="op">=</span> substitute<span class="op">(^^</span>std<span class="op">::</span>array, <span class="op">{</span></span>
-<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>        type_of<span class="op">(</span>member<span class="op">)</span>,</span>
-<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>meta<span class="op">::</span>reflect_value<span class="op">(</span>N<span class="op">)</span>,</span>
-<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a>    <span class="op">})</span>;</span>
-<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> mem_descr <span class="op">=</span> data_member_spec<span class="op">(</span>array_type, <span class="op">{.</span>name <span class="op">=</span> identifier_of<span class="op">(</span>member<span class="op">)})</span>;</span>
-<span id="cb23-16"><a href="#cb23-16" aria-hidden="true" tabindex="-1"></a>    new_members<span class="op">.</span>push_back<span class="op">(</span>mem_descr<span class="op">)</span>;</span>
-<span id="cb23-17"><a href="#cb23-17" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb23-18"><a href="#cb23-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>meta<span class="op">::</span>define_aggregate<span class="op">(^^</span>impl, new_members<span class="op">)</span>;</span>
-<span id="cb23-19"><a href="#cb23-19" aria-hidden="true" tabindex="-1"></a><span class="op">}()</span>;</span>
-<span id="cb23-20"><a href="#cb23-20" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb23-21"><a href="#cb23-21" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
-<span id="cb23-22"><a href="#cb23-22" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> struct_of_arrays <span class="op">=</span> <span class="op">[:</span> struct_of_arrays_impl<span class="op">&lt;</span>T, N<span class="op">&gt;</span> <span class="op">:]</span>;</span></code></pre></div>
+<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="op">{</span></span>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> old_members <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>T<span class="op">)</span>;</span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members <span class="op">=</span> <span class="op">{}</span>;</span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> old_members<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>        <span class="kw">auto</span> array_type <span class="op">=</span> substitute<span class="op">(^^</span>std<span class="op">::</span>array, <span class="op">{</span></span>
+<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>            type_of<span class="op">(</span>member<span class="op">)</span>,</span>
+<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a>            std<span class="op">::</span>meta<span class="op">::</span>reflect_value<span class="op">(</span>N<span class="op">)</span>,</span>
+<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
+<span id="cb23-16"><a href="#cb23-16" aria-hidden="true" tabindex="-1"></a>        <span class="kw">auto</span> mem_descr <span class="op">=</span> data_member_spec<span class="op">(</span>array_type, <span class="op">{.</span>name <span class="op">=</span> identifier_of<span class="op">(</span>member<span class="op">)})</span>;</span>
+<span id="cb23-17"><a href="#cb23-17" aria-hidden="true" tabindex="-1"></a>        new_members<span class="op">.</span>push_back<span class="op">(</span>mem_descr<span class="op">)</span>;</span>
+<span id="cb23-18"><a href="#cb23-18" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb23-19"><a href="#cb23-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-20"><a href="#cb23-20" aria-hidden="true" tabindex="-1"></a>    define_aggregate<span class="op">(^^</span>impl, new_members<span class="op">)</span>;</span>
+<span id="cb23-21"><a href="#cb23-21" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb23-22"><a href="#cb23-22" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb23-23"><a href="#cb23-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-24"><a href="#cb23-24" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
+<span id="cb23-25"><a href="#cb23-25" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> struct_of_arrays <span class="op">=</span> struct_of_arrays_impl<span class="op">&lt;</span>T, N<span class="op">&gt;::</span>impl;</span></code></pre></div>
 </blockquote>
 </div>
 <p>Example:</p>
@@ -5283,15 +5286,14 @@ it is a <code class="sourceCode cpp"><em>using-declaration</em></code>
 <a href="https://wg21.link/basic.def.odr">[basic.def.odr]</a></span>
 One-definition rule<a href="#basic.def.odr-one-definition-rule" class="self-link"></a></h3>
 <p>Add <code class="sourceCode cpp"><em>splice-expression</em></code>s
-to the set of potential results of an expression in paragarph 3.</p>
+to the set of potential results of an expression in paragraph 3.</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_26" id="pnum_26">3</a></span>
 An expression or conversion is <em>potentially evaluated</em> unless it
-is an unevaluated operand (<span>7.2.3 <a href="https://wg21.link/expr.context">[expr.context]</a></span>), a
-subexpression thereof, or a conversion in an initialization or
-conversion sequence in such a context. The set of <em>potential
-results</em> of an expression
+is an unevaluated operand ([expr.context]), a subexpression thereof, or
+a conversion in an initialization or conversion sequence in such a
+context. The set of <em>potential results</em> of an expression
 <code class="sourceCode cpp"><em>E</em></code> is defined as
 follows:</p>
 <ul>
@@ -5324,20 +5326,23 @@ proposal:</p>
 <blockquote>
 <ul>
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_29" id="pnum_29">(4.1)</a></span>
-A function is named by an expression or conversion if it is the selected
-member of an overload set (<span class="rm" style="color: #bf0303"><del>[basic.pre]</del></span> <span class="addu">[over.pre]</span>, [over.match], [over.over]) in an
+A function is named by an expression or conversion <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> if it
+is the selected member of an overload set (<span class="rm" style="color: #bf0303"><del>[basic.lookup]</del></span> <span class="addu">[over.pre]</span>, [over.match], [over.over]) in an
 overload resolution performed as part of forming that expression or
-conversion, unless it is a pure virtual function and <span class="rm" style="color: #bf0303"><del>either</del></span> the expression<span class="addu"> </span></p>
+conversion, unless it is a pure virtual function and <span class="rm" style="color: #bf0303"><del>either the expression</del></span><span class="addu"> </span></p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(4.1.1)</a></span>
+<span class="addu"><code class="sourceCode cpp"><em>E</em></code></span>
 is not an <code class="sourceCode cpp"><em>id-expression</em></code>
 naming the function with an explicitly qualified name<span class="addu">,</span></li>
 <li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_31" id="pnum_31">(4.1.2)</a></span>
+<span class="addu"><code class="sourceCode cpp"><em>E</em></code></span>
 is not a
 <code class="sourceCode cpp"><em>splice-expression</em></code>,</span>
 or</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_32" id="pnum_32">(4.1.3)</a></span>
 <span class="rm" style="color: #bf0303"><del>the expression</del></span>
+<span class="addu"><code class="sourceCode cpp"><em>E</em></code></span>
 forms a pointer to member ([expr.unary.op]).</li>
 </ul></li>
 </ul>
@@ -6403,7 +6408,7 @@ to form a pointer to member (<span>7.6.2.2 <a href="https://wg21.link/expr.unary
 or</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(4.3)</a></span>
 if that <code class="sourceCode cpp"><em>splice-expression</em></code>
-denotes a non-static data member and it appears in an unevaluated
+designates a non-static data member and it appears in an unevaluated
 operand.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 3:</em> </span>The implicit
@@ -6794,12 +6799,18 @@ represents <code class="sourceCode cpp"><em>F</em></code>.</p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(10.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
-variable or structured binding not captured by an enclosing
-<code class="sourceCode cpp"><em>lambda-expression</em></code>, an
-enumerator, or a non-static data member or member function, the
+local entity captured by an enclosing
+<code class="sourceCode cpp"><em>lambda-expression</em></code>, the
+<code class="sourceCode cpp"><em>reflect-expression</em></code> is
+ill-formed.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(10.3)</a></span>
+Otherwise, if the
+<code class="sourceCode cpp"><em>id-expression</em></code> denotes a
+variable, structured binding, enumerator, or non-static data member or
+member function, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents that entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(10.4)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 ill-formed. <span class="note"><span>[ <em>Note 2:</em> </span>This
@@ -6839,7 +6850,7 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <p>Extend paragraph 2 to also handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
 pointer-to-member type, <span class="addu">type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>.
@@ -6857,33 +6868,33 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between paragraphs 5 and 6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">5</a></span>
 Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">5+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">5+</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(5+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(5+.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(5+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(5+.2)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a value that is
 template-argument-equivalent (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(5+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(5+.3)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(5+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(5+.4)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(5+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(5+.5)</a></span>
 Otherwise, if one operand represents a direct base class relationship,
 then they compare equal if and only if the other operand represents the
 same direct base class relationship.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(5+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(5+.6)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -6894,7 +6905,7 @@ data member descriptions represented by
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -6915,7 +6926,7 @@ Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3
 <code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">10</a></span>
 During the evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> as a core constant
 expression, all
@@ -6933,15 +6944,15 @@ includes the entire constant evaluation. […]</p>
 and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">15</a></span>
 A <em>constant expression</em> is either a glvalue core constant
 expression <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> that
 <span class="addu"> </span></p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(15.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(15.1)</a></span>
 refers to an <span class="rm" style="color: #bf0303"><del>entity</del></span> <span class="addu">object or function</span> that is a permitted result of a
 constant expression<span class="addu">, and</span></p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(15.2)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(15.2)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> designates a function
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>)
 or an object whose complete object is of consteval-only type, then
@@ -6966,34 +6977,34 @@ type,</span></p>
 <p>or a prvalue core constant expression whose value satisfies the
 following constraints:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(15.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(15.3)</a></span>
 if the value is an object of class type, each non-static data member of
 reference type refers to an <span class="rm" style="color: #bf0303"><del>entity</del></span> <span class="addu">object or function</span> that is a permitted result of a
 constant expression, <span class="addu">and if the object or function is
 of consteval-only type, or is the subobject of such an object, then so
 is the value,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(15.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(15.4)</a></span>
 if the value is an object of scalar type, it does not have an
 indeterminate or erroneous value (<span>6.7.4 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(15.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(15.5)</a></span>
 if the value is of pointer type, <span class="addu">then: </span>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(15.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(15.5.1)</a></span>
 it is a pointer to an object of static storage duration<span class="rm" style="color: #bf0303"><del>,</del></span> <span class="addu">or</span>
 a pointer past the end of such an object (<span>7.6.6 <a href="https://wg21.link/expr.add">[expr.add]</a></span>), <span class="addu">and if the complete object of that object is of
 consteval-only type then so is that pointer,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(15.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(15.5.2)</a></span>
 <span class="addu">it is</span> a pointer to a non-immediate function,
 <span class="addu">and if that function is of consteval-only type then
 so is that pointer,</span> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(15.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(15.5.3)</a></span>
 <span class="addu">it is</span> a null pointer value,</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(15.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(15.6)</a></span>
 if the value is of pointer-to-member-function type, it does not
 designate an immediate function, <span class="addu">and if that function
 is of consteval-only type then so is that value,</span> and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(15.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(15.7)</a></span>
 if the value is an object of class or array type, each subobject
 satisfies these constraints for the value.</li>
 </ul>
@@ -7003,13 +7014,13 @@ satisfies these constraints for the value.</li>
 in paragraph 18 to also apply to expressions of consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">18</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it is <span class="rm" style="color: #bf0303"><del>either</del></span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(18.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(18.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -7017,10 +7028,10 @@ potentially-evaluated</del></span> <span class="addu">an</span>
 that <span class="rm" style="color: #bf0303"><del>denotes</del></span>
 <span class="addu">designates</span> an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that
 is not a subexpression of an immediate invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(18.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(18.2)</a></span>
 an immediate invocation that is not a constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(18.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(18.3)</a></span>
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>).</span></li>
 </ul>
 </blockquote>
@@ -7031,18 +7042,18 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">21pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">21pre</a></span>
 A non-dependent expression or conversion is <em>plainly
 constant-evaluated</em> if it is not in a complete-class context
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 and is either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(21pre.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(21pre.1)</a></span>
 the <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 (<span>9.1 <a href="https://wg21.link/dcl.pre">[dcl.pre]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(21pre.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(21pre.2)</a></span>
 an initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
@@ -7065,22 +7076,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">21</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(21.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(21.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(21.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(21.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -7102,7 +7113,7 @@ injecting declarations and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">22</a></span>
 The evaluation of an expression can introduce one or more <em>injected
 declarations</em>. Each such declaration has an associated
 <em>synthesized point</em> which follows the last non-synthesized
@@ -7111,17 +7122,17 @@ evaluation is said to <em>produce</em> the declaration.</p>
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to synthesized points (<span>10.7 <a href="https://wg21.link/module.reach">[module.reach]</a></span>).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">23</a></span>
 The program is ill-formed if the evaluation of a manifestly
 constant-evaluated expression
 <code class="sourceCode cpp"><em>M</em></code> produces an injected
 declaration <code class="sourceCode cpp"><em>D</em></code> and
 either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(23.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(23.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a plainly
 constant-evaluated expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(23.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(23.2)</a></span>
 the target scope of <code class="sourceCode cpp"><em>D</em></code> is
 not semantically sequenced with
 <code class="sourceCode cpp"><em>M</em></code> (<span>5.2 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span>).</li>
@@ -7129,20 +7140,20 @@ not semantically sequenced with
 <p>Furthermore, the program is ill-formed, no diagnostic required,
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(23.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(23.3)</a></span>
 an evaluation
 <code class="sourceCode cpp"><em>E</em><sub><em>1</em></sub></code>
 produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> during the evaluation of
 a manifestly constant-evaluated expression
 <code class="sourceCode cpp"><em>M</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(23.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(23.4)</a></span>
 a second evaluation
 <code class="sourceCode cpp"><em>E</em><sub><em>2</em></sub></code>
 computes a reflection of <code class="sourceCode cpp"><em>D</em></code>
 during the same evaluation of
 <code class="sourceCode cpp"><em>M</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(23.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(23.5)</a></span>
 <code class="sourceCode cpp"><em>E</em><sub><em>1</em></sub></code> is
 unsequenced with
 <code class="sourceCode cpp"><em>E</em><sub><em>2</em></sub></code>
@@ -7183,7 +7194,7 @@ unsequenced with
 <span id="cb118-31"><a href="#cb118-31" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ill-formed, no diagnostic required</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines the behavior of certain functions used for reflection
 ([meta.reflection]). During the evaluation of a manifestly
@@ -7192,11 +7203,11 @@ constant-evaluated expression
 of an evaluation <code class="sourceCode cpp"><em>E</em></code>
 comprises the union of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> (<span>10.6 <a href="https://wg21.link/module.context">[module.context]</a></span>),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(24.2)</a></span>
 the synthesized points corresponding to any injected declarations
 produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> (<span>6.9.1 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>).</li>
@@ -7211,7 +7222,7 @@ with its associated type from paragraph 8 (type aliases are entities
 now).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">8</a></span>
 If the <code class="sourceCode cpp"><em>decl-specifier-seq</em></code>
 contains the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7229,7 +7240,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 specifier now introduces an entity.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">1</a></span>
 Declarations containing the
 <code class="sourceCode cpp"><em>decl-specifier</em></code>
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7272,7 +7283,7 @@ a <code class="sourceCode cpp"><em>typedef-name</em></code> <span class="rm" sty
 <code class="sourceCode cpp"><em>typedef-name</em></code> does not
 introduce a new type the way a class declaration (<span>11.3 <a href="https://wg21.link/class.name">[class.name]</a></span>) or enum
 declaration (<span>9.7.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">2</a></span>
 A <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span> can also be <span class="rm" style="color: #bf0303"><del>introduced</del></span> <span class="addu">declared</span> by an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>. The
@@ -7310,7 +7321,7 @@ to accommodate
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -7318,10 +7329,10 @@ is a placeholder for a type to be deduced ([dcl.spec.auto]). A
 is a placeholder for a deduced class type ([dcl.type.class.deduct])
 <span class="addu">if it either </span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(3.1)</a></span>
 is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(3.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(3.2)</a></span>
 is of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>
 and the <code class="sourceCode cpp"><em>splice-specifier</em></code>
@@ -7420,13 +7431,13 @@ Decltype specifiers<a href="#dcl.type.decltype-decltype-specifiers" class="self-
 <code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">1</a></span>
 For an expression <code class="sourceCode cpp"><em>E</em></code>, the
 type denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
 is defined as follows:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(1.3)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>id-expression</em></code> or an
@@ -7434,11 +7445,12 @@ unparenthesized class member access ([expr.ref]), <code class="sourceCode cpp"><
 is the type of the entity named by
 <code class="sourceCode cpp"><em>E</em></code>. If there is no such
 entity, the program is ill-formed;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(1.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(1.3+)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>splice-expression</em></code>, <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
-is the type of the entity, object, or value named by
+is the type of the entity, object, or value designated by the
+<code class="sourceCode cpp"><em>splice-specifier</em></code> of
 <code class="sourceCode cpp"><em>E</em></code>;</span></li>
 </ul>
 <p>[…]</p>
@@ -7457,7 +7469,7 @@ specifier is an unevaluated operand.</p>
 <div class="sourceCode" id="cb122"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
 <span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specifier</em></span>
 <span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -7486,7 +7498,7 @@ within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.gen
 <span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> alias <span class="op">=</span> <span class="op">[:^^</span>S<span class="op">::</span>type<span class="op">:]</span>;    <span class="co">// OK, type-only context</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>,
@@ -7496,7 +7508,7 @@ concept. The
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -7509,12 +7521,12 @@ shall designate a primary class template or an alias template. Let
 any) of the
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>T</em></code> is a primary class
 template, the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(3.2)</a></span>
 Otherwise if <code class="sourceCode cpp"><em>T</em></code> is an alias
 template, the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
@@ -7529,7 +7541,7 @@ designates the type denoted by
 clear about the entity being referred to.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
@@ -7540,7 +7552,7 @@ type <span class="rm" style="color: #bf0303"><del>named</del></span>
 <span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>)) shall
 appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(9.1)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7551,7 +7563,7 @@ Default arguments<a href="#dcl.fct.default-default-arguments" class="self-link">
 appear in default function arguments.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">9</a></span>
 A default argument is evaluated each time the function is called with no
 argument for the corresponding parameter.</p>
 <p>[…]</p>
@@ -7572,46 +7584,46 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>),
 the object is initialized to the value obtained by converting the
 integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -7619,7 +7631,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -7628,26 +7640,26 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
 type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -7656,7 +7668,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -7670,7 +7682,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 a <code class="sourceCode cpp"><em>reflect-expression</em></code>
@@ -7699,7 +7711,7 @@ follows:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">1</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> of
 the form
@@ -7727,7 +7739,7 @@ in paragraph 1, and clarify that such declarations declare a “namespace
 alias” (which is now an entity as per [basic.pre]).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">1</a></span>
 A
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 declares <span class="rm" style="color: #bf0303"><del>an alternative
@@ -7755,7 +7767,7 @@ this will fall out from the “underlying entity” of the namespace alias
 defined below:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -7769,7 +7781,7 @@ note:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">2+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">2+</a></span>
 The underlying entity (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>) of the
 namespace alias is the namespace either denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
@@ -7797,14 +7809,14 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
 any, designates a namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> and
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 not be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -7868,7 +7880,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -7892,7 +7904,7 @@ Deprecated attribute<a href="#dcl.attr.deprecated-deprecated-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">2</a></span>
 The attribute may be applied to the declaration of a class, a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, a variable, a non-static data
 member, a function, a namespace, an enumeration, an enumerator, a
@@ -7906,7 +7918,7 @@ Maybe unused attribute<a href="#dcl.attr.unused-maybe-unused-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">2</a></span>
 The attribute may be applied to the declaration of a class, <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, variable (including a structured
 binding declaration), structured binding, non-static data member,
@@ -7927,13 +7939,13 @@ might have a
 designating a specialization.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>decl-reachable</em> from a declaration
 <code class="sourceCode cpp"><em>S</em></code> in the same translation
 unit if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(3.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> does not declare a
 function or function template and
 <code class="sourceCode cpp"><em>S</em></code> contains an
@@ -7947,7 +7959,7 @@ function or function template and
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 designating <code class="sourceCode cpp"><em>D</em></code></span>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(3.2)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7960,7 +7972,7 @@ splice specifier is replaced.</p>
 <blockquote>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7969,22 +7981,22 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>template-name</em></code> names an
 alias template is replaced by its denoted type prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(3.8)</a></span>
 whether a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 that does not <span class="rm" style="color: #bf0303"><del>denote</del></span> <span class="addu">designate</span> a dependent type is replaced by its <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> type prior to this determination, <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(3.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(3.9)</a></span>
 whether a non-value-dependent constant expression is replaced by the
 result of constant evaluation prior to this determination<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(3.10)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(3.10)</a></span>
 whether a <code class="sourceCode cpp"><em>splice-specifier</em></code>
 that is not dependent is replaced by the construct that it designates
 prior to this determination.</span></li>
@@ -7997,23 +8009,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 a synthesized point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 synthesized point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 (<span>10.4 <a href="https://wg21.link/module.global.frag">[module.global.frag]</a></span>),
 appears in a translation unit that is reachable from
@@ -8029,7 +8041,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -8054,7 +8066,7 @@ member description</em>:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">29+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">29+</a></span>
 A <em>data member description</em> is a quintuple
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -8063,19 +8075,19 @@ A <em>data member description</em> is a quintuple
 <code class="sourceCode cpp"><em>NUA</em></code>) describing the
 potential declaration of a nonstatic data member where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(29+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(29+.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a type or type
 alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(29+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(29+.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is an
 <code class="sourceCode cpp"><em>identifier</em></code> or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(29+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(29+.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is an alignment or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(29+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(29+.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is a bit-field width or
 <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(29+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(29+.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is a boolean
 value.</li>
 </ul>
@@ -8085,14 +8097,14 @@ components are same types, same identifiers, and equal values.</p>
 <p><span>[ <em>Note 4:</em> </span>The components of a data member
 description describe a data member such that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(29+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(29+.6)</a></span>
 its type is specified using the type or type alias given by
 <code class="sourceCode cpp"><em>T</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(29+.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(29+.7)</a></span>
 it is declared with the name given by
 <code class="sourceCode cpp"><em>N</em></code> if <code class="sourceCode cpp"><em>N</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise unnamed,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(29+.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(29+.8)</a></span>
 it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>
 (<span>9.12.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
@@ -8100,11 +8112,11 @@ it is declared with the
 if <code class="sourceCode cpp"><em>A</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise declared without an
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(29+.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">(29+.9)</a></span>
 it is a bit-field (<span>11.4.10 <a href="https://wg21.link/class.bit">[class.bit]</a></span>) with the
 width given by <code class="sourceCode cpp"><em>W</em></code> if <code class="sourceCode cpp"><em>W</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise not a bit-field,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">(29+.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">(29+.10)</a></span>
 it is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
 (<span>9.12.12 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
 if <code class="sourceCode cpp"><em>NUA</em></code> is
@@ -8127,7 +8139,7 @@ note</em> ]</span></p>
 General<a href="#class.derived.general-general" class="self-link"></a></h3>
 <p>Introduce the term “direct base class relationship” to paragraph
 2.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>class-or-decltype</em></code> are those
 of its
@@ -8174,7 +8186,7 @@ resolution, and add a note explaining the expressions that form overload
 sets.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">2</a></span>
 <span class="addu">An <em>overload set</em> is a set of declarations
 that each denote a function or function template. Using these
 declarations as a starting point, the process of <em>overload
@@ -8203,14 +8215,14 @@ General<a href="#over.match.general-general" class="self-link"></a></h3>
 in all contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">3</a></span>
 If a best viable function exists and is unique, overload resolution
 succeeds and produces it as the result. Otherwise overload resolution
 fails and the invocation is ill-formed. When overload resolution
 succeeds, and the best viable function is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither
 designated in a manner exempt from access rules nor</span> accessible in
 the context in which it is used, the program is ill-formed.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">4</a></span>
 Overload resolution results in a <em>usable candidate</em> if overload
 resolution succeeds and the selected candidate is either not a function
 (<span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>), or is a
@@ -8225,7 +8237,7 @@ to named function<a href="#over.call.func-call-to-named-function" class="self-li
 splices of function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">1</a></span>
 Of interest in [over.call.func] are only those function calls in which
 the <code class="sourceCode cpp"><em>posfix-expression</em></code>
 ultimately contains an
@@ -8253,7 +8265,7 @@ qualified function calls and unqualified function calls.</p>
 designating member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">2</a></span>
 In qualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -8296,7 +8308,7 @@ in the normalized member function call as the implied object argument
 designating non-member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">3</a></span>
 In unqualified function calls, the function is named by a
 <code class="sourceCode cpp"><em>primary-expression</em></code>. <span class="addu">If that
 <code class="sourceCode cpp"><em>primary-expression</em></code> is a
@@ -8336,7 +8348,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -8346,7 +8358,7 @@ where the <code class="sourceCode cpp"><em>template-name</em></code>
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -8355,7 +8367,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">3</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -8378,10 +8390,10 @@ paragraph 1 to allow taking the address of an overload set specified by
 a <code class="sourceCode cpp"><em>splice-expression</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">1</a></span>
 An <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span>
-whose terminal name</del></span> <span class="addu">expression
-that</span> refers to an overload set
+whose terminal name refers</del></span> <span class="addu">expression
+that designates</span> to an overload set
 <code class="sourceCode cpp"><em>S</em></code> and that appears without
 arguments is resolved to a function, a pointer to function, or a pointer
 to member function for a specific function that is chosen from a set of
@@ -8400,7 +8412,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -8442,7 +8454,7 @@ the grammar for
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">3+</a></span>
 A non-dependent
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
 forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
@@ -8478,32 +8490,32 @@ and add it as a production for
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">(3.1)</a></span>
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
 either appears in a type-only context or is preceded by
 <code class="sourceCode cpp"><span class="kw">template</span></code> or
 <code class="sourceCode cpp"><span class="kw">typename</span></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -8543,7 +8555,7 @@ disambiguation in paragraph 4 also applies to the parsing of
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">4</a></span>
 When parsing a
 <code class="sourceCode cpp"><em>template-argument-list</em></code>, the
 first non-nested
@@ -8572,27 +8584,27 @@ cast).<span> — <em>end note</em> ]</span></span></p>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">7</a></span>
 A <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is <em>valid</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(7.1)</a></span>
 there are at most as many arguments as there are parameters or a
 parameter is a template parameter pack (<span>13.7.4 <a href="https://wg21.link/temp.variadic">[temp.variadic]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(7.2)</a></span>
 there is an argument for each non-deducible non-pack parameter that does
 not have a default
 <code class="sourceCode cpp"><em>template-argument</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(7.3)</a></span>
 each <code class="sourceCode cpp"><em>template-argument</em></code>
 matches the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>
 (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(7.4)</a></span>
 substitution of each template argument into the following template
 parameters (if any) succeeds, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(7.5)</a></span>
 if the <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is non-dependent, the associated constraints are satisfied as specified
@@ -8609,7 +8621,7 @@ shall be valid unless it names a function template specialization
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or the
 <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
@@ -8629,7 +8641,7 @@ of the constrained template shall be satisfied (<span>13.5.2 <a href="https://wg
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">111)</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">111)</a></span>
 A <code class="sourceCode cpp"><span class="op">&gt;</span></code> that
 encloses the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>,
@@ -8651,7 +8663,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>template-argument</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">1</a></span>
 There are <span class="rm" style="color: #bf0303"><del>three</del></span> <span class="addu">four</span> forms of
 <code class="sourceCode cpp"><em>template-argument</em></code>, <span class="addu">three of which</span> correspond<span class="rm" style="color: #bf0303"><del>ing</del></span> to the three forms of
 <code class="sourceCode cpp"><em>template-parameter</em></code>: type,
@@ -8672,7 +8684,7 @@ declared by the template in its
 in paragraph 3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -8707,7 +8719,7 @@ form of the corresponding
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">9</a></span>
 When a <code class="sourceCode cpp"><em>simple-template-id</em></code>
 <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -8724,7 +8736,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -8746,7 +8758,7 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
@@ -8755,11 +8767,11 @@ for the variable x in the invented declaration</p>
 <div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">2</a></span>
 The value of a non-type <em>template-parameter</em>
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">3</a></span>
 Otherwise, a temporary variable</p>
 <div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
@@ -8771,7 +8783,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be <span class="rm" style="color: #bf0303"><del>the name
@@ -8808,27 +8820,27 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s</span>
 are the same if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(1.1)</a></span>
 their <code class="sourceCode cpp"><em>template-name</em></code>s,
 <code class="sourceCode cpp"><em>operator-function-id</em></code>s,
 <span class="rm" style="color: #bf0303"><del>or</del></span>
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>s<span class="addu">, or
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s</span>
 refer to the same template, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(1.2)</a></span>
 their corresponding type
 <code class="sourceCode cpp"><em>template-argument</em></code>s are the
 same type, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(1.3)</a></span>
 the template parameter values determined by their corresponding non-type
 template arguments (<span>13.4.3 <a href="https://wg21.link/temp.arg.nontype">[temp.arg.nontype]</a></span>)
 are template-argument-equivalent (see below), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(1.4)</a></span>
 their corresponding template
 <code class="sourceCode cpp"><em>template-argument</em></code>s refer to
 the same template.</li>
@@ -8842,23 +8854,23 @@ that are the same refer to the same class, function, or variable.</p>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -8870,7 +8882,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -8909,7 +8921,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When a</del></span> <span class="addu">A</span>
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">that</span> refers to the specialization of an alias
 template<span class="rm" style="color: #bf0303"><del>, it is equivalent
@@ -8936,22 +8948,22 @@ be elided from a
 non-dependent contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">4</a></span>
 A qualified or unqualified name is said to be in a
 <code class="sourceCode cpp"><em>type-only context</em></code> if it is
 the terminal name of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.1)</a></span>
 a <code class="sourceCode cpp"><em>typename-specifier</em></code>,
 <code class="sourceCode cpp"><em>type-requirement</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>elaborated-type-specifier</em></code>,
 <code class="sourceCode cpp"><em>class-or-decltype</em></code>, <span class="addu"><code class="sourceCode cpp"><em>using-enum-declarator</em></code></span>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.2)</a></span>
 […]
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(4.4.6)</a></span>
 <code class="sourceCode cpp"><em>parameter-declaration</em></code> of a
 (non-type)
 <code class="sourceCode cpp"><em>template-parameter</em></code>.</li>
@@ -8996,7 +9008,7 @@ Dependent types<a href="#temp.dep.type-dependent-types" class="self-link"></a></
 paragraph 7.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">7</a></span>
 An initializer is dependent if any constituent expression (<span>6.9.1
 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>)
 of the initializer is type-dependent. A placeholder type
@@ -9015,18 +9027,18 @@ definition to apply to
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">8</a></span>
 A placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 is dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(8.1)</a></span>
 it has a dependent initializer, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(8.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(8.2)</a></span>
 it has a dependent
 <code class="sourceCode cpp"><em>template-name</em></code> or a
 dependent <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(8.3)</a></span>
 it refers to an alias template that is a member of the current
 instantiation and whose
 <code class="sourceCode cpp"><em>defining-type-id</em></code> is
@@ -9040,28 +9052,28 @@ and substitution (<span>13.7.8 <a href="https://wg21.link/temp.alias">[temp.alia
 paragraph 10:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">10</a></span>
 A type is dependent if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(10.1)</a></span>
 a template parameter,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(10.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(10.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(10.11)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> in which
 either the template name is a template parameter or any of the template
 arguments is a dependent type or an expression that is type-dependent or
 value-dependent or is a pack expansion,<sup>121</sup></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(10.12)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(10.12)</a></span>
 a <code class="sourceCode cpp"><em>pack-index-specifier</em></code>,
 <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(10.13)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(10.13)</a></span>
 denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>expression</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is
 type-dependent<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(10.14)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(10.14)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> in
 which either the
@@ -9099,16 +9111,16 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is type-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(9.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(9.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -9124,10 +9136,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -9155,16 +9167,16 @@ or a value-dependent or type-dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is value-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(6.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(6.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -9183,7 +9195,7 @@ and renumber accordingly.</p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent splice specifiers [temp.dep.splice]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if its converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
@@ -9193,7 +9205,7 @@ or <code class="sourceCode cpp"><em>splice-scope-specifier</em></code>
 is dependent if its
 <code class="sourceCode cpp"><em>splice-template-argument</em></code> is
 dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> T, <span class="kw">auto</span> NS, <span class="kw">auto</span> C, <span class="kw">auto</span> V<span class="op">&gt;</span></span>
@@ -9225,7 +9237,7 @@ Explicit specialization<a href="#temp.expl.spec-explicit-specialization" class="
 to be used like incompletely-defined classes.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">9</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 that <span class="rm" style="color: #bf0303"><del>names</del></span>
@@ -9243,7 +9255,7 @@ General<a href="#temp.deduct.general-general" class="self-link"></a></h3>
 in paragraph 2:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">2</a></span>
 When an explicit template argument list is specified, if the given
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -9264,7 +9276,7 @@ the same as parameter types that are specified using
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(4.3)</a></span>
 If <code class="sourceCode cpp">P</code> is a class and
 <code class="sourceCode cpp">P</code> has the form
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code></span>,
@@ -9296,7 +9308,7 @@ template argument might also be a
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">20</a></span>
 If <code class="sourceCode cpp">P</code> has a form that contains <code class="sourceCode cpp"><span class="op">&lt;</span>i<span class="op">&gt;</span></code>,
 and if the type of <code class="sourceCode cpp">i</code> differs from
 the type of the corresponding template parameter of the template named
@@ -9321,7 +9333,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -9339,24 +9351,24 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const]).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">4</a></span>
 […] Next, the semantics of the code sequence are determined by the
 <em>Constraints</em>, <em>Mandates</em>, <span class="addu"><em>Constant
 When</em>,</span> <em>Preconditions</em>, <em>Effects</em>,
@@ -9372,7 +9384,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -9380,7 +9392,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -9389,14 +9401,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not return reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -9828,11 +9840,11 @@ synopsis</strong></p>
 <span id="cb146-331"><a href="#cb146-331" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb146-332"><a href="#cb146-332" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb146-333"><a href="#cb146-333" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">2</a></span>
 The behavior of any function specified in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 implementation-defined when a reflection of a construct not otherwise
@@ -9862,7 +9874,7 @@ definition, the specialization is implicitly instantiated.</p>
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">3</a></span>
 Any function in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>
 that whose return type is
@@ -9891,7 +9903,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb149-3"><a href="#cb149-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb149-4"><a href="#cb149-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -10144,10 +10156,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -10155,11 +10167,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">5</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -10174,14 +10186,14 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> is an unnamed entity other than
 a class that has a typedef name for linkage purposes (<span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.typedef]</a></span>), then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -10190,14 +10202,14 @@ either the <code class="sourceCode cpp"><em>class-name</em></code> of
 <code class="sourceCode cpp"><em>C</em></code> has a typedef name for
 linkage purposes. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -10205,20 +10217,20 @@ function template, then
 template, operator function template, or conversion function template.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents variable
 or a type alias, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(1.8)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10229,37 +10241,37 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 </ul>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, then the identifier introduced by the declaration of that
 entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>
 or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>,
 respectively.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(4.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10273,21 +10285,21 @@ identifier <code class="sourceCode cpp"><em>N</em></code> encoded with
 </ul>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a data member
 description, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or direct base class relationship that was
 introduced by a declaration, implementations should return a value
@@ -10306,7 +10318,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or
@@ -10314,7 +10326,7 @@ direct base class relationship that is public, protected, or private,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -10322,7 +10334,7 @@ function or a direct base class relationship that is virtual. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -10330,7 +10342,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -10338,7 +10350,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -10347,7 +10359,7 @@ deleted function ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -10355,7 +10367,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -10370,7 +10382,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -10387,7 +10399,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -10401,7 +10413,7 @@ for which <code class="sourceCode cpp"><em>W</em></code> is not <code class="sou
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -10409,7 +10421,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -10418,7 +10430,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -10427,7 +10439,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -10437,7 +10449,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -10448,7 +10460,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -10457,7 +10469,7 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -10467,7 +10479,7 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">17</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -10476,20 +10488,20 @@ introduced within the scope of the entity represented by
 <code class="sourceCode cpp">r</code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">19</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity whose
@@ -10497,7 +10509,7 @@ underlying entity is a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb176-2"><a href="#cb176-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias or
@@ -10506,7 +10518,7 @@ namespace alias, respectively <span class="note"><span>[ <em>Note
 alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -10514,7 +10526,7 @@ alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -10529,7 +10541,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb179-7"><a href="#cb179-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb179-8"><a href="#cb179-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb179-9"><a href="#cb179-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -10539,14 +10551,14 @@ operator, a copy assignment operator, a move assignment operator, or a
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">26</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -10563,7 +10575,7 @@ is
 <span id="cb181-7"><a href="#cb181-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb181-8"><a href="#cb181-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb181-9"><a href="#cb181-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -10572,7 +10584,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">28</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -10581,14 +10593,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -10599,7 +10611,7 @@ Otherwise,
 <span id="cb185-3"><a href="#cb185-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-4"><a href="#cb185-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-5"><a href="#cb185-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -10607,19 +10619,19 @@ namespace member, non-static data member, static member, or direct base
 class relationship, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">33</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, direct base
 class relationship, or data member description.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">34</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then a reflection of the type of what is
 represented by <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -10634,11 +10646,11 @@ Otherwise, for a data member description
 a reflection of the type
 <code class="sourceCode cpp"><em>T</em></code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -10654,33 +10666,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(37.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(37.1)</a></span>
 either an object or variable, usable in constant expressions from some
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(37.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(37.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(37.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(37.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">38</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(38.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(38.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(38.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(38.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(38.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(38.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -10696,13 +10708,13 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>), type
 alias, or direct base class relationship.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">40</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a direct member of an anonymous union,
 then a reflection representing the innermost enclosing anonymous union.
@@ -10710,10 +10722,10 @@ Otherwise, a reflection of the class, function, or namespace that is the
 target scope ([basic.scope.scope]) of the first declaration of what is
 represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">41</a></span>
 <em>Returns</em>: A reflection representing the underlying entity of
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">42</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">42</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb194"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -10725,15 +10737,15 @@ represented by <code class="sourceCode cpp">r</code>.</p>
 </div>
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">43</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">44</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">44</a></span>
 <em>Returns</em>: A reflection of the primary template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">45</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">45</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb196"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -10757,11 +10769,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a class type that is complete from some
 point in the evaluation context or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -10784,7 +10796,7 @@ members-of-representable,</li>
 members-of-representable members include: injected class names, partial
 template specializations, friend declarations, and static
 assertions.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-reachable</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -10795,7 +10807,7 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">4</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -10810,10 +10822,10 @@ but the order of namespace members is unspecified. <span class="note"><span>[ <
 members. Implicitly-declared special members appear after any
 user-declared members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">6</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -10823,70 +10835,70 @@ relationships are indexed in the order in which the corresponding base
 classes appear in the <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">8</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_variable<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">10</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_nonstatic_data_member<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">11</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">12</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">13</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">18</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">19</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">20</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -10901,22 +10913,22 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or direct base class
 relationship other than a virtual base class of an abstract class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the offset in bits
 from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, direct base class relationship, or data
@@ -10924,7 +10936,7 @@ member description. If <code class="sourceCode cpp">dealias<span class="op">(</s
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a data member
@@ -10942,7 +10954,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing a type, object, variable, non-static data
 member that is not a bit-field, direct base class relationship, or data
@@ -10950,21 +10962,21 @@ member description. If <code class="sourceCode cpp">dealias<span class="op">(</s
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(8.1)</a></span>
 If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, variable, or object, then the alignment requirement
 of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(8.4)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10974,7 +10986,7 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 The value <code class="sourceCode cpp"><em>A</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, unnamed bit-field, direct base class
@@ -10982,7 +10994,7 @@ relationship, or data member description. If <code class="sourceCode cpp">dealia
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field or unnamed bit-field with
 width <code class="sourceCode cpp"><em>W</em></code>, or a data member
@@ -11000,32 +11012,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from some point in the evaluation
 context and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -11033,7 +11045,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -11041,7 +11053,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -11049,58 +11061,58 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">7</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a pointer type, then a
 pointer value pointing to the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">(7.2)</a></span>
 Otherwise, a pointer-to-member value designating the entity represented
 by <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value that
 <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value that <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">10</a></span>
 <em>Returns</em>: the value that <code class="sourceCode cpp">r</code>
 represents converted to <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -11118,40 +11130,40 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb215-5"><a href="#cb215-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">8</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span><code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">..&gt;</span></code>
 is not instantiated.<span> — <em>end note</em> ]</span></span></p>
 </div>
@@ -11164,32 +11176,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is neither a reference type nor an array type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, is the address of or refers to an object or function that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -11197,37 +11209,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or function that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -11240,7 +11252,7 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">name_type</code> are consteval-only types
 ([basic.types.general]), and are not a structural types
@@ -11263,12 +11275,12 @@ The classes <code class="sourceCode cpp">data_member_options</code> and
 <span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -11289,64 +11301,64 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp">cv <em>T</em></code>
 where <code class="sourceCode cpp"><em>T</em></code> is either an object
 type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">(4.3)</a></span>
 otherwise, if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(4.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(4.5.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(4.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(4.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(4.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(4.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(4.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">(4.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -11355,10 +11367,10 @@ does not contain a value.</li>
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type or type alias
 represented by <code class="sourceCode cpp">type</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
@@ -11366,23 +11378,23 @@ or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</spa
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 is empty,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 is empty,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 is empty, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">6</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>. Certain other
@@ -11394,7 +11406,7 @@ query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
@@ -11402,7 +11414,7 @@ description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">8</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -11410,7 +11422,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(8.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -11427,18 +11439,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(8.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(8.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(8.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -11452,7 +11464,7 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">9</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -11463,26 +11475,26 @@ values such that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">(10.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">(10.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -11495,28 +11507,28 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">(10.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(10.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or type alias represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(10.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(10.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(10.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(10.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(10.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(10.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(10.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(10.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -11528,18 +11540,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(10.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(10.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(10.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(10.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -11549,10 +11561,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -11571,7 +11583,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11592,7 +11604,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb229-13"><a href="#cb229-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-14"><a href="#cb229-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-15"><a href="#cb229-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -11618,7 +11630,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11639,7 +11651,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -11648,7 +11660,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TYPE</em></code>
@@ -11657,7 +11669,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11741,12 +11753,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb233"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb234"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -11758,17 +11770,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type</code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11778,7 +11790,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11805,7 +11817,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb235-15"><a href="#cb235-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb235-16"><a href="#cb235-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb235-17"><a href="#cb235-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -11827,7 +11839,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -11839,7 +11851,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11859,7 +11871,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11876,7 +11888,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11892,7 +11904,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11908,7 +11920,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11934,14 +11946,14 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause with signature <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>to<span class="op">&lt;</span>vector<span class="op">&gt;(</span>r<span class="op">)</span> <span class="op">==</span> vector<span class="op">{^^</span>T<span class="op">...}</span></code>
@@ -11950,7 +11962,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11970,7 +11982,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb241-9"><a href="#cb241-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb241-10"><a href="#cb241-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb241-11"><a href="#cb241-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb242"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -11992,14 +12004,14 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
 defined in this clause with the signature <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 value <code class="sourceCode cpp">I</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em></code>
 defined in this clause with the signature <code class="sourceCode cpp">info<span class="op">(</span><span class="dt">size_t</span>, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
@@ -12021,7 +12033,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -12029,27 +12041,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>

--- a/2996_reflection/p2996r8.html
+++ b/2996_reflection/p2996r8.html
@@ -6127,7 +6127,11 @@ is preceded by
 <span id="cb109-9"><a href="#cb109-9" aria-hidden="true" tabindex="-1"></a>  <span class="co">// OK, template binds to splice-scope-specifier</span></span>
 <span id="cb109-10"><a href="#cb109-10" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb109-11"><a href="#cb109-11" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">typename</span> <span class="op">[:^^</span>TCls<span class="op">:]&lt;</span><span class="dv">3</span><span class="op">&gt;::</span>type v3 <span class="op">=</span> <span class="dv">3</span>;</span>
-<span id="cb109-12"><a href="#cb109-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">// OK, typename binds to the qualified name</span></span></code></pre></div>
+<span id="cb109-12"><a href="#cb109-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">// OK, typename binds to the qualified name</span></span>
+<span id="cb109-13"><a href="#cb109-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb109-14"><a href="#cb109-14" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="op">[:^^</span>TCls<span class="op">:]&lt;</span><span class="dv">3</span><span class="op">&gt;::</span>type v4 <span class="op">=</span> <span class="dv">4</span>;</span>
+<span id="cb109-15"><a href="#cb109-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// error: [:^^TCls:]&lt; is parsed as a splice-expression followed</span></span>
+<span id="cb109-16"><a href="#cb109-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">// by a comparison operator</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6299,7 +6303,8 @@ note</em> ]</span></span></p></li>
 <p><strong>Expression Splicing [expr.prim.splice]</strong></p>
 <div class="sourceCode" id="cb110"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><em>splice-expression</em>:</span>
 <span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
-<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specialization-specifier</em></span></code></pre></div>
+<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em></span>
+<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specialization-specifier</em></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
@@ -6333,15 +6338,21 @@ let <code class="sourceCode cpp"><em>S</em></code> be the construct
 designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(2.1)</a></span>
-If <code class="sourceCode cpp"><em>S</em></code> is an object, a
-function, a function template, or a non-static data member, the
-expression is an lvalue designating
-<code class="sourceCode cpp"><em>S</em></code>. The expression has the
-same type as <code class="sourceCode cpp"><em>S</em></code>, and is a
-bit-field if and only if <code class="sourceCode cpp"><em>S</em></code>
-is a bit-field.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(2.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">3</a></span>
+If <code class="sourceCode cpp"><em>S</em></code> is a function,
+overload resolution ([over.match], [temp.over]) is performed from an
+initial set of candidate functions containing only that function. The
+expression is an lvalue referring to the selected function and has the
+same type as that function.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(3.1)</a></span>
+Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is an
+object or a non-static data member, the expression is an lvalue
+designating <code class="sourceCode cpp"><em>S</em></code>. The
+expression has the same type as
+<code class="sourceCode cpp"><em>S</em></code>, and is a bit-field if
+and only if <code class="sourceCode cpp"><em>S</em></code> is a
+bit-field.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 variable or a structured binding,
 <code class="sourceCode cpp"><em>S</em></code> shall either have static
@@ -6357,15 +6368,23 @@ is a bit-field.</p>
 designating a variable or structured binding of reference type will be
 adjusted to a non-reference type (<span>7.2.2 <a href="https://wg21.link/expr.type">[expr.type]</a></span>).<span>
 — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(3.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a value
 or an enumerator, the expression is a prvalue that computes
 <code class="sourceCode cpp"><em>S</em></code> and whose type is the
 same as <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(2.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(3.4)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">4</a></span>
+For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
+the form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em></code>,
+the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
+designate a function template. Overload resolution is performed from an
+initial set of candidate functions containing only that function
+template. The expression is an lvalue referring to the selected function
+and has the same type as that function.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">5</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -6378,35 +6397,42 @@ shall designate a template. Let
 any) of the
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(3.1)</a></span>
-If <code class="sourceCode cpp"><em>T</em></code> is a primary variable
-template or function template, the expression is an lvalue referring to
-the same object or function associated with
-<code class="sourceCode cpp"><em>S</em></code>. The expression has the
-same type as <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(5.1)</a></span>
+If <code class="sourceCode cpp"><em>T</em></code> is a function
+template, overload resolution is performed from an initial set of
+candidate functions containing only the function associated with
+<code class="sourceCode cpp"><em>S</em></code>. The expression is an
+lvalue referring to the selected function and has the same type as that
+function.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(5.2)</a></span>
+Otherwise, if <code class="sourceCode cpp"><em>T</em></code> is a
+primary variable template, the expression is an lvalue referring to the
+same object associated with
+<code class="sourceCode cpp"><em>S</em></code> and has the same type as
+<code class="sourceCode cpp"><em>S</em></code>.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(5.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>T</em></code> is a
 concept, the expression is a prvalue that computes the same boolean
 value as the <code class="sourceCode cpp"><em>concept-id</em></code>
 formed by <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(3.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(5.4)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 2:</em> </span>Access checking of
 class members occurs during lookup, and therefore does not pertain to
 splicing.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">6</a></span>
 A <code class="sourceCode cpp"><em>splice-expression</em></code> that
 designates a non-static data member or implicit object member function
 of a class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(6.1)</a></span>
 as part of a class member access in which the object expression refers
 to the member’s class or a class derived from that class,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(6.2)</a></span>
 to form a pointer to member (<span>7.6.2.2 <a href="https://wg21.link/expr.unary.op">[expr.unary.op]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(6.3)</a></span>
 if that <code class="sourceCode cpp"><em>splice-expression</em></code>
 designates a non-static data member and it appears in an unevaluated
 operand.</li>
@@ -6417,15 +6443,11 @@ an <code class="sourceCode cpp"><em>id-expression</em></code> denoting a
 non-static member becomes a class member access does not apply to a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">5</a></span>
-For a <code class="sourceCode cpp"><em>splice-expression</em></code>
-that designates a function or function template, overload resolution is
-performed (<span>12.2 <a href="https://wg21.link/over.match">[over.match]</a></span>,
-<span>13.10.4 <a href="https://wg21.link/temp.over">[temp.over]</a></span>) from an
-initial set of candidate functions containing only the entity designated
-by the <code class="sourceCode cpp"><em>splice-expression</em></code>.
-The best viable function selected by overload resolution is
-<em>designated in a manner exempt from access rules</em>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">7</a></span>
+While performing overload resolution to determine the entity referred to
+by a <code class="sourceCode cpp"><em>splice-expression</em></code>, the
+best viable function is <em>designated in a manner exempt from access
+rules</em>.</p>
 </div>
 </blockquote>
 </div>
@@ -6454,7 +6476,7 @@ access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -6480,7 +6502,7 @@ and is followed by a
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">2</a></span>
 For <span class="rm" style="color: #bf0303"><del>the first option, if
 the</del></span> <span class="addu">a dot that is followed by an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">or
@@ -6503,7 +6525,7 @@ the remainder of [expr.ref] will address only <span class="rm" style="color: #bf
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">3</a></span>
 The postfix expression before the dot is evaluated; the result of that
 evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -6515,7 +6537,7 @@ determines the result of the entire postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">4</a></span>
 Abbreviating
 <code class="sourceCode cpp"><em>postfix-expression</em></code>.<code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="addu">or <code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span><em>splice-expression</em></code></span>
@@ -6530,11 +6552,11 @@ Explicitly add a fallback to paragraph 7 that makes other cases
 ill-formed.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">7</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="addu">designates
 an entity that</span> is declared to have type “reference to
 <code class="sourceCode cpp">T</code>”, then
@@ -6549,13 +6571,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(7.2)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
@@ -6574,15 +6596,15 @@ member, then the type of
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 “<em>cq12</em> <em>vq12</em>
 <code class="sourceCode cpp">T</code>”.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(7.3)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> is an overload set, […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(7.4)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(7.5)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
@@ -6590,10 +6612,10 @@ ill-formed.</p></li>
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(7.6)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(7.6)</a></span>
 Otherwise, the program is ill-formed.</span></p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">8</a></span>
 If <code class="sourceCode cpp">E2</code> is <span class="addu">an
 <code class="sourceCode cpp"><em>id-expression</em></code>
 denoting</span> a non-static member, the program is ill-formed if the
@@ -6601,7 +6623,7 @@ class of which <code class="sourceCode cpp">E2</code> <span class="rm" style="co
 <a href="https://wg21.link/class.member.lookup">[class.member.lookup]</a></span>)
 of the naming class (<span>11.8.3 <a href="https://wg21.link/class.access.base">[class.access.base]</a></span>)
 of <code class="sourceCode cpp">E2</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -6617,7 +6639,7 @@ to the grammar for
 paragraph 1:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb113"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -6634,13 +6656,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -6650,7 +6672,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -6661,7 +6683,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -6685,7 +6707,7 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <span id="cb114-5"><a href="#cb114-5" aria-hidden="true" tabindex="-1"></a>   ^^ <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></span>
 <span id="cb114-6"><a href="#cb114-6" aria-hidden="true" tabindex="-1"></a>   ^^ <em>type-id</em></span>
 <span id="cb114-7"><a href="#cb114-7" aria-hidden="true" tabindex="-1"></a>   ^^ <em>id-expression</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -6695,7 +6717,7 @@ described by this document can also be represented by reflections, and
 can appear as operands of
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">2</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 parsed as the longest possible sequence of tokens that could
 syntactically form a
@@ -6716,7 +6738,7 @@ syntactically form a
 <span id="cb115-12"><a href="#cb115-12" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">3</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> that
 could be validly interpreted as <code class="sourceCode cpp"><span class="op">^^</span> <em>template-name</em></code>
 is never interpreted as <code class="sourceCode cpp"><span class="op">^^</span> <em>id-expression</em></code>,
@@ -6724,7 +6746,7 @@ and is interpreted as
 <code class="sourceCode cpp"><span class="op">^^</span> <em>type-id</em></code>
 if and only if the operand refers to the current instantiation
 ([temp.dep.type]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">4</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <span class="op">::</span></code>
 represents the global namespace. A
@@ -6732,7 +6754,7 @@ represents the global namespace. A
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>qualified-namespace-specifier</em></code>
 is interpreted as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">5</a></span>
 If lookup of the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
 unambiguously finds a
@@ -6740,54 +6762,54 @@ unambiguously finds a
 the <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the namespace alias declared by that
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">6</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the namespace denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">7</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>
 represents the primary class template, function template, primary
 variable template, or alias template denoted by the
 <code class="sourceCode cpp"><em>template-name</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">8</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>concept-name</em></code>
 represents the concept denoted by the
 <code class="sourceCode cpp"><em>concept-name</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">9</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form
 <code class="sourceCode cpp"><span class="op">^^</span> <em>type-id</em></code>
 is interpreted as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(9.1)</a></span>
 If the <code class="sourceCode cpp"><em>type-id</em></code> is a
 <code class="sourceCode cpp"><em>typedef-name</em></code> that was
 introduced by the declaration of a template parameter, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the type denoted by that
 <code class="sourceCode cpp"><em>typedef-name</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(9.2)</a></span>
 Otherwise, if the <code class="sourceCode cpp"><em>type-id</em></code>
 is any other <code class="sourceCode cpp"><em>typedef-name</em></code>,
 the <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the type alias associated with that
 <code class="sourceCode cpp"><em>typedef-name</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(9.3)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents the type denoted by the
 <code class="sourceCode cpp"><em>type-id</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">10</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <em>id-expression</em></code>
 is interpreted as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(10.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(10.1)</a></span>
 If the <code class="sourceCode cpp"><em>id-expression</em></code>
 denotes an overload set <code class="sourceCode cpp"><em>S</em></code>
 and overload resolution for the expression
@@ -6796,21 +6818,21 @@ determines a unique function
 <code class="sourceCode cpp"><em>F</em></code> (<span>12.3 <a href="https://wg21.link/over.over">[over.over]</a></span>), the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents <code class="sourceCode cpp"><em>F</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(10.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(10.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 local entity captured by an enclosing
 <code class="sourceCode cpp"><em>lambda-expression</em></code>, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(10.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 variable, structured binding, enumerator, or non-static data member or
 member function, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 represents that entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(10.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(10.4)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 ill-formed. <span class="note"><span>[ <em>Note 2:</em> </span>This
@@ -6828,10 +6850,10 @@ unevaluated operand (<span>7.2.3 <a href="https://wg21.link/expr.context">[expr.
 <span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^^</span>T <span class="op">==</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
 <span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span><span class="kw">sizeof</span><span class="op">(</span>T<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span><span class="dt">int</span><span class="op">))</span>;</span>
 <span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> x <span class="op">=</span> <span class="op">^^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
-<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> y <span class="op">=</span> <span class="op">^^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: ambiguous</span></span>
+<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> a <span class="op">=</span> <span class="op">^^</span>fn<span class="op">&lt;</span><span class="dt">char</span><span class="op">&gt;</span>;     <span class="co">// OK</span></span>
+<span id="cb116-6"><a href="#cb116-6" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> b <span class="op">=</span> <span class="op">^^</span>fn<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span>;      <span class="co">// error: ambiguous</span></span>
 <span id="cb116-7"><a href="#cb116-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> z <span class="op">=</span> <span class="op">^^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span>
+<span id="cb116-8"><a href="#cb116-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> c <span class="op">=</span> <span class="op">^^</span>std<span class="op">::</span>vector;  <span class="co">// OK</span></span>
 <span id="cb116-9"><a href="#cb116-9" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb116-10"><a href="#cb116-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb116-11"><a href="#cb116-11" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">{</span></span>
@@ -6839,7 +6861,12 @@ unevaluated operand (<span>7.2.3 <a href="https://wg21.link/expr.context">[expr.
 <span id="cb116-13"><a href="#cb116-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> type <span class="op">=</span> T;</span>
 <span id="cb116-14"><a href="#cb116-14" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
 <span id="cb116-15"><a href="#cb116-15" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>S<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;::</span>r <span class="op">==</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb116-16"><a href="#cb116-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>S<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;::</span>type <span class="op">!=</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span></code></pre></div>
+<span id="cb116-16"><a href="#cb116-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>S<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;::</span>type <span class="op">!=</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb116-17"><a href="#cb116-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb116-18"><a href="#cb116-18" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> X <span class="op">{}</span> Y;</span>
+<span id="cb116-19"><a href="#cb116-19" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> Z <span class="op">{}</span> Z;</span>
+<span id="cb116-20"><a href="#cb116-20" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> e <span class="op">=</span> <span class="op">^^</span>Y;  <span class="co">// OK, represents the type alias Y</span></span>
+<span id="cb116-21"><a href="#cb116-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> f <span class="op">=</span> <span class="op">^^</span>Z;  <span class="co">// OK, represents the type Z (not the type alias)</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -6850,7 +6877,7 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <p>Extend paragraph 2 to also handle <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">2</a></span>
 The converted operands shall have arithmetic, enumeration, pointer, or
 pointer-to-member type, <span class="addu">type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>.
@@ -6868,33 +6895,33 @@ specified conversions have been applied.</p>
 <p>Add a new paragraph between paragraphs 5 and 6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">5</a></span>
 Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">5+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">5+</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(5+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(5+.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(5+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(5+.2)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a value that is
 template-argument-equivalent (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(5+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(5+.3)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(5+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(5+.4)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(5+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(5+.5)</a></span>
 Otherwise, if one operand represents a direct base class relationship,
 then they compare equal if and only if the other operand represents the
 same direct base class relationship.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(5+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(5+.6)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -6905,7 +6932,7 @@ data member descriptions represented by
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -6926,7 +6953,7 @@ Expressions<a href="#expr.const-constant-expressions" class="self-link"></a></h3
 <code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">10</a></span>
 During the evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> as a core constant
 expression, all
@@ -6944,15 +6971,15 @@ includes the entire constant evaluation. […]</p>
 and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">15</a></span>
 A <em>constant expression</em> is either a glvalue core constant
 expression <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> that
 <span class="addu"> </span></p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(15.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(15.1)</a></span>
 refers to an <span class="rm" style="color: #bf0303"><del>entity</del></span> <span class="addu">object or function</span> that is a permitted result of a
 constant expression<span class="addu">, and</span></p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(15.2)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(15.2)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> designates a function
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>)
 or an object whose complete object is of consteval-only type, then
@@ -6977,34 +7004,34 @@ type,</span></p>
 <p>or a prvalue core constant expression whose value satisfies the
 following constraints:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(15.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(15.3)</a></span>
 if the value is an object of class type, each non-static data member of
 reference type refers to an <span class="rm" style="color: #bf0303"><del>entity</del></span> <span class="addu">object or function</span> that is a permitted result of a
 constant expression, <span class="addu">and if the object or function is
 of consteval-only type, or is the subobject of such an object, then so
 is the value,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(15.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(15.4)</a></span>
 if the value is an object of scalar type, it does not have an
 indeterminate or erroneous value (<span>6.7.4 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(15.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(15.5)</a></span>
 if the value is of pointer type, <span class="addu">then: </span>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(15.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(15.5.1)</a></span>
 it is a pointer to an object of static storage duration<span class="rm" style="color: #bf0303"><del>,</del></span> <span class="addu">or</span>
 a pointer past the end of such an object (<span>7.6.6 <a href="https://wg21.link/expr.add">[expr.add]</a></span>), <span class="addu">and if the complete object of that object is of
 consteval-only type then so is that pointer,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(15.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(15.5.2)</a></span>
 <span class="addu">it is</span> a pointer to a non-immediate function,
 <span class="addu">and if that function is of consteval-only type then
 so is that pointer,</span> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(15.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(15.5.3)</a></span>
 <span class="addu">it is</span> a null pointer value,</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(15.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(15.6)</a></span>
 if the value is of pointer-to-member-function type, it does not
 designate an immediate function, <span class="addu">and if that function
 is of consteval-only type then so is that value,</span> and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(15.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(15.7)</a></span>
 if the value is an object of class or array type, each subobject
 satisfies these constraints for the value.</li>
 </ul>
@@ -7014,13 +7041,13 @@ satisfies these constraints for the value.</li>
 in paragraph 18 to also apply to expressions of consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">18</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it is <span class="rm" style="color: #bf0303"><del>either</del></span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(18.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(18.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -7028,10 +7055,10 @@ potentially-evaluated</del></span> <span class="addu">an</span>
 that <span class="rm" style="color: #bf0303"><del>denotes</del></span>
 <span class="addu">designates</span> an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that
 is not a subexpression of an immediate invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(18.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(18.2)</a></span>
 an immediate invocation that is not a constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(18.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(18.3)</a></span>
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>).</span></li>
 </ul>
 </blockquote>
@@ -7042,18 +7069,18 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">21pre</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">21pre</a></span>
 A non-dependent expression or conversion is <em>plainly
 constant-evaluated</em> if it is not in a complete-class context
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 and is either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(21pre.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(21pre.1)</a></span>
 the <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 (<span>9.1 <a href="https://wg21.link/dcl.pre">[dcl.pre]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(21pre.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(21pre.2)</a></span>
 an initializer of a
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>
 (<span>9.2.6 <a href="https://wg21.link/dcl.constexpr">[dcl.constexpr]</a></span>) or
@@ -7076,22 +7103,22 @@ constant-evaluated</em> to clarify the relationship with <em>plainly
 constant-evaluated</em> expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">21</a></span>
 An expression or conversion is <em>manifestly constant-evaluated</em> if
 it is:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(21.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(21.1)</a></span>
 a <code class="sourceCode cpp"><em>constant-expression</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(21.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(21.2)</a></span>
 the condition of a constexpr if statement (<span>8.5.2 <a href="https://wg21.link/stmt.if">[stmt.if]</a></span>), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(21.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(21.3)</a></span>
 an immediate invocation, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(21.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(21.4)</a></span>
 the result of substitution into an atomic constraint expression to
 determine whether it is satisfied (<span>13.5.2.3 <a href="https://wg21.link/temp.constr.atomic">[temp.constr.atomic]</a></span>),
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(21.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(21.5)</a></span>
 the initializer for a variable that is usable in constant expressions or
 has constant initialization (<span>6.9.3.2 <a href="https://wg21.link/basic.start.static">[basic.start.static]</a></span>).</li>
 </ul>
@@ -7113,7 +7140,7 @@ injecting declarations and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">22</a></span>
 The evaluation of an expression can introduce one or more <em>injected
 declarations</em>. Each such declaration has an associated
 <em>synthesized point</em> which follows the last non-synthesized
@@ -7122,17 +7149,17 @@ evaluation is said to <em>produce</em> the declaration.</p>
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to synthesized points (<span>10.7 <a href="https://wg21.link/module.reach">[module.reach]</a></span>).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">23</a></span>
 The program is ill-formed if the evaluation of a manifestly
 constant-evaluated expression
 <code class="sourceCode cpp"><em>M</em></code> produces an injected
 declaration <code class="sourceCode cpp"><em>D</em></code> and
 either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(23.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(23.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a plainly
 constant-evaluated expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(23.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(23.2)</a></span>
 the target scope of <code class="sourceCode cpp"><em>D</em></code> is
 not semantically sequenced with
 <code class="sourceCode cpp"><em>M</em></code> (<span>5.2 <a href="https://wg21.link/lex.phases">[lex.phases]</a></span>).</li>
@@ -7140,20 +7167,20 @@ not semantically sequenced with
 <p>Furthermore, the program is ill-formed, no diagnostic required,
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(23.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(23.3)</a></span>
 an evaluation
 <code class="sourceCode cpp"><em>E</em><sub><em>1</em></sub></code>
 produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> during the evaluation of
 a manifestly constant-evaluated expression
 <code class="sourceCode cpp"><em>M</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(23.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(23.4)</a></span>
 a second evaluation
 <code class="sourceCode cpp"><em>E</em><sub><em>2</em></sub></code>
 computes a reflection of <code class="sourceCode cpp"><em>D</em></code>
 during the same evaluation of
 <code class="sourceCode cpp"><em>M</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(23.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(23.5)</a></span>
 <code class="sourceCode cpp"><em>E</em><sub><em>1</em></sub></code> is
 unsequenced with
 <code class="sourceCode cpp"><em>E</em><sub><em>2</em></sub></code>
@@ -7194,7 +7221,7 @@ unsequenced with
 <span id="cb118-31"><a href="#cb118-31" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ill-formed, no diagnostic required</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">24</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines the behavior of certain functions used for reflection
 ([meta.reflection]). During the evaluation of a manifestly
@@ -7203,11 +7230,11 @@ constant-evaluated expression
 of an evaluation <code class="sourceCode cpp"><em>E</em></code>
 comprises the union of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(24.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(24.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>M</em></code> (<span>10.6 <a href="https://wg21.link/module.context">[module.context]</a></span>),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(24.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(24.2)</a></span>
 the synthesized points corresponding to any injected declarations
 produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> (<span>6.9.1 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>).</li>
@@ -7222,7 +7249,7 @@ with its associated type from paragraph 8 (type aliases are entities
 now).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">8</a></span>
 If the <code class="sourceCode cpp"><em>decl-specifier-seq</em></code>
 contains the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7240,7 +7267,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 specifier now introduces an entity.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">1</a></span>
 Declarations containing the
 <code class="sourceCode cpp"><em>decl-specifier</em></code>
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7283,7 +7310,7 @@ a <code class="sourceCode cpp"><em>typedef-name</em></code> <span class="rm" sty
 <code class="sourceCode cpp"><em>typedef-name</em></code> does not
 introduce a new type the way a class declaration (<span>11.3 <a href="https://wg21.link/class.name">[class.name]</a></span>) or enum
 declaration (<span>9.7.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">2</a></span>
 A <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span> can also be <span class="rm" style="color: #bf0303"><del>introduced</del></span> <span class="addu">declared</span> by an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>. The
@@ -7321,7 +7348,7 @@ to accommodate
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -7329,10 +7356,10 @@ is a placeholder for a type to be deduced ([dcl.spec.auto]). A
 is a placeholder for a deduced class type ([dcl.type.class.deduct])
 <span class="addu">if it either </span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(3.1)</a></span>
 is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(3.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(3.2)</a></span>
 is of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>
 and the <code class="sourceCode cpp"><em>splice-specifier</em></code>
@@ -7431,13 +7458,13 @@ Decltype specifiers<a href="#dcl.type.decltype-decltype-specifiers" class="self-
 <code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">1</a></span>
 For an expression <code class="sourceCode cpp"><em>E</em></code>, the
 type denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
 is defined as follows:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(1.3)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>id-expression</em></code> or an
@@ -7445,7 +7472,7 @@ unparenthesized class member access ([expr.ref]), <code class="sourceCode cpp"><
 is the type of the entity named by
 <code class="sourceCode cpp"><em>E</em></code>. If there is no such
 entity, the program is ill-formed;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(1.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(1.3+)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>splice-expression</em></code>, <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
@@ -7469,7 +7496,7 @@ specifier is an unevaluated operand.</p>
 <div class="sourceCode" id="cb122"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
 <span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specifier</em></span>
 <span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -7498,7 +7525,7 @@ within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.gen
 <span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> alias <span class="op">=</span> <span class="op">[:^^</span>S<span class="op">::</span>type<span class="op">:]</span>;    <span class="co">// OK, type-only context</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>,
@@ -7508,7 +7535,7 @@ concept. The
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -7521,12 +7548,12 @@ shall designate a primary class template or an alias template. Let
 any) of the
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>T</em></code> is a primary class
 template, the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(3.2)</a></span>
 Otherwise if <code class="sourceCode cpp"><em>T</em></code> is an alias
 template, the
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
@@ -7541,7 +7568,7 @@ designates the type denoted by
 clear about the entity being referred to.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
@@ -7552,7 +7579,7 @@ type <span class="rm" style="color: #bf0303"><del>named</del></span>
 <span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>)) shall
 appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(9.1)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7563,7 +7590,7 @@ Default arguments<a href="#dcl.fct.default-default-arguments" class="self-link">
 appear in default function arguments.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">9</a></span>
 A default argument is evaluated each time the function is called with no
 argument for the corresponding parameter.</p>
 <p>[…]</p>
@@ -7584,46 +7611,46 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>),
 the object is initialized to the value obtained by converting the
 integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -7631,7 +7658,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible <span class="rm" style="color: #bf0303"><del>class</del></span> type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -7640,26 +7667,26 @@ To value-initialize an object of type T means: […]</p>
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
 type named by <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -7668,7 +7695,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -7682,7 +7709,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 a <code class="sourceCode cpp"><em>reflect-expression</em></code>
@@ -7711,7 +7738,7 @@ follows:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">1</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> of
 the form
@@ -7739,7 +7766,7 @@ in paragraph 1, and clarify that such declarations declare a “namespace
 alias” (which is now an entity as per [basic.pre]).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">1</a></span>
 A
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 declares <span class="rm" style="color: #bf0303"><del>an alternative
@@ -7767,7 +7794,7 @@ this will fall out from the “underlying entity” of the namespace alias
 defined below:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -7781,7 +7808,7 @@ note:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">2+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">2+</a></span>
 The underlying entity (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>) of the
 namespace alias is the namespace either denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
@@ -7809,14 +7836,14 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code>, if
 any, designates a namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> and
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
 not be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -7880,7 +7907,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -7904,7 +7931,7 @@ Deprecated attribute<a href="#dcl.attr.deprecated-deprecated-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">2</a></span>
 The attribute may be applied to the declaration of a class, a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, a variable, a non-static data
 member, a function, a namespace, an enumeration, an enumerator, a
@@ -7918,7 +7945,7 @@ Maybe unused attribute<a href="#dcl.attr.unused-maybe-unused-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">2</a></span>
 The attribute may be applied to the declaration of a class, <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, variable (including a structured
 binding declaration), structured binding, non-static data member,
@@ -7939,13 +7966,13 @@ might have a
 designating a specialization.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>decl-reachable</em> from a declaration
 <code class="sourceCode cpp"><em>S</em></code> in the same translation
 unit if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(3.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> does not declare a
 function or function template and
 <code class="sourceCode cpp"><em>S</em></code> contains an
@@ -7959,7 +7986,7 @@ function or function template and
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 designating <code class="sourceCode cpp"><em>D</em></code></span>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(3.2)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7972,7 +7999,7 @@ splice specifier is replaced.</p>
 <blockquote>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -7981,22 +8008,22 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>template-name</em></code> names an
 alias template is replaced by its denoted type prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(3.8)</a></span>
 whether a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 that does not <span class="rm" style="color: #bf0303"><del>denote</del></span> <span class="addu">designate</span> a dependent type is replaced by its <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> type prior to this determination, <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(3.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(3.9)</a></span>
 whether a non-value-dependent constant expression is replaced by the
 result of constant evaluation prior to this determination<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(3.10)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(3.10)</a></span>
 whether a <code class="sourceCode cpp"><em>splice-specifier</em></code>
 that is not dependent is replaced by the construct that it designates
 prior to this determination.</span></li>
@@ -8009,23 +8036,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 a synthesized point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 synthesized point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 (<span>10.4 <a href="https://wg21.link/module.global.frag">[module.global.frag]</a></span>),
 appears in a translation unit that is reachable from
@@ -8041,7 +8068,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">5</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <em>member-declaration</em>, in which case it is a <em>static
@@ -8066,7 +8093,7 @@ member description</em>:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">29+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">29+</a></span>
 A <em>data member description</em> is a quintuple
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -8075,19 +8102,19 @@ A <em>data member description</em> is a quintuple
 <code class="sourceCode cpp"><em>NUA</em></code>) describing the
 potential declaration of a nonstatic data member where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(29+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(29+.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a type or type
 alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(29+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(29+.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is an
 <code class="sourceCode cpp"><em>identifier</em></code> or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(29+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(29+.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is an alignment or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(29+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(29+.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is a bit-field width or
 <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(29+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(29+.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is a boolean
 value.</li>
 </ul>
@@ -8097,14 +8124,14 @@ components are same types, same identifiers, and equal values.</p>
 <p><span>[ <em>Note 4:</em> </span>The components of a data member
 description describe a data member such that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(29+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">(29+.6)</a></span>
 its type is specified using the type or type alias given by
 <code class="sourceCode cpp"><em>T</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(29+.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">(29+.7)</a></span>
 it is declared with the name given by
 <code class="sourceCode cpp"><em>N</em></code> if <code class="sourceCode cpp"><em>N</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise unnamed,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(29+.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">(29+.8)</a></span>
 it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>
 (<span>9.12.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
@@ -8112,11 +8139,11 @@ it is declared with the
 if <code class="sourceCode cpp"><em>A</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise declared without an
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">(29+.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">(29+.9)</a></span>
 it is a bit-field (<span>11.4.10 <a href="https://wg21.link/class.bit">[class.bit]</a></span>) with the
 width given by <code class="sourceCode cpp"><em>W</em></code> if <code class="sourceCode cpp"><em>W</em> <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span></code>
 and is otherwise not a bit-field,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">(29+.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">(29+.10)</a></span>
 it is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
 (<span>9.12.12 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
 if <code class="sourceCode cpp"><em>NUA</em></code> is
@@ -8139,7 +8166,7 @@ note</em> ]</span></p>
 General<a href="#class.derived.general-general" class="self-link"></a></h3>
 <p>Introduce the term “direct base class relationship” to paragraph
 2.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>class-or-decltype</em></code> are those
 of its
@@ -8186,7 +8213,7 @@ resolution, and add a note explaining the expressions that form overload
 sets.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">2</a></span>
 <span class="addu">An <em>overload set</em> is a set of declarations
 that each denote a function or function template. Using these
 declarations as a starting point, the process of <em>overload
@@ -8215,14 +8242,14 @@ General<a href="#over.match.general-general" class="self-link"></a></h3>
 in all contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">3</a></span>
 If a best viable function exists and is unique, overload resolution
 succeeds and produces it as the result. Otherwise overload resolution
 fails and the invocation is ill-formed. When overload resolution
 succeeds, and the best viable function is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither
 designated in a manner exempt from access rules nor</span> accessible in
 the context in which it is used, the program is ill-formed.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">4</a></span>
 Overload resolution results in a <em>usable candidate</em> if overload
 resolution succeeds and the selected candidate is either not a function
 (<span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>), or is a
@@ -8237,7 +8264,7 @@ to named function<a href="#over.call.func-call-to-named-function" class="self-li
 splices of function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
 Of interest in [over.call.func] are only those function calls in which
 the <code class="sourceCode cpp"><em>posfix-expression</em></code>
 ultimately contains an
@@ -8265,7 +8292,7 @@ qualified function calls and unqualified function calls.</p>
 designating member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">2</a></span>
 In qualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -8308,7 +8335,7 @@ in the normalized member function call as the implied object argument
 designating non-member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">3</a></span>
 In unqualified function calls, the function is named by a
 <code class="sourceCode cpp"><em>primary-expression</em></code>. <span class="addu">If that
 <code class="sourceCode cpp"><em>primary-expression</em></code> is a
@@ -8348,7 +8375,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">1</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -8358,7 +8385,7 @@ where the <code class="sourceCode cpp"><em>template-name</em></code>
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -8367,7 +8394,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">3</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -8390,7 +8417,7 @@ paragraph 1 to allow taking the address of an overload set specified by
 a <code class="sourceCode cpp"><em>splice-expression</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">1</a></span>
 An <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span>
 whose terminal name refers</del></span> <span class="addu">expression
 that designates</span> to an overload set
@@ -8412,7 +8439,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -8454,7 +8481,7 @@ the grammar for
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">3+</a></span>
 A non-dependent
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> only
 forms a <code class="sourceCode cpp"><em>type-constraint</em></code>
@@ -8490,32 +8517,32 @@ and add it as a production for
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(3.1)</a></span>
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
 either appears in a type-only context or is preceded by
 <code class="sourceCode cpp"><span class="kw">template</span></code> or
 <code class="sourceCode cpp"><span class="kw">typename</span></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -8555,7 +8582,7 @@ disambiguation in paragraph 4 also applies to the parsing of
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">4</a></span>
 When parsing a
 <code class="sourceCode cpp"><em>template-argument-list</em></code>, the
 first non-nested
@@ -8584,27 +8611,27 @@ cast).<span> — <em>end note</em> ]</span></span></p>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">7</a></span>
 A <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is <em>valid</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(7.1)</a></span>
 there are at most as many arguments as there are parameters or a
 parameter is a template parameter pack (<span>13.7.4 <a href="https://wg21.link/temp.variadic">[temp.variadic]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(7.2)</a></span>
 there is an argument for each non-deducible non-pack parameter that does
 not have a default
 <code class="sourceCode cpp"><em>template-argument</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(7.3)</a></span>
 each <code class="sourceCode cpp"><em>template-argument</em></code>
 matches the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>
 (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(7.4)</a></span>
 substitution of each template argument into the following template
 parameters (if any) succeeds, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(7.5)</a></span>
 if the <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is non-dependent, the associated constraints are satisfied as specified
@@ -8621,7 +8648,7 @@ shall be valid unless it names a function template specialization
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or the
 <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
@@ -8641,7 +8668,7 @@ of the constrained template shall be satisfied (<span>13.5.2 <a href="https://wg
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">111)</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">111)</a></span>
 A <code class="sourceCode cpp"><span class="op">&gt;</span></code> that
 encloses the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>,
@@ -8663,7 +8690,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>template-argument</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
 There are <span class="rm" style="color: #bf0303"><del>three</del></span> <span class="addu">four</span> forms of
 <code class="sourceCode cpp"><em>template-argument</em></code>, <span class="addu">three of which</span> correspond<span class="rm" style="color: #bf0303"><del>ing</del></span> to the three forms of
 <code class="sourceCode cpp"><em>template-parameter</em></code>: type,
@@ -8684,7 +8711,7 @@ declared by the template in its
 in paragraph 3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -8719,7 +8746,7 @@ form of the corresponding
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">9</a></span>
 When a <code class="sourceCode cpp"><em>simple-template-id</em></code>
 <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -8736,7 +8763,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>template-parameter</em></code> which is
 a type shall <span class="addu">either</span> be a
@@ -8758,7 +8785,7 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
@@ -8767,11 +8794,11 @@ for the variable x in the invented declaration</p>
 <div class="sourceCode" id="cb136"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">2</a></span>
 The value of a non-type <em>template-parameter</em>
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">3</a></span>
 Otherwise, a temporary variable</p>
 <div class="sourceCode" id="cb137"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
@@ -8783,7 +8810,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template <code class="sourceCode cpp"><em>template-parameter</em></code>
 shall be <span class="rm" style="color: #bf0303"><del>the name
@@ -8820,27 +8847,27 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s</span>
 are the same if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(1.1)</a></span>
 their <code class="sourceCode cpp"><em>template-name</em></code>s,
 <code class="sourceCode cpp"><em>operator-function-id</em></code>s,
 <span class="rm" style="color: #bf0303"><del>or</del></span>
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>s<span class="addu">, or
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s</span>
 refer to the same template, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(1.2)</a></span>
 their corresponding type
 <code class="sourceCode cpp"><em>template-argument</em></code>s are the
 same type, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(1.3)</a></span>
 the template parameter values determined by their corresponding non-type
 template arguments (<span>13.4.3 <a href="https://wg21.link/temp.arg.nontype">[temp.arg.nontype]</a></span>)
 are template-argument-equivalent (see below), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(1.4)</a></span>
 their corresponding template
 <code class="sourceCode cpp"><em>template-argument</em></code>s refer to
 the same template.</li>
@@ -8854,23 +8881,23 @@ that are the same refer to the same class, function, or variable.</p>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -8882,7 +8909,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -8921,7 +8948,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When a</del></span> <span class="addu">A</span>
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">that</span> refers to the specialization of an alias
 template<span class="rm" style="color: #bf0303"><del>, it is equivalent
@@ -8948,22 +8975,22 @@ be elided from a
 non-dependent contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">4</a></span>
 A qualified or unqualified name is said to be in a
 <code class="sourceCode cpp"><em>type-only context</em></code> if it is
 the terminal name of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(4.1)</a></span>
 a <code class="sourceCode cpp"><em>typename-specifier</em></code>,
 <code class="sourceCode cpp"><em>type-requirement</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>elaborated-type-specifier</em></code>,
 <code class="sourceCode cpp"><em>class-or-decltype</em></code>, <span class="addu"><code class="sourceCode cpp"><em>using-enum-declarator</em></code></span>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">(4.2)</a></span>
 […]
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(4.4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(4.4.6)</a></span>
 <code class="sourceCode cpp"><em>parameter-declaration</em></code> of a
 (non-type)
 <code class="sourceCode cpp"><em>template-parameter</em></code>.</li>
@@ -9008,7 +9035,7 @@ Dependent types<a href="#temp.dep.type-dependent-types" class="self-link"></a></
 paragraph 7.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">7</a></span>
 An initializer is dependent if any constituent expression (<span>6.9.1
 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>)
 of the initializer is type-dependent. A placeholder type
@@ -9027,18 +9054,18 @@ definition to apply to
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">8</a></span>
 A placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 is dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(8.1)</a></span>
 it has a dependent initializer, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(8.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(8.2)</a></span>
 it has a dependent
 <code class="sourceCode cpp"><em>template-name</em></code> or a
 dependent <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(8.3)</a></span>
 it refers to an alias template that is a member of the current
 instantiation and whose
 <code class="sourceCode cpp"><em>defining-type-id</em></code> is
@@ -9052,28 +9079,28 @@ and substitution (<span>13.7.8 <a href="https://wg21.link/temp.alias">[temp.alia
 paragraph 10:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">10</a></span>
 A type is dependent if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(10.1)</a></span>
 a template parameter,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(10.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(10.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(10.11)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> in which
 either the template name is a template parameter or any of the template
 arguments is a dependent type or an expression that is type-dependent or
 value-dependent or is a pack expansion,<sup>121</sup></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(10.12)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(10.12)</a></span>
 a <code class="sourceCode cpp"><em>pack-index-specifier</em></code>,
 <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(10.13)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(10.13)</a></span>
 denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>expression</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is
 type-dependent<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(10.14)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(10.14)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> in
 which either the
@@ -9111,16 +9138,16 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is type-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(9.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(9.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -9136,10 +9163,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -9167,16 +9194,16 @@ or a value-dependent or type-dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">6</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em> <span class="op">&lt;</span> <em>template-argument-list</em><sub><em>opt</em></sub> <span class="op">&gt;</span></code>
 is value-dependent if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(6.1)</a></span>
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(6.2)</a></span>
 the optional
 <code class="sourceCode cpp"><em>template-argument-list</em></code>
 contains a dependent type argument, a value-dependent non-type argument,
@@ -9195,7 +9222,7 @@ and renumber accordingly.</p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent splice specifiers [temp.dep.splice]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if its converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
@@ -9205,7 +9232,7 @@ or <code class="sourceCode cpp"><em>splice-scope-specifier</em></code>
 is dependent if its
 <code class="sourceCode cpp"><em>splice-template-argument</em></code> is
 dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb141"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> T, <span class="kw">auto</span> NS, <span class="kw">auto</span> C, <span class="kw">auto</span> V<span class="op">&gt;</span></span>
@@ -9237,7 +9264,7 @@ Explicit specialization<a href="#temp.expl.spec-explicit-specialization" class="
 to be used like incompletely-defined classes.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">9</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 that <span class="rm" style="color: #bf0303"><del>names</del></span>
@@ -9255,7 +9282,7 @@ General<a href="#temp.deduct.general-general" class="self-link"></a></h3>
 in paragraph 2:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">2</a></span>
 When an explicit template argument list is specified, if the given
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -9276,7 +9303,7 @@ the same as parameter types that are specified using
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(4.3)</a></span>
 If <code class="sourceCode cpp">P</code> is a class and
 <code class="sourceCode cpp">P</code> has the form
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code></span>,
@@ -9308,7 +9335,7 @@ template argument might also be a
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">20</a></span>
 If <code class="sourceCode cpp">P</code> has a form that contains <code class="sourceCode cpp"><span class="op">&lt;</span>i<span class="op">&gt;</span></code>,
 and if the type of <code class="sourceCode cpp">i</code> differs from
 the type of the corresponding template parameter of the template named
@@ -9333,7 +9360,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">9</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb142"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -9351,24 +9378,24 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 this function to be a core constant expression ([expr.const]).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">4</a></span>
 […] Next, the semantics of the code sequence are determined by the
 <em>Constraints</em>, <em>Mandates</em>, <span class="addu"><em>Constant
 When</em>,</span> <em>Preconditions</em>, <em>Effects</em>,
@@ -9384,7 +9411,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -9392,7 +9419,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">6a</a></span>
 Let F denote a standard library function, member function, or function
 template. If F does not designate an addressable function, it is
 unspecified if or how a reflection value designating the associated
@@ -9401,14 +9428,14 @@ entity can be formed. <span class="note"><span>[ <em>Note 1:</em>
 might not return reflections of standard functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -9840,11 +9867,11 @@ synopsis</strong></p>
 <span id="cb146-331"><a href="#cb146-331" aria-hidden="true" tabindex="-1"></a>  consteval size_t variant_size(info type);</span>
 <span id="cb146-332"><a href="#cb146-332" aria-hidden="true" tabindex="-1"></a>  consteval info variant_alternative(size_t index, info type);</span>
 <span id="cb146-333"><a href="#cb146-333" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">1</a></span>
 Each function, and each instantiation of each function template,
 specified in this header is a designated addressable function
 ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">2</a></span>
 The behavior of any function specified in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 implementation-defined when a reflection of a construct not otherwise
@@ -9874,7 +9901,7 @@ definition, the specialization is implicitly instantiated.</p>
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">3</a></span>
 Any function in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>
 that whose return type is
@@ -9903,7 +9930,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb149-3"><a href="#cb149-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb149-4"><a href="#cb149-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -10156,10 +10183,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb150"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -10167,11 +10194,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb151"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb151-2"><a href="#cb151-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">5</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -10186,14 +10213,14 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb152"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> is an unnamed entity other than
 a class that has a typedef name for linkage purposes (<span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.typedef]</a></span>), then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> when
@@ -10202,14 +10229,14 @@ either the <code class="sourceCode cpp"><em>class-name</em></code> of
 <code class="sourceCode cpp"><em>C</em></code> has a typedef name for
 linkage purposes. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if the
 function is not a function template specialization, constructor,
 destructor, operator function, or conversion function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -10217,20 +10244,20 @@ function template, then
 template, operator function template, or conversion function template.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents variable
 or a type alias, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, enumerator, non-static data member, template,
 namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(1.8)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10241,37 +10268,37 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 </ul>
 <div class="sourceCode" id="cb153"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a literal operator
 or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then either the typedef name for linkage purposes or the
 identifier introduced by the declaration of the represented type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, then the identifier introduced by the declaration of that
 entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>
 or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>,
 respectively.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(4.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10285,21 +10312,21 @@ identifier <code class="sourceCode cpp"><em>N</em></code> encoded with
 </ul>
 <div class="sourceCode" id="cb154"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb155"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a non-class type, the global namespace, or a data member
 description, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity, name, or direct base class relationship that was
 introduced by a declaration, implementations should return a value
@@ -10318,7 +10345,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="sourceCode" id="cb156"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-2"><a href="#cb156-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb156-3"><a href="#cb156-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or
@@ -10326,7 +10353,7 @@ direct base class relationship that is public, protected, or private,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb157"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">2</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -10334,7 +10361,7 @@ function or a direct base class relationship that is virtual. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb158"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -10342,7 +10369,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb159"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">4</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -10350,7 +10377,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb160"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">5</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -10359,7 +10386,7 @@ deleted function ([dcl.fct.def.delete]) or defined as defaulted
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb161"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb161-1"><a href="#cb161-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb161-2"><a href="#cb161-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -10367,7 +10394,7 @@ user-provided or user-declared (<span>9.5.2 <a href="https://wg21.link/dcl.fct.d
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb162"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb162-1"><a href="#cb162-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -10382,7 +10409,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb163"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -10399,7 +10426,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -10413,7 +10440,7 @@ for which <code class="sourceCode cpp"><em>W</em></code> is not <code class="sou
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -10421,7 +10448,7 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb166"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a const or volatile
@@ -10430,7 +10457,7 @@ type (respectively), a const- or volatile-qualified function type
 function with such a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb167"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -10439,7 +10466,7 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb168"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a lvalue- or
@@ -10449,7 +10476,7 @@ function with such a type. Otherwise,
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -10460,7 +10487,7 @@ that has static, thread, or automatic storage duration, respectively
 <span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb170-4"><a href="#cb170-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -10469,7 +10496,7 @@ linkage, external linkage, or any linkage, respectively ([basic.link]).
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -10479,7 +10506,7 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_complete_definition<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">17</a></span>
 Returns:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function, class type,
@@ -10488,20 +10515,20 @@ introduced within the scope of the entity represented by
 <code class="sourceCode cpp">r</code>. Otherwise
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a namespace or
 namespace alias. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb174"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">19</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb175"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb175-1"><a href="#cb175-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity whose
@@ -10509,7 +10536,7 @@ underlying entity is a type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb176"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb176-1"><a href="#cb176-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb176-2"><a href="#cb176-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias or
@@ -10518,7 +10545,7 @@ namespace alias, respectively <span class="note"><span>[ <em>Note
 alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb177"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb177-1"><a href="#cb177-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">22</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -10526,7 +10553,7 @@ alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <div class="sourceCode" id="cb178"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb178-1"><a href="#cb178-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb178-2"><a href="#cb178-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb178-3"><a href="#cb178-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a conversion function,
@@ -10541,7 +10568,7 @@ operator function, or literal operator, respectively. Otherwise,
 <span id="cb179-7"><a href="#cb179-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb179-8"><a href="#cb179-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb179-9"><a href="#cb179-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -10551,14 +10578,14 @@ operator, a copy assignment operator, a move assignment operator, or a
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb180"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">26</a></span>
 <span class="note"><span>[ <em>Note 4:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -10575,7 +10602,7 @@ is
 <span id="cb181-7"><a href="#cb181-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb181-8"><a href="#cb181-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb181-9"><a href="#cb181-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">27</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -10584,7 +10611,7 @@ template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">28</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -10593,14 +10620,14 @@ template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -10611,7 +10638,7 @@ Otherwise,
 <span id="cb185-3"><a href="#cb185-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-4"><a href="#cb185-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-5"><a href="#cb185-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -10619,19 +10646,19 @@ namespace member, non-static data member, static member, or direct base
 class relationship, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">33</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a value, object, variable, function that is not a constructor or
 destructor, enumerator, non-static data member, bit-field, direct base
 class relationship, or data member description.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">34</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 entity, object, or value, then a reflection of the type of what is
 represented by <code class="sourceCode cpp">r</code>. Otherwise, if
@@ -10646,11 +10673,11 @@ Otherwise, for a data member description
 a reflection of the type
 <code class="sourceCode cpp"><em>T</em></code>.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">35</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either an object or a variable denoting an
 object with static storage duration ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">36</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> is a
 reflection of a variable, then a reflection of the object denoted by the
 variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
@@ -10666,33 +10693,33 @@ variable. Otherwise, <code class="sourceCode cpp">r</code>.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">37</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(37.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">(37.1)</a></span>
 either an object or variable, usable in constant expressions from some
 point in the evaluation context ([expr.const]), whose type is a
 structural type ([temp.type]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(37.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(37.2)</a></span>
 an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(37.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(37.3)</a></span>
 a value.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">38</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">(38.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(38.1)</a></span>
 If <code class="sourceCode cpp">r</code> is a reflection of an object
 <code class="sourceCode cpp">o</code>, or a reflection of a variable
 which designates an object <code class="sourceCode cpp">o</code>, then a
 reflection of the value held by <code class="sourceCode cpp">o</code>.
 The reflected value has type <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
 with the cv-qualifiers removed if this is a scalar type</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(38.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(38.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> is a reflection of
 an enumerator, then a reflection of the value of the enumerator.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(38.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(38.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="example">
@@ -10708,13 +10735,13 @@ Otherwise, <code class="sourceCode cpp">r</code>.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">39</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable, structured binding, function, enumerator, class, class
 member, bit-field, template, namespace or namespace alias (other than
 <code class="sourceCode cpp"><span class="op">::</span></code>), type
 alias, or direct base class relationship.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">40</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a direct member of an anonymous union,
 then a reflection representing the innermost enclosing anonymous union.
@@ -10722,10 +10749,10 @@ Otherwise, a reflection of the class, function, or namespace that is the
 target scope ([basic.scope.scope]) of the first declaration of what is
 represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">41</a></span>
 <em>Returns</em>: A reflection representing the underlying entity of
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">42</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">42</a></span></p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
 <div class="sourceCode" id="cb194"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -10737,15 +10764,15 @@ represented by <code class="sourceCode cpp">r</code>.</p>
 </div>
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">43</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">44</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">44</a></span>
 <em>Returns</em>: A reflection of the primary template of
 <code class="sourceCode cpp">r</code>, and the reflections of the
 template arguments of the specialization represented by
 <code class="sourceCode cpp">r</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">45</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">45</a></span></p>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
 <div class="sourceCode" id="cb196"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
@@ -10769,11 +10796,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either a class type that is complete from some
 point in the evaluation context or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
 A member of a class or namespace
 <code class="sourceCode cpp"><em>E</em></code> is
 <em>members-of-representable</em> if it is either</p>
@@ -10796,7 +10823,7 @@ members-of-representable,</li>
 members-of-representable members include: injected class names, partial
 template specializations, friend declarations, and static
 assertions.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">3</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace is <em>members-of-reachable</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if there exists a
@@ -10807,7 +10834,7 @@ declaration <code class="sourceCode cpp"><em>D</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> is declared in the
 translation unit containing
 <code class="sourceCode cpp"><em>P</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">4</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members-of-representable members of the
 entity represented by <code class="sourceCode cpp">r</code> that are
@@ -10822,10 +10849,10 @@ but the order of namespace members is unspecified. <span class="note"><span>[ <
 members. Implicitly-declared special members appear after any
 user-declared members.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">6</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp">C</code> be the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -10835,70 +10862,70 @@ relationships are indexed in the order in which the corresponding base
 classes appear in the <em>base-specifier-list</em> of
 <code class="sourceCode cpp">C</code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">8</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_variable<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">10</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_nonstatic_data_member<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">11</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">has_complete_definition<span class="op">(</span>dealias<span class="op">(</span>type_enum<span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">12</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
 in the order in which they are declared.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">13</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">14</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_bases<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">15</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">16</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">bases_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_static_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">17</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">18</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">static_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, in
 order.</p>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> get_public_nonstatic_data_members<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">19</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">20</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_public<span class="op">(</span>e<span class="op">)</span></code>
@@ -10913,22 +10940,22 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or direct base class
 relationship other than a virtual base class of an abstract class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the offset in bits
 from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, direct base class relationship, or data
@@ -10936,7 +10963,7 @@ member description. If <code class="sourceCode cpp">dealias<span class="op">(</s
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member whose corresponding subobject has type
 <code class="sourceCode cpp"><em>T</em></code>, or a data member
@@ -10954,7 +10981,7 @@ corresponding to a non-static data member of reference type has the same
 size and alignment as the corresponding pointer type.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing a type, object, variable, non-static data
 member that is not a bit-field, direct base class relationship, or data
@@ -10962,21 +10989,21 @@ member description. If <code class="sourceCode cpp">dealias<span class="op">(</s
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(8.1)</a></span>
 If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, variable, or object, then the alignment requirement
 of the entity or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(8.4)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -10986,7 +11013,7 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 The value <code class="sourceCode cpp"><em>A</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, unnamed bit-field, direct base class
@@ -10994,7 +11021,7 @@ relationship, or data member description. If <code class="sourceCode cpp">dealia
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">10</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member that is a bit-field or unnamed bit-field with
 width <code class="sourceCode cpp"><em>W</em></code>, or a data member
@@ -11012,32 +11039,32 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when the type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a variable or object of type <code class="sourceCode cpp">U</code> that
 is usable in constant expressions from some point in the evaluation
 context and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">5</a></span>
 <em>Returns</em>: the object represented by <code class="sourceCode cpp">object_of<span class="op">(</span>r<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(6.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X</code>, then when
@@ -11045,7 +11072,7 @@ member of a class <code class="sourceCode cpp">C</code> with type
 <code class="sourceCode cpp">X C<span class="op">::*</span></code> and
 <code class="sourceCode cpp">r</code> does not represent a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(6.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 implicit object member function of class
 <code class="sourceCode cpp">C</code> with type
@@ -11053,7 +11080,7 @@ implicit object member function of class
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>,
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -11061,58 +11088,58 @@ type <code class="sourceCode cpp">F</code> or
 then when <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">7</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a pointer type, then a
 pointer value pointing to the entity represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(7.2)</a></span>
 Otherwise, a pointer-to-member value designating the entity represented
 by <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-val</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value that
 <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value that <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">10</a></span>
 <em>Returns</em>: the value that <code class="sourceCode cpp">r</code>
 represents converted to <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">11</a></span>
 <em>Effects</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">12</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">12</a></span>
 If <code class="sourceCode cpp">T</code> is a reference type, then
 equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">13</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">13</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, non-static data member, or member function, equivalent to
 <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</code></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">14</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">14</a></span>
 Otherwise, equivalent to <code class="sourceCode cpp"><span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span></code></li>
 </ul>
 </div>
@@ -11130,40 +11157,40 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb215-5"><a href="#cb215-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^^</span>Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">8</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span><code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">..&gt;</span></code>
 is not instantiated.<span> — <em>end note</em> ]</span></span></p>
 </div>
@@ -11176,32 +11203,32 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is neither a reference type nor an array type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">2</a></span>
 <em>Constant When</em>: Any value computed by
 <code class="sourceCode cpp">expr</code> having pointer type, or every
 subobject of the value computed by
 <code class="sourceCode cpp">expr</code> having pointer or reference
 type, is the address of or refers to an object or function that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">(2.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">(2.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">(2.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">(2.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">(2.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">3</a></span>
 <em>Returns</em>: A reflection of the value computed by an
 lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>. The type of the represented
@@ -11209,37 +11236,37 @@ value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">4</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates an object or function that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">(5.1)</a></span>
 is a permitted result of a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">(5.2)</a></span>
 is not a temporary object ([class.temporary]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">(5.3)</a></span>
 is not a string literal object ([lex.string]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">(5.4)</a></span>
 is not the result of a
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expression ([expr.typeid]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">(5.5)</a></span>
 is not an object associated with a predefined
 <code class="sourceCode cpp"><span class="ot">__func__</span></code>
 variable ([dcl.fct.def.general]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">6</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">7</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="op">^^</span>fn</code>, where
 <code class="sourceCode cpp">fn</code> is the function designated by
@@ -11252,7 +11279,7 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">name_type</code> are consteval-only types
 ([basic.types.general]), and are not a structural types
@@ -11275,12 +11302,12 @@ The classes <code class="sourceCode cpp">data_member_options</code> and
 <span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span>name_type<span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>value<span class="op">)</span></code>.</p>
 <div class="note">
@@ -11301,64 +11328,64 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp">cv <em>T</em></code>
 where <code class="sourceCode cpp"><em>T</em></code> is either an object
 type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(4.3)</a></span>
 otherwise, if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(4.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">(4.5.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(4.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">(4.5.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(4.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">(4.5.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">(4.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">(4.5.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em> <span class="op">==</span> <span class="dv">0</span></code>
 then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -11367,10 +11394,10 @@ does not contain a value.</li>
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type or type alias
 represented by <code class="sourceCode cpp">type</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
@@ -11378,23 +11405,23 @@ or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</spa
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 is empty,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 is empty,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or <code class="sourceCode cpp"><span class="op">-</span><span class="dv">1</span></code>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 is empty, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">6</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>. Certain other
@@ -11406,7 +11433,7 @@ query the characteristics indicated by the arguments provided to
 <code class="sourceCode cpp">data_member_spec</code>.<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
@@ -11414,7 +11441,7 @@ description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">8</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -11422,7 +11449,7 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(8.1)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a complete type
 from some point in the evaluation context, then
 <ul>
@@ -11439,18 +11466,18 @@ describes a data member with all of the same properties as the
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> data member
 of <code class="sourceCode cpp"><em>C</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">(8.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(8.3)</a></span>
 the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is a complete type for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(8.4)</a></span>
 for every pair 0 ≤ <code class="sourceCode cpp"><em>K</em></code> &lt;
 <code class="sourceCode cpp"><em>L</em></code> &lt; <code class="sourceCode cpp">mdescrs<span class="op">.</span>size<span class="op">()</span></code>,
 if <code class="sourceCode cpp">has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">&amp;&amp;</span> has_identifier<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>,
@@ -11464,7 +11491,7 @@ be unique.<span> — <em>end note</em> ]</span></span></li>
 </span><code class="sourceCode cpp"><em>C</em></code> could be a class
 template specialization for which there is no reachable
 definition.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">9</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -11475,26 +11502,26 @@ values such that</p>
 <p>for every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the manifestly constant-evaluated expression currently
 under evaluation.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a class template <code class="sourceCode cpp"><em>T</em></code>, then
 <code class="sourceCode cpp"><em>D</em></code> is is an explicit
 specialization of <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">(10.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(10.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 reflection value
@@ -11507,28 +11534,28 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(10.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(10.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 type or type alias represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(10.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(10.6)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> is
 declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(10.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(10.7)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(10.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(10.8)</a></span>
 A non-static data member corresponding to a reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> for which <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(10.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">(10.9)</a></span>
 A non-static data member or unnamed bit-field corresponding to a
 reflection
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with a
@@ -11540,18 +11567,18 @@ does not contain a value, an unnamed bit-field is declared.</li>
 determined by the character sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 in UTF-8.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(10.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">(10.10)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially default constructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 default constructor which has no effect.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(10.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(10.11)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a union type for
 which any of its members are not trivially destructible, then
 <code class="sourceCode cpp"><em>D</em></code> has a user-provided
 destructor which has no effect.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -11561,10 +11588,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -11583,7 +11610,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11604,7 +11631,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb229-13"><a href="#cb229-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-14"><a href="#cb229-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb229-15"><a href="#cb229-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -11630,7 +11657,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11651,7 +11678,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -11660,7 +11687,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TYPE</em></code>
@@ -11669,7 +11696,7 @@ defined in this clause with signature <code class="sourceCode cpp"><span class="
 or <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp">std<span class="op">::</span><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11753,12 +11780,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb233"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
 <div class="sourceCode" id="cb234"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> std<span class="op">::</span>extent_v<span class="op">&lt;</span>T, i<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">type</code>.</p>
@@ -11770,17 +11797,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">1</a></span>
 The consteval functions specified in this clause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type</code>
 defined in this clause with signature <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>REL</em>_type<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11790,7 +11817,7 @@ each binary function template <code class="sourceCode cpp">std<span class="op">:
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11817,7 +11844,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb235-15"><a href="#cb235-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb235-16"><a href="#cb235-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb235-17"><a href="#cb235-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -11839,7 +11866,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -11851,7 +11878,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11871,7 +11898,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11888,7 +11915,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11904,7 +11931,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11920,7 +11947,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em></code>
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
@@ -11946,14 +11973,14 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em></code>
 defined in this clause with signature <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>type_<em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>to<span class="op">&lt;</span>vector<span class="op">&gt;(</span>r<span class="op">)</span> <span class="op">==</span> vector<span class="op">{^^</span>T<span class="op">...}</span></code>
@@ -11962,7 +11989,7 @@ each unary function template <code class="sourceCode cpp">std<span class="op">::
 defined in this clause, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type <code class="sourceCode cpp">std<span class="op">::</span><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -11982,7 +12009,7 @@ returns the reflection of the corresponding type <code class="sourceCode cpp">st
 <span id="cb241-9"><a href="#cb241-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb241-10"><a href="#cb241-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb241-11"><a href="#cb241-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb242"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -12004,14 +12031,14 @@ Tuple and Variant Queries<a href="#meta.reflection.tuple.variant-tuple-and-varia
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
 defined in this clause with the signature <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp">std<span class="op">::</span><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 value <code class="sourceCode cpp">I</code>, for each function <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span><em>BINARY-TRAIT</em></code>
 defined in this clause with the signature <code class="sourceCode cpp">info<span class="op">(</span><span class="dt">size_t</span>, std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
@@ -12033,7 +12060,7 @@ not allow casting to or from <code class="sourceCode cpp">std<span class="op">::
 as a constant, in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">3</a></span>
 <em>Remarks</em>: This function is constexpr if and only if
 <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -12041,27 +12068,27 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(3.π)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(3.π)</a></span>
 <span class="addu"><code class="sourceCode cpp">is_reflection_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>


### PR DESCRIPTION
Mainly two things.
1. I audited every use of _id-expression_ in the Standard, and found a bunch of places where we need to account for _splice-expressions_.
2. The "struct to struct of arrays" example is broken in the face of the new injected declaration rules (i.e., it injected a declaration from an instantiation into the global namespace) - this "fixes" the example against our latest understanding of those rules.