### PR TITLE
[P2996] Update examples in the paper

### DIFF
--- a/2996_reflection/d2996r11.html
+++ b/2996_reflection/d2996r11.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-03-11" />
+  <meta name="dcterms.date" content="2025-03-12" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -575,7 +575,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-03-11</td>
+    <td>2025-03-12</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -759,10 +759,10 @@ definitions<span></span></a></li>
 <li><a href="#lex.phases-phases-of-translation" id="toc-lex.phases-phases-of-translation"><span>5.2
 <span>[lex.phases]</span></span> Phases of
 translation<span></span></a></li>
-<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.5
+<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.4
 <span>[lex.pptoken]</span></span> Preprocessing
 tokens<span></span></a></li>
-<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.8
+<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.12
 <span>[lex.operators]</span></span> Operators and
 punctuators<span></span></a></li>
 <li><a href="#basic.pre-preamble" id="toc-basic.pre-preamble"><span>6.1
@@ -804,21 +804,21 @@ dependence<span></span></a></li>
 <li><a href="#expr.prim-primary-expressions" id="toc-expr.prim-primary-expressions"><span>7.5
 <span>[expr.prim]</span></span> Primary
 expressions<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.5.2
+<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.4.2
 <span>[expr.prim.id.unqual]</span></span> Unqualified
 names<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
-<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.6.2
+<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.5.2
 <span>[expr.prim.lambda.closure]</span></span> Closure
 types<span></span></a></li>
-<li><a href="#expr.prim.lambda.capture-captures" id="toc-expr.prim.lambda.capture-captures"><span>7.5.6.3
+<li><a href="#expr.prim.lambda.capture-captures" id="toc-expr.prim.lambda.capture-captures"><span>7.5.5.3
 <span>[expr.prim.lambda.capture]</span></span>
 Captures<span></span></a></li>
-<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span class="toc-section-number">5.1.1</span> <span>7.5.8.3
+<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span class="toc-section-number">5.1.1</span> <span>7.5.7.3
 <span>[expr.prim.req.type]</span></span> Type
 requirements<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
@@ -1052,7 +1052,7 @@ Other transformations<span></span></a></li>
 <li><a href="#meta.reflection.misc-miscellaneous-reflection-queries" id="toc-meta.reflection.misc-miscellaneous-reflection-queries">[meta.reflection.misc],
 Miscellaneous Reflection Queries<span></span></a></li>
 </ul></li>
-<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.11.3
+<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.15.3
 <span>[bit.cast]</span></span> Function template
 <code class="sourceCode cpp">bit_cast</code><span></span></a></li>
 <li><a href="#diff.cpp23-annex-c-informative-compatibility" id="toc-diff.cpp23-annex-c-informative-compatibility"><span>C.1
@@ -1069,7 +1069,7 @@ Hagenberg<span></span></a></li>
 </div>
 <h1 data-number="1" style="border-bottom:1px solid #cccccc" id="revision-history"><span class="header-section-number">1</span>
 Revision History<a href="#revision-history" class="self-link"></a></h1>
-<p>Since <span class="citation" data-cites="P2996R10"><a href="https://wg21.link/p2996r10" role="doc-biblioref">[P2996R10]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R10">[<a href="https://wg21.link/p2996r10" role="doc-biblioref">P2996R10</a>]</span>:</p>
 <ul>
 <li>replaced <code class="sourceCode cpp">has_complete_definition</code>
 function with more narrow
@@ -1086,17 +1086,16 @@ immediate functions</li>
 enumerators called from within the containing
 <code class="sourceCode cpp"><em>enum-specifier</em></code></li>
 <li>minor editing and phrasing updates to address CWG feedback</li>
-<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13"><a href="https://wg21.link/p2786r13" role="doc-biblioref">[P2786R13] (Trivial Relocatability For
-C++26)</a></span></span></li>
+<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13">[<a href="https://wg21.link/p2786r13" role="doc-biblioref">P2786R13</a>]</span></span></li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R9"><a href="https://wg21.link/p2996r9" role="doc-biblioref">[P2996R9]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R9">[<a href="https://wg21.link/p2996r9" role="doc-biblioref">P2996R9</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
-<li>merge <span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1] (Consteval blocks)</a></span></span> into
-P2996. Replace the category of “plainly constant-evaluated expressions”
-with consteval blocks.</li>
+<li>merge <span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span> into P2996. Replace the
+category of “plainly constant-evaluated expressions” with consteval
+blocks.</li>
 <li>make the [expr.const] “scope rule” for injected declarations more
 rigorous; disallow escape from function parameter scopes</li>
 <li>revise [expr.reflect] grammar according to CWG feedback</li>
@@ -1104,7 +1103,7 @@ rigorous; disallow escape from function parameter scopes</li>
 arguments</li>
 <li>bring notes and examples into line with current definitions</li>
 <li>rebase [expr.const] onto latest from working draft (in particular,
-integrate changes from <span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+integrate changes from <span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>prefer “core constant expressions” to “manifestly constant-evaluated
 expression” in several places</li>
 <li>producing an injected declaration from a non-plainly
@@ -1122,14 +1121,14 @@ lieu of “core constant expression”)</li>
 <li>avoid referring to “permitted results of constant expressions” in
 wording for <code class="sourceCode cpp">reflect_value</code> and
 <code class="sourceCode cpp">reflect_object</code> (term was retired by
-<span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+<span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>template specializations and non-static data members of closure
 types are not <em>members-of-representable</em></li>
-<li>integrated <span class="title"><span class="citation" data-cites="P3547R1"><a href="https://isocpp.org/files/papers/P3547R1.html" role="doc-biblioref">[P3547R1] (Modeling Access Control With
-Reflection)</a></span></span> following its approval in (L)EWG.</li>
+<li>integrated <span class="title"><span class="citation" data-cites="P3547R1">[<a href="https://isocpp.org/files/papers/P3547R1.html" role="doc-biblioref">P3547R1</a>]</span></span> following its approval
+in (L)EWG.</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R8"><a href="https://wg21.link/p2996r8" role="doc-biblioref">[P2996R8]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R8">[<a href="https://wg21.link/p2996r8" role="doc-biblioref">P2996R8</a>]</span>:</p>
 <ul>
 <li>ensure <code class="sourceCode cpp">value_of</code> and
 <code class="sourceCode cpp">extract</code> are usable with reflections
@@ -1182,12 +1181,12 @@ complete-class contexts; rename to “<em>members-of-precedes</em>”</li>
 </ul></li>
 <li>fleshed out revision history for R8</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R7"><a href="https://wg21.link/p2996r7" role="doc-biblioref">[P2996R7]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R7">[<a href="https://wg21.link/p2996r7" role="doc-biblioref">P2996R7</a>]</span>:</p>
 <ul>
 <li>changed reflection operator from
 <code class="sourceCode cpp"><span class="op">^</span></code> to
 <code class="sourceCode cpp"><span class="op">^^</span></code> following
-adoption of <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span></li>
+adoption of <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span></li>
 <li>renamed <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>operator_symbol_of</code>
 to <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>symbol_of</code></li>
 <li>renamed some <code class="sourceCode cpp">operators</code>
@@ -1276,7 +1275,7 @@ base class relationship</em> to assist with specification of
 in [temp.arg.general]</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R6"><a href="https://wg21.link/p2996r6" role="doc-biblioref">[P2996R6]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R6">[<a href="https://wg21.link/p2996r6" role="doc-biblioref">P2996R6</a>]</span>:</p>
 <ul>
 <li>removed the <code class="sourceCode cpp">accessible_members</code>
 family of functions</li>
@@ -1295,7 +1294,7 @@ functions, tweaked enumerator names in <code class="sourceCode cpp">std<span cla
 completeness with
 <code class="sourceCode cpp">is_user_provided</code></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R5"><a href="https://wg21.link/p2996r5" role="doc-biblioref">[P2996R5]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R5">[<a href="https://wg21.link/p2996r5" role="doc-biblioref">P2996R5</a>]</span>:</p>
 <ul>
 <li>fixed broken “Emulating typeful reflection” example.</li>
 <li>removed linkage restrictions on objects of consteval-only type that
@@ -1316,7 +1315,7 @@ Aliases”</a> section.</li>
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
 <li>removed <code class="sourceCode cpp">subobjects_of</code> and
 <code class="sourceCode cpp">accessible_subobjects_of</code> (will be
-reintroduced by <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>).</li>
+reintroduced by <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>).</li>
 <li>specified constraints for
 <code class="sourceCode cpp">enumerators_of</code> in terms of
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
@@ -1338,7 +1337,7 @@ with core language terminology.</li>
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” over “alias
 of a type” in formal wording.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span>:</p>
 <ul>
 <li>removed filters from query functions</li>
 <li>cleaned up accessibility interface, removed
@@ -1380,7 +1379,7 @@ comparison among reflections returned by it.</li>
 <code class="sourceCode cpp">is_complete_type</code></li>
 <li>Many wording updates in response to feedback from CWG.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R3"><a href="https://wg21.link/p2996r3" role="doc-biblioref">[P2996R3]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R3">[<a href="https://wg21.link/p2996r3" role="doc-biblioref">P2996R3</a>]</span>:</p>
 <ul>
 <li>changes to name functions to improve Unicode-friendliness; added
 <code class="sourceCode cpp">u8name_of</code>,
@@ -1406,7 +1405,7 @@ object; added <code class="sourceCode cpp">object_of</code>
 metafunction</li>
 <li>more wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R2"><a href="https://wg21.link/p2996r2" role="doc-biblioref">[P2996R2]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R2">[<a href="https://wg21.link/p2996r2" role="doc-biblioref">P2996R2</a>]</span>:</p>
 <ul>
 <li>many wording changes, additions, and improvements</li>
 <li>elaborated on equivalence among reflections and linkage of templated
@@ -1447,8 +1446,8 @@ functions, not member function templates</li>
 text</a></li>
 <li>added a section discussing ODR concerns</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R1"><a href="https://wg21.link/p2996r1" role="doc-biblioref">[P2996R1]</a></span>, several changes to the
-overall library API:</p>
+<p>Since <span class="citation" data-cites="P2996R1">[<a href="https://wg21.link/p2996r1" role="doc-biblioref">P2996R1</a>]</span>, several changes to the overall
+library API:</p>
 <ul>
 <li>added <code class="sourceCode cpp">qualified_name_of</code> (to
 partner with <code class="sourceCode cpp">name_of</code>)</li>
@@ -1472,7 +1471,7 @@ reflection</a>.</li>
 freestanding.</li>
 <li>adding lots of wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R0"><a href="https://wg21.link/p2996r0" role="doc-biblioref">[P2996R0]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R0">[<a href="https://wg21.link/p2996r0" role="doc-biblioref">P2996R0</a>]</span>:</p>
 <ul>
 <li>added links to Compiler Explorer demonstrating just about all of the
 examples</li>
@@ -1491,7 +1490,7 @@ for exceptions (removing invalid reflections)</li>
 Introduction<a href="#introduction" class="self-link"></a></h1>
 <p>This is a proposal for a reduced initial set of features to support
 static reflection in C++. Specifically, we are mostly proposing a subset
-of features suggested in <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>:</p>
+of features suggested in <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>:</p>
 <ul>
 <li>the representation of program elements via constant-expressions
 producing <em>reflection values</em> — <em>reflections</em> for short —
@@ -1517,7 +1516,7 @@ and compile-time metaprogramming are concerned. Instead, we expect it
 will be a useful core around which more powerful features will be added
 incrementally over time. In particular, we believe that most or all the
 remaining features explored in P1240R2 and that code injection (along
-the lines described in <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>) are desirable directions to
+the lines described in <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>) are desirable directions to
 pursue.</p>
 <p>Our choice to start with something smaller is primarily motivated by
 the belief that that improves the chances of these facilities making it
@@ -1531,7 +1530,7 @@ predicates (such as <code class="sourceCode cpp">is_class_v</code>) in
 reflection computations.</p>
 <p>One addition does stand out, however: We have added metafunctions
 that permit the synthesis of simple struct and union types. While it is
-not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>), it can be remarkably
+not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>), it can be remarkably
 effective in practice.</p>
 <h2 data-number="2.2" id="why-a-single-opaque-reflection-type"><span class="header-section-number">2.2</span> Why a single opaque reflection
 type?<a href="#why-a-single-opaque-reflection-type" class="self-link"></a></h2>
@@ -1677,17 +1676,9 @@ rely on these features, and it is possible to do without them - but it
 would greatly help the usability experience if those could be adopted as
 well:</p>
 <ul>
-<li><span class="title"><span class="citation" data-cites="P1306R2"><a href="https://wg21.link/p1306r2" role="doc-biblioref">[P1306R2]
-(Expansion statements)</a></span></span></li>
-<li><span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]
-(Consteval blocks)</a></span></span></li>
-<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7"><a href="https://wg21.link/p0784r7" role="doc-biblioref">[P0784R7] (More
-constexpr containers)</a></span></span>, <span class="title"><span class="citation" data-cites="P1974R0"><a href="https://wg21.link/p1974r0" role="doc-biblioref">[P1974R0]
-(Non-transient constexpr allocation using propconst)</a></span></span>,
-<span class="title"><span class="citation" data-cites="P2670R1"><a href="https://wg21.link/p2670r1" role="doc-biblioref">[P2670R1]
-(Non-transient constexpr allocation)</a></span></span>, <span class="title"><span class="citation" data-cites="P3554R0"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3554R0]
-(Non-transient allocation with std::vector and
-std::basic_string)</a></span></span></li>
+<li><span class="title"><span class="citation" data-cites="P1306R2">[<a href="https://wg21.link/p1306r2" role="doc-biblioref">P1306R2</a>]</span></span></li>
+<li><span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span></li>
+<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7">[<a href="https://wg21.link/p0784r7" role="doc-biblioref">P0784R7</a>]</span></span>, <span class="title"><span class="citation" data-cites="P1974R0">[<a href="https://wg21.link/p1974r0" role="doc-biblioref">P1974R0</a>]</span></span>, <span class="title"><span class="citation" data-cites="P2670R1">[<a href="https://wg21.link/p2670r1" role="doc-biblioref">P2670R1</a>]</span></span>, <span class="title"><span class="citation" data-cites="P3554R0">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3554R0</a>]</span></span></li>
 </ul>
 <h2 data-number="3.1" id="back-and-forth"><span class="header-section-number">3.1</span> Back-And-Forth<a href="#back-and-forth" class="self-link"></a></h2>
 <p>Our first example is not meant to be compelling but to show how to go
@@ -1747,17 +1738,18 @@ members of a given type. We could thus rewrite the above example as:</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">{</span> <span class="dt">unsigned</span> i<span class="op">:</span><span class="dv">2</span>, j<span class="op">:</span><span class="dv">6</span>; <span class="op">}</span>;</span>
 <span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> member_number<span class="op">(</span><span class="dt">int</span> n<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>meta<span class="op">::</span>nonstatic_data_members_of<span class="op">(^^</span>S<span class="op">)[</span>n<span class="op">]</span>;</span>
-<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>  S s<span class="op">{</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">}</span>;</span>
-<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_number<span class="op">(</span><span class="dv">1</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">42</span>;  <span class="co">// Same as: s.j = 42;</span></span>
-<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_number<span class="op">(</span><span class="dv">5</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">0</span>;   <span class="co">// Error (member_number(5) is not a constant).</span></span>
-<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>meta<span class="op">::</span>nonstatic_data_members_of<span class="op">(^^</span>S, ctx<span class="op">)[</span>n<span class="op">]</span>;</span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>  S s<span class="op">{</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">}</span>;</span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_number<span class="op">(</span><span class="dv">1</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">42</span>;  <span class="co">// Same as: s.j = 42;</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_number<span class="op">(</span><span class="dv">5</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">0</span>;   <span class="co">// Error (member_number(5) is not a constant).</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/7P3ax5K16">EDG</a>, <a href="https://godbolt.org/z/8M5jP9d9E">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/7P3ax5K16">EDG</a>, <a href="https://godbolt.org/z/naTTzGebr">Clang</a>.</p>
 <p>This proposal specifies that namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 associated with the reflection type (<code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>);
@@ -1773,20 +1765,21 @@ conceivably access non-static data members “by string”:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">{</span> <span class="dt">unsigned</span> i<span class="op">:</span><span class="dv">2</span>, j<span class="op">:</span><span class="dv">6</span>; <span class="op">}</span>;</span>
 <span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> member_named<span class="op">(</span>std<span class="op">::</span>string_view name<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info field <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>S<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>has_identifier<span class="op">(</span>field<span class="op">)</span> <span class="op">&amp;&amp;</span> identifier_of<span class="op">(</span>field<span class="op">)</span> <span class="op">==</span> name<span class="op">)</span></span>
-<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> field;</span>
-<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>  S s<span class="op">{</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">}</span>;</span>
-<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_named<span class="op">(</span><span class="st">&quot;j&quot;</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">42</span>;  <span class="co">// Same as: s.j = 42;</span></span>
-<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_named<span class="op">(</span><span class="st">&quot;x&quot;</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">0</span>;   <span class="co">// Error (member_named(&quot;x&quot;) is not a constant).</span></span>
-<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info field <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>S, ctx<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>has_identifier<span class="op">(</span>field<span class="op">)</span> <span class="op">&amp;&amp;</span> identifier_of<span class="op">(</span>field<span class="op">)</span> <span class="op">==</span> name<span class="op">)</span></span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> field;</span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>  S s<span class="op">{</span><span class="dv">0</span>, <span class="dv">0</span><span class="op">}</span>;</span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_named<span class="op">(</span><span class="st">&quot;j&quot;</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">42</span>;  <span class="co">// Same as: s.j = 42;</span></span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>  s<span class="op">.[:</span>member_named<span class="op">(</span><span class="st">&quot;x&quot;</span><span class="op">):]</span> <span class="op">=</span> <span class="dv">0</span>;   <span class="co">// Error (member_named(&quot;x&quot;) is not a constant).</span></span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/hhd9vePW7">EDG</a>, <a href="https://godbolt.org/z/1hP77jbsd">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/hhd9vePW7">EDG</a>, <a href="https://godbolt.org/z/q3c55jsKE">Clang</a>.</p>
 <h2 data-number="3.3" id="list-of-types-to-list-of-sizes"><span class="header-section-number">3.3</span> List of Types to List of
 Sizes<a href="#list-of-types-to-list-of-sizes" class="self-link"></a></h2>
 <p>Here, <code class="sourceCode cpp">sizes</code> will be a <code class="sourceCode cpp">std<span class="op">::</span>array<span class="op">&lt;</span>std<span class="op">::</span><span class="dt">size_t</span>, <span class="dv">3</span><span class="op">&gt;</span></code>
@@ -1855,64 +1848,75 @@ will only involve one evaluation of <code class="sourceCode cpp">make_integer_se
 <span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a><span class="co">// returns std::array&lt;member_descriptor, N&gt;</span></span>
 <span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> S<span class="op">&gt;</span></span>
 <span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> get_layout<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> members <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>S<span class="op">)</span>;</span>
-<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>array<span class="op">&lt;</span>member_descriptor, members<span class="op">.</span>size<span class="op">()&gt;</span> layout;</span>
-<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span><span class="dt">int</span> i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> members<span class="op">.</span>size<span class="op">()</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>      layout<span class="op">[</span>i<span class="op">]</span> <span class="op">=</span> <span class="op">{.</span>offset<span class="op">=</span>offset_of<span class="op">(</span>members<span class="op">[</span>i<span class="op">]).</span>bytes, <span class="op">.</span>size<span class="op">=</span>size_of<span class="op">(</span>members<span class="op">[</span>i<span class="op">])}</span>;</span>
-<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> layout;</span>
-<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb12-18"><a href="#cb12-18" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> X</span>
-<span id="cb12-19"><a href="#cb12-19" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
-<span id="cb12-20"><a href="#cb12-20" aria-hidden="true" tabindex="-1"></a>    <span class="dt">char</span> a;</span>
-<span id="cb12-21"><a href="#cb12-21" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> b;</span>
-<span id="cb12-22"><a href="#cb12-22" aria-hidden="true" tabindex="-1"></a>    <span class="dt">double</span> c;</span>
-<span id="cb12-23"><a href="#cb12-23" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb12-24"><a href="#cb12-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb12-25"><a href="#cb12-25" aria-hidden="true" tabindex="-1"></a><span class="co">/*constexpr*/</span> <span class="kw">auto</span> Xd <span class="op">=</span> get_layout<span class="op">&lt;</span>X<span class="op">&gt;()</span>;</span>
-<span id="cb12-26"><a href="#cb12-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb12-27"><a href="#cb12-27" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
-<span id="cb12-28"><a href="#cb12-28" aria-hidden="true" tabindex="-1"></a><span class="co">where Xd would be std::array&lt;member_descriptor, 3&gt;{{</span></span>
-<span id="cb12-29"><a href="#cb12-29" aria-hidden="true" tabindex="-1"></a><span class="co">  { 0, 1 }, { 4, 4 }, { 8, 8 }</span></span>
-<span id="cb12-30"><a href="#cb12-30" aria-hidden="true" tabindex="-1"></a><span class="co">}}</span></span>
-<span id="cb12-31"><a href="#cb12-31" aria-hidden="true" tabindex="-1"></a><span class="co">*/</span></span></code></pre></div>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">size_t</span> N <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>nonstatic_data_members_of<span class="op">(^^</span>S, ctx<span class="op">).</span>size<span class="op">()</span>;</span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> members <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>nonstatic_data_members_of<span class="op">(^^</span>S, ctx<span class="op">)</span>;</span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>array<span class="op">&lt;</span>member_descriptor, N<span class="op">&gt;</span> layout;</span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span><span class="dt">int</span> i <span class="op">=</span> <span class="dv">0</span>; i <span class="op">&lt;</span> members<span class="op">.</span>size<span class="op">()</span>; <span class="op">++</span>i<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>      layout<span class="op">[</span>i<span class="op">]</span> <span class="op">=</span> <span class="op">{.</span>offset<span class="op">=</span>std<span class="op">::</span>meta<span class="op">::</span>offset_of<span class="op">(</span>members<span class="op">[</span>i<span class="op">]).</span>bytes,</span>
+<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a>                   <span class="op">.</span>size<span class="op">=</span>std<span class="op">::</span>meta<span class="op">::</span>size_of<span class="op">(</span>members<span class="op">[</span>i<span class="op">])}</span>;</span>
+<span id="cb12-18"><a href="#cb12-18" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb12-19"><a href="#cb12-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> layout;</span>
+<span id="cb12-20"><a href="#cb12-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb12-21"><a href="#cb12-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-22"><a href="#cb12-22" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> X</span>
+<span id="cb12-23"><a href="#cb12-23" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb12-24"><a href="#cb12-24" aria-hidden="true" tabindex="-1"></a>    <span class="dt">char</span> a;</span>
+<span id="cb12-25"><a href="#cb12-25" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> b;</span>
+<span id="cb12-26"><a href="#cb12-26" aria-hidden="true" tabindex="-1"></a>    <span class="dt">double</span> c;</span>
+<span id="cb12-27"><a href="#cb12-27" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb12-28"><a href="#cb12-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-29"><a href="#cb12-29" aria-hidden="true" tabindex="-1"></a><span class="co">/*constexpr*/</span> <span class="kw">auto</span> Xd <span class="op">=</span> get_layout<span class="op">&lt;</span>X<span class="op">&gt;()</span>;</span>
+<span id="cb12-30"><a href="#cb12-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-31"><a href="#cb12-31" aria-hidden="true" tabindex="-1"></a><span class="co">/*</span></span>
+<span id="cb12-32"><a href="#cb12-32" aria-hidden="true" tabindex="-1"></a><span class="co">where Xd would be std::array&lt;member_descriptor, 3&gt;{{</span></span>
+<span id="cb12-33"><a href="#cb12-33" aria-hidden="true" tabindex="-1"></a><span class="co">  { 0, 1 }, { 4, 4 }, { 8, 8 }</span></span>
+<span id="cb12-34"><a href="#cb12-34" aria-hidden="true" tabindex="-1"></a><span class="co">}}</span></span>
+<span id="cb12-35"><a href="#cb12-35" aria-hidden="true" tabindex="-1"></a><span class="co">*/</span></span></code></pre></div>
 </blockquote>
 </div>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/ss9hfaMKT">EDG</a>, <a href="https://godbolt.org/z/Wq13c7Gsv">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/ss9hfaMKT">EDG</a>, <a href="https://godbolt.org/z/doe83nGze">Clang</a>.</p>
 <h2 data-number="3.6" id="enum-to-string"><span class="header-section-number">3.6</span> Enum to String<a href="#enum-to-string" class="self-link"></a></h2>
 <p>One of the most commonly requested facilities is to convert an enum
 value to a string (this example relies on expansion statements):</p>
 <div class="std">
 <blockquote>
-<div class="sourceCode" id="cb13"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> E<span class="op">&gt;</span></span>
+<div class="sourceCode" id="cb13"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">typename</span> E, <span class="dt">bool</span> Enumerable <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">)&gt;</span></span>
 <span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">requires</span> std<span class="op">::</span>is_enum_v<span class="op">&lt;</span>E<span class="op">&gt;</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> std<span class="op">::</span>string enum_to_string<span class="op">(</span>E value<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> e <span class="op">:</span> std<span class="op">::</span>meta<span class="op">::</span>enumerators_of<span class="op">(^^</span>E<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>value <span class="op">==</span> <span class="op">[:</span>e<span class="op">:])</span> <span class="op">{</span></span>
-<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> std<span class="op">::</span>string<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>identifier_of<span class="op">(</span>e<span class="op">))</span>;</span>
-<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> std<span class="op">::</span>string_view enum_to_string<span class="op">(</span>E value<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>Enumerable<span class="op">)</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> e <span class="op">:</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a>                  std<span class="op">::</span>meta<span class="op">::</span>define_static_array<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>enumerators_of<span class="op">(^^</span>E<span class="op">)))</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> <span class="op">(</span>value <span class="op">==</span> <span class="op">[:</span>e<span class="op">:])</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> std<span class="op">::</span>meta<span class="op">::</span>identifier_of<span class="op">(</span>e<span class="op">)</span>;</span>
 <span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="st">&quot;&lt;unnamed&gt;&quot;</span>;</span>
 <span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
 <span id="cb13-12"><a href="#cb13-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> Color <span class="op">{</span> red, green, blue <span class="op">}</span>;</span>
-<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>enum_to_string<span class="op">(</span>Color<span class="op">::</span>red<span class="op">)</span> <span class="op">==</span> <span class="st">&quot;red&quot;</span><span class="op">)</span>;</span>
-<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>enum_to_string<span class="op">(</span>Color<span class="op">(</span><span class="dv">42</span><span class="op">))</span> <span class="op">==</span> <span class="st">&quot;&lt;unnamed&gt;&quot;</span><span class="op">)</span>;</span></code></pre></div>
+<span id="cb13-13"><a href="#cb13-13" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb13-14"><a href="#cb13-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">enum</span> Color <span class="op">:</span> <span class="dt">int</span>;</span>
+<span id="cb13-15"><a href="#cb13-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(</span>enum_to_string<span class="op">(</span>Color<span class="op">(</span><span class="dv">0</span><span class="op">))</span> <span class="op">==</span> <span class="st">&quot;&lt;unnamed&gt;&quot;</span><span class="op">)</span>;</span>
+<span id="cb13-16"><a href="#cb13-16" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>println<span class="op">(</span><span class="st">&quot;Color 0: {}&quot;</span>, enum_to_string<span class="op">(</span>Color<span class="op">(</span><span class="dv">0</span><span class="op">)))</span>;  <span class="co">// prints &#39;&lt;unnamed&gt;&#39;</span></span>
+<span id="cb13-17"><a href="#cb13-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">enum</span> Color <span class="op">:</span> <span class="dt">int</span> <span class="op">{</span> red, green, blue <span class="op">}</span>;</span>
+<span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(</span>enum_to_string<span class="op">(</span>Color<span class="op">::</span>red<span class="op">)</span> <span class="op">==</span> <span class="st">&quot;red&quot;</span><span class="op">)</span>;</span>
+<span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(</span>enum_to_string<span class="op">(</span>Color<span class="op">(</span><span class="dv">42</span><span class="op">))</span> <span class="op">==</span> <span class="st">&quot;&lt;unnamed&gt;&quot;</span><span class="op">)</span>;</span>
+<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>println<span class="op">(</span><span class="st">&quot;Color 0: {}&quot;</span>, enum_to_string<span class="op">(</span>Color<span class="op">(</span><span class="dv">0</span><span class="op">)))</span>;  <span class="co">// prints &#39;red&#39;</span></span>
+<span id="cb13-22"><a href="#cb13-22" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <p>We can also do the reverse in pretty much the same way:</p>
 <div class="std">
 <blockquote>
-<div class="sourceCode" id="cb14"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> E<span class="op">&gt;</span></span>
+<div class="sourceCode" id="cb14"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> E, <span class="dt">bool</span> Enumerable <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">)&gt;</span></span>
 <span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">requires</span> std<span class="op">::</span>is_enum_v<span class="op">&lt;</span>E<span class="op">&gt;</span></span>
 <span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> std<span class="op">::</span>optional<span class="op">&lt;</span>E<span class="op">&gt;</span> string_to_enum<span class="op">(</span>std<span class="op">::</span>string_view name<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> e <span class="op">:</span> std<span class="op">::</span>meta<span class="op">::</span>enumerators_of<span class="op">(^^</span>E<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>name <span class="op">==</span> std<span class="op">::</span>meta<span class="op">::</span>identifier_of<span class="op">(</span>e<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="op">[:</span>e<span class="op">:]</span>;</span>
-<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>Enumerable<span class="op">)</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> e <span class="op">:</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>                  std<span class="op">::</span>meta<span class="op">::</span>define_static_array<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>enumerators_of<span class="op">(^^</span>E<span class="op">)))</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> <span class="op">(</span>name <span class="op">==</span> std<span class="op">::</span>meta<span class="op">::</span>identifier_of<span class="op">(</span>e<span class="op">))</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> <span class="op">[:</span>e<span class="op">:]</span>;</span>
 <span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>nullopt;</span>
 <span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
@@ -1970,7 +1974,7 @@ to find the matching entry, a
 <code class="sourceCode cpp">std<span class="op">::</span>map</code>
 achieves the same with O(log(N)) complexity (where N is the number of
 enumerator constants).</p>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/hf777PfGo">EDG</a>, <a href="https://godbolt.org/z/h5rTnWrKW">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/hf777PfGo">EDG</a>, <a href="https://godbolt.org/z/TTxMs4fMa">Clang</a>.</p>
 <p>Many many variations of these functions are possible and beneficial
 depending on the needs of the client code. For example:</p>
 <ul>
@@ -1993,43 +1997,45 @@ parser would of course be more complex, this is just the beginning.</p>
 <div class="sourceCode" id="cb16"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">typename</span> Opts<span class="op">&gt;</span></span>
 <span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> parse_options<span class="op">(</span>std<span class="op">::</span>span<span class="op">&lt;</span>std<span class="op">::</span>string_view <span class="kw">const</span><span class="op">&gt;</span> args<span class="op">)</span> <span class="op">-&gt;</span> Opts <span class="op">{</span></span>
 <span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  Opts opts;</span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> dm <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>Opts<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> it <span class="op">=</span> std<span class="op">::</span>ranges<span class="op">::</span>find_if<span class="op">(</span>args,</span>
-<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="op">[](</span>std<span class="op">::</span>string_view arg<span class="op">){</span></span>
-<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> arg<span class="op">.</span>starts_with<span class="op">(</span><span class="st">&quot;--&quot;</span><span class="op">)</span> <span class="op">&amp;&amp;</span> arg<span class="op">.</span>substr<span class="op">(</span><span class="dv">2</span><span class="op">)</span> <span class="op">==</span> identifier_of<span class="op">(</span>dm<span class="op">)</span>;</span>
-<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="op">})</span>;</span>
-<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>it <span class="op">==</span> args<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>      <span class="co">// no option provided, use default</span></span>
-<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>      <span class="cf">continue</span>;</span>
-<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>it <span class="op">+</span> <span class="dv">1</span> <span class="op">==</span> args<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Option {} is missing a value</span><span class="sc">\n</span><span class="st">&quot;</span>, <span class="op">*</span>it<span class="op">)</span>;</span>
-<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
-<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> T <span class="op">=</span> <span class="kw">typename</span><span class="op">[:</span>type_of<span class="op">(</span>dm<span class="op">):]</span>;</span>
-<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> iss <span class="op">=</span> std<span class="op">::</span>ispanstream<span class="op">(</span>it<span class="op">[</span><span class="dv">1</span><span class="op">])</span>;</span>
-<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>iss <span class="op">&gt;&gt;</span> opts<span class="op">.[:</span>dm<span class="op">:]</span>; <span class="op">!</span>iss<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Failed to parse option {} into a {}</span><span class="sc">\n</span><span class="st">&quot;</span>, <span class="op">*</span>it, display_string_of<span class="op">(^^</span>T<span class="op">))</span>;</span>
-<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
-<span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> opts;</span>
-<span id="cb16-26"><a href="#cb16-26" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb16-28"><a href="#cb16-28" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> MyOpts <span class="op">{</span></span>
-<span id="cb16-29"><a href="#cb16-29" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>string file_name <span class="op">=</span> <span class="st">&quot;input.txt&quot;</span>;  <span class="co">// Option &quot;--file_name &lt;string&gt;&quot;</span></span>
-<span id="cb16-30"><a href="#cb16-30" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span>    count <span class="op">=</span> <span class="dv">1</span>;                     <span class="co">// Option &quot;--count &lt;int&gt;&quot;</span></span>
-<span id="cb16-31"><a href="#cb16-31" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb16-32"><a href="#cb16-32" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb16-33"><a href="#cb16-33" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">(</span><span class="dt">int</span> argc, <span class="dt">char</span> <span class="op">*</span>argv<span class="op">[])</span> <span class="op">{</span></span>
-<span id="cb16-34"><a href="#cb16-34" aria-hidden="true" tabindex="-1"></a>  MyOpts opts <span class="op">=</span> parse_options<span class="op">&lt;</span>MyOpts<span class="op">&gt;(</span>std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>string_view<span class="op">&gt;(</span>argv<span class="op">+</span><span class="dv">1</span>, argv<span class="op">+</span>argc<span class="op">))</span>;</span>
-<span id="cb16-35"><a href="#cb16-35" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ...</span></span>
-<span id="cb16-36"><a href="#cb16-36" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> dm <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>Opts, ctx<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> it <span class="op">=</span> std<span class="op">::</span>ranges<span class="op">::</span>find_if<span class="op">(</span>args,</span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>      <span class="op">[](</span>std<span class="op">::</span>string_view arg<span class="op">){</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> arg<span class="op">.</span>starts_with<span class="op">(</span><span class="st">&quot;--&quot;</span><span class="op">)</span> <span class="op">&amp;&amp;</span> arg<span class="op">.</span>substr<span class="op">(</span><span class="dv">2</span><span class="op">)</span> <span class="op">==</span> identifier_of<span class="op">(</span>dm<span class="op">)</span>;</span>
+<span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>      <span class="op">})</span>;</span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>it <span class="op">==</span> args<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a>      <span class="co">// no option provided, use default</span></span>
+<span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>      <span class="cf">continue</span>;</span>
+<span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>it <span class="op">+</span> <span class="dv">1</span> <span class="op">==</span> args<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Option {} is missing a value</span><span class="sc">\n</span><span class="st">&quot;</span>, <span class="op">*</span>it<span class="op">)</span>;</span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
+<span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">using</span> T <span class="op">=</span> <span class="kw">typename</span><span class="op">[:</span>type_of<span class="op">(</span>dm<span class="op">):]</span>;</span>
+<span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> iss <span class="op">=</span> std<span class="op">::</span>ispanstream<span class="op">(</span>it<span class="op">[</span><span class="dv">1</span><span class="op">])</span>;</span>
+<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> <span class="op">(</span>iss <span class="op">&gt;&gt;</span> opts<span class="op">.[:</span>dm<span class="op">:]</span>; <span class="op">!</span>iss<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Failed to parse option {} into a {}</span><span class="sc">\n</span><span class="st">&quot;</span>, <span class="op">*</span>it, display_string_of<span class="op">(^^</span>T<span class="op">))</span>;</span>
+<span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
+<span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb16-26"><a href="#cb16-26" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> opts;</span>
+<span id="cb16-28"><a href="#cb16-28" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb16-29"><a href="#cb16-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-30"><a href="#cb16-30" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> MyOpts <span class="op">{</span></span>
+<span id="cb16-31"><a href="#cb16-31" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>string file_name <span class="op">=</span> <span class="st">&quot;input.txt&quot;</span>;  <span class="co">// Option &quot;--file_name &lt;string&gt;&quot;</span></span>
+<span id="cb16-32"><a href="#cb16-32" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span>    count <span class="op">=</span> <span class="dv">1</span>;                     <span class="co">// Option &quot;--count &lt;int&gt;&quot;</span></span>
+<span id="cb16-33"><a href="#cb16-33" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb16-34"><a href="#cb16-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-35"><a href="#cb16-35" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">(</span><span class="dt">int</span> argc, <span class="dt">char</span> <span class="op">*</span>argv<span class="op">[])</span> <span class="op">{</span></span>
+<span id="cb16-36"><a href="#cb16-36" aria-hidden="true" tabindex="-1"></a>  MyOpts opts <span class="op">=</span> parse_options<span class="op">&lt;</span>MyOpts<span class="op">&gt;(</span>std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>string_view<span class="op">&gt;(</span>argv<span class="op">+</span><span class="dv">1</span>, argv<span class="op">+</span>argc<span class="op">))</span>;</span>
+<span id="cb16-37"><a href="#cb16-37" aria-hidden="true" tabindex="-1"></a>  <span class="co">// ...</span></span>
+<span id="cb16-38"><a href="#cb16-38" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <p>This example is based on a presentation by Matúš Chochlík.</p>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/jGfGv84oh">EDG</a>, <a href="https://godbolt.org/z/hfoP5P3sd">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/jGfGv84oh">EDG</a>, <a href="https://godbolt.org/z/5rYqnYWq4">Clang</a>.</p>
 <h2 data-number="3.8" id="a-simple-tuple-type"><span class="header-section-number">3.8</span> A Simple Tuple Type<a href="#a-simple-tuple-type" class="self-link"></a></h2>
 <div class="std">
 <blockquote>
@@ -2056,7 +2062,7 @@ parser would of course be more complex, this is just the beginning.</p>
 <span id="cb17-21"><a href="#cb17-21" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
 <span id="cb17-22"><a href="#cb17-22" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb17-23"><a href="#cb17-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> std<span class="op">::</span>meta<span class="op">::</span>info get_nth_field<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info r, std<span class="op">::</span><span class="dt">size_t</span> n<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb17-24"><a href="#cb17-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> nonstatic_data_members_of<span class="op">(</span>r<span class="op">)[</span>n<span class="op">]</span>;</span>
+<span id="cb17-24"><a href="#cb17-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> nonstatic_data_members_of<span class="op">(</span>r, std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">())[</span>n<span class="op">]</span>;</span>
 <span id="cb17-25"><a href="#cb17-25" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
 <span id="cb17-26"><a href="#cb17-26" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb17-27"><a href="#cb17-27" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span>std<span class="op">::</span><span class="dt">size_t</span> I, <span class="kw">typename</span><span class="op">...</span> Ts<span class="op">&gt;</span></span>
@@ -2077,7 +2083,7 @@ tricks that that involves when these facilities are not available.
 for an incomplete class or union plus a vector of non-static data member
 descriptions, and completes the give class or union type to have the
 described members.</p>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/76EojjcEe">EDG</a>, <a href="https://godbolt.org/z/cx8cr53q7">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/76EojjcEe">EDG</a>, <a href="https://godbolt.org/z/E9hxqKzE9">Clang</a>.</p>
 <h2 data-number="3.9" id="a-simple-variant-type"><span class="header-section-number">3.9</span> A Simple Variant Type<a href="#a-simple-variant-type" class="self-link"></a></h2>
 <p>Similarly to how we can implement a tuple using
 <code class="sourceCode cpp">define_aggregate</code> to create on the
@@ -2151,77 +2157,78 @@ demonstrate the idea:</p>
 <span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
 <span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">consteval</span> std<span class="op">::</span>meta<span class="op">::</span>info get_nth_field<span class="op">(</span>std<span class="op">::</span><span class="dt">size_t</span> n<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> nonstatic_data_members_of<span class="op">(^^</span>Storage<span class="op">)[</span>n<span class="op">+</span><span class="dv">1</span><span class="op">]</span>;</span>
-<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a>    Storage storage_;</span>
-<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> index_ <span class="op">=</span> <span class="op">-</span><span class="dv">1</span>;</span>
-<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a>    <span class="co">// cheat: use libstdc++&#39;s implementation</span></span>
-<span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">size_t</span> accepted_index <span class="op">=</span> std<span class="op">::</span>__detail<span class="op">::</span>__variant<span class="op">::</span>__accepted_index<span class="op">&lt;</span>T, std<span class="op">::</span>variant<span class="op">&lt;</span>Ts<span class="op">...&gt;&gt;</span>;</span>
-<span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-24"><a href="#cb20-24" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> F<span class="op">&gt;</span></span>
-<span id="cb20-25"><a href="#cb20-25" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> with_index<span class="op">(</span>F<span class="op">&amp;&amp;</span> f<span class="op">)</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb20-26"><a href="#cb20-26" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> mp_with_index<span class="op">&lt;</span><span class="kw">sizeof</span><span class="op">...(</span>Ts<span class="op">)&gt;(</span>index_, <span class="op">(</span>F<span class="op">&amp;&amp;)</span>f<span class="op">)</span>;</span>
-<span id="cb20-27"><a href="#cb20-27" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb20-28"><a href="#cb20-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-29"><a href="#cb20-29" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb20-30"><a href="#cb20-30" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">()</span> <span class="kw">requires</span> std<span class="op">::</span>is_default_constructible_v<span class="op">&lt;</span>Ts<span class="op">...[</span><span class="dv">0</span><span class="op">]&gt;</span></span>
-<span id="cb20-31"><a href="#cb20-31" aria-hidden="true" tabindex="-1"></a>        <span class="co">// should this work: storage_{. [: get_nth_field(0) :]{} }</span></span>
-<span id="cb20-32"><a href="#cb20-32" aria-hidden="true" tabindex="-1"></a>        <span class="op">:</span> storage_<span class="op">{.</span>empty<span class="op">={}}</span></span>
-<span id="cb20-33"><a href="#cb20-33" aria-hidden="true" tabindex="-1"></a>        , index_<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span>
-<span id="cb20-34"><a href="#cb20-34" aria-hidden="true" tabindex="-1"></a>    <span class="op">{</span></span>
-<span id="cb20-35"><a href="#cb20-35" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>construct_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">:])</span>;</span>
-<span id="cb20-36"><a href="#cb20-36" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb20-37"><a href="#cb20-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-38"><a href="#cb20-38" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="op">~</span>Variant<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span>std<span class="op">::</span>is_trivially_destructible_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb20-39"><a href="#cb20-39" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="op">~</span>Variant<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb20-40"><a href="#cb20-40" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> <span class="op">(</span>index_ <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb20-41"><a href="#cb20-41" aria-hidden="true" tabindex="-1"></a>            with_index<span class="op">([&amp;](</span><span class="kw">auto</span> I<span class="op">){</span></span>
-<span id="cb20-42"><a href="#cb20-42" aria-hidden="true" tabindex="-1"></a>                std<span class="op">::</span>destroy_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span>I<span class="op">)</span> <span class="op">:])</span>;</span>
-<span id="cb20-43"><a href="#cb20-43" aria-hidden="true" tabindex="-1"></a>            <span class="op">})</span>;</span>
-<span id="cb20-44"><a href="#cb20-44" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span></span>
-<span id="cb20-45"><a href="#cb20-45" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb20-46"><a href="#cb20-46" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-47"><a href="#cb20-47" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> I <span class="op">=</span> accepted_index<span class="op">&lt;</span>T<span class="op">&amp;&amp;&gt;&gt;</span></span>
-<span id="cb20-48"><a href="#cb20-48" aria-hidden="true" tabindex="-1"></a>        <span class="kw">requires</span> <span class="op">(!</span>std<span class="op">::</span>is_base_of_v<span class="op">&lt;</span>Variant, std<span class="op">::</span>decay_t<span class="op">&lt;</span>T<span class="op">&gt;&gt;)</span></span>
-<span id="cb20-49"><a href="#cb20-49" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">(</span>T<span class="op">&amp;&amp;</span> t<span class="op">)</span></span>
-<span id="cb20-50"><a href="#cb20-50" aria-hidden="true" tabindex="-1"></a>        <span class="op">:</span> storage_<span class="op">{.</span>empty<span class="op">={}}</span></span>
-<span id="cb20-51"><a href="#cb20-51" aria-hidden="true" tabindex="-1"></a>        , index_<span class="op">(-</span><span class="dv">1</span><span class="op">)</span></span>
-<span id="cb20-52"><a href="#cb20-52" aria-hidden="true" tabindex="-1"></a>    <span class="op">{</span></span>
-<span id="cb20-53"><a href="#cb20-53" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>construct_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span>I<span class="op">)</span> <span class="op">:]</span>, <span class="op">(</span>T<span class="op">&amp;&amp;)</span>t<span class="op">)</span>;</span>
-<span id="cb20-54"><a href="#cb20-54" aria-hidden="true" tabindex="-1"></a>        index_ <span class="op">=</span> <span class="op">(</span><span class="dt">int</span><span class="op">)</span>I;</span>
-<span id="cb20-55"><a href="#cb20-55" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb20-56"><a href="#cb20-56" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-57"><a href="#cb20-57" aria-hidden="true" tabindex="-1"></a>    <span class="co">// you can&#39;t actually express this constraint nicely until P2963</span></span>
-<span id="cb20-58"><a href="#cb20-58" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">(</span>Variant <span class="kw">const</span><span class="op">&amp;)</span> <span class="kw">requires</span> <span class="op">(</span>std<span class="op">::</span>is_trivially_copyable_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb20-59"><a href="#cb20-59" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">(</span>Variant <span class="kw">const</span><span class="op">&amp;</span> rhs<span class="op">)</span></span>
-<span id="cb20-60"><a href="#cb20-60" aria-hidden="true" tabindex="-1"></a>            <span class="kw">requires</span> <span class="op">((</span>std<span class="op">::</span>is_copy_constructible_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...)</span></span>
-<span id="cb20-61"><a href="#cb20-61" aria-hidden="true" tabindex="-1"></a>                <span class="kw">and</span> <span class="kw">not</span> <span class="op">(</span>std<span class="op">::</span>is_trivially_copyable_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...))</span></span>
-<span id="cb20-62"><a href="#cb20-62" aria-hidden="true" tabindex="-1"></a>        <span class="op">:</span> storage_<span class="op">{.</span>empty<span class="op">={}}</span></span>
-<span id="cb20-63"><a href="#cb20-63" aria-hidden="true" tabindex="-1"></a>        , index_<span class="op">(-</span><span class="dv">1</span><span class="op">)</span></span>
-<span id="cb20-64"><a href="#cb20-64" aria-hidden="true" tabindex="-1"></a>    <span class="op">{</span></span>
-<span id="cb20-65"><a href="#cb20-65" aria-hidden="true" tabindex="-1"></a>        rhs<span class="op">.</span>with_index<span class="op">([&amp;](</span><span class="kw">auto</span> I<span class="op">){</span></span>
-<span id="cb20-66"><a href="#cb20-66" aria-hidden="true" tabindex="-1"></a>            <span class="kw">constexpr</span> <span class="kw">auto</span> field <span class="op">=</span> get_nth_field<span class="op">(</span>I<span class="op">)</span>;</span>
-<span id="cb20-67"><a href="#cb20-67" aria-hidden="true" tabindex="-1"></a>            std<span class="op">::</span>construct_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> field <span class="op">:]</span>, rhs<span class="op">.</span>storage_<span class="op">.[:</span> field <span class="op">:])</span>;</span>
-<span id="cb20-68"><a href="#cb20-68" aria-hidden="true" tabindex="-1"></a>            index_ <span class="op">=</span> I;</span>
-<span id="cb20-69"><a href="#cb20-69" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
-<span id="cb20-70"><a href="#cb20-70" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb20-71"><a href="#cb20-71" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-72"><a href="#cb20-72" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> index<span class="op">()</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="dt">int</span> <span class="op">{</span> <span class="cf">return</span> index_; <span class="op">}</span></span>
-<span id="cb20-73"><a href="#cb20-73" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-74"><a href="#cb20-74" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> F<span class="op">&gt;</span></span>
-<span id="cb20-75"><a href="#cb20-75" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> visit<span class="op">(</span>F<span class="op">&amp;&amp;</span> f<span class="op">)</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb20-76"><a href="#cb20-76" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> <span class="op">(</span>index_ <span class="op">==</span> <span class="op">-</span><span class="dv">1</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb20-77"><a href="#cb20-77" aria-hidden="true" tabindex="-1"></a>            <span class="cf">throw</span> std<span class="op">::</span>bad_variant_access<span class="op">()</span>;</span>
-<span id="cb20-78"><a href="#cb20-78" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span></span>
-<span id="cb20-79"><a href="#cb20-79" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb20-80"><a href="#cb20-80" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> mp_with_index<span class="op">&lt;</span><span class="kw">sizeof</span><span class="op">...(</span>Ts<span class="op">)&gt;(</span>index_, <span class="op">[&amp;](</span><span class="kw">auto</span> I<span class="op">)</span> <span class="op">-&gt;</span> <span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span> <span class="op">{</span></span>
-<span id="cb20-81"><a href="#cb20-81" aria-hidden="true" tabindex="-1"></a>            <span class="cf">return</span> std<span class="op">::</span>invoke<span class="op">((</span>F<span class="op">&amp;&amp;)</span>f,  storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span>I<span class="op">)</span> <span class="op">:])</span>;</span>
-<span id="cb20-82"><a href="#cb20-82" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
-<span id="cb20-83"><a href="#cb20-83" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb20-84"><a href="#cb20-84" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb20-15"><a href="#cb20-15" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> nonstatic_data_members_of<span class="op">(^^</span>Storage, ctx<span class="op">)[</span>n<span class="op">+</span><span class="dv">1</span><span class="op">]</span>;</span>
+<span id="cb20-16"><a href="#cb20-16" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb20-17"><a href="#cb20-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-18"><a href="#cb20-18" aria-hidden="true" tabindex="-1"></a>    Storage storage_;</span>
+<span id="cb20-19"><a href="#cb20-19" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> index_ <span class="op">=</span> <span class="op">-</span><span class="dv">1</span>;</span>
+<span id="cb20-20"><a href="#cb20-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-21"><a href="#cb20-21" aria-hidden="true" tabindex="-1"></a>    <span class="co">// cheat: use libstdc++&#39;s implementation</span></span>
+<span id="cb20-22"><a href="#cb20-22" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb20-23"><a href="#cb20-23" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">size_t</span> accepted_index <span class="op">=</span> std<span class="op">::</span>__detail<span class="op">::</span>__variant<span class="op">::</span>__accepted_index<span class="op">&lt;</span>T, std<span class="op">::</span>variant<span class="op">&lt;</span>Ts<span class="op">...&gt;&gt;</span>;</span>
+<span id="cb20-24"><a href="#cb20-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-25"><a href="#cb20-25" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> F<span class="op">&gt;</span></span>
+<span id="cb20-26"><a href="#cb20-26" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> with_index<span class="op">(</span>F<span class="op">&amp;&amp;</span> f<span class="op">)</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb20-27"><a href="#cb20-27" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> mp_with_index<span class="op">&lt;</span><span class="kw">sizeof</span><span class="op">...(</span>Ts<span class="op">)&gt;(</span>index_, <span class="op">(</span>F<span class="op">&amp;&amp;)</span>f<span class="op">)</span>;</span>
+<span id="cb20-28"><a href="#cb20-28" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb20-29"><a href="#cb20-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-30"><a href="#cb20-30" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb20-31"><a href="#cb20-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">()</span> <span class="kw">requires</span> std<span class="op">::</span>is_default_constructible_v<span class="op">&lt;</span>Ts<span class="op">...[</span><span class="dv">0</span><span class="op">]&gt;</span></span>
+<span id="cb20-32"><a href="#cb20-32" aria-hidden="true" tabindex="-1"></a>        <span class="co">// should this work: storage_{. [: get_nth_field(0) :]{} }</span></span>
+<span id="cb20-33"><a href="#cb20-33" aria-hidden="true" tabindex="-1"></a>        <span class="op">:</span> storage_<span class="op">{.</span>empty<span class="op">={}}</span></span>
+<span id="cb20-34"><a href="#cb20-34" aria-hidden="true" tabindex="-1"></a>        , index_<span class="op">(</span><span class="dv">0</span><span class="op">)</span></span>
+<span id="cb20-35"><a href="#cb20-35" aria-hidden="true" tabindex="-1"></a>    <span class="op">{</span></span>
+<span id="cb20-36"><a href="#cb20-36" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>construct_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span><span class="dv">0</span><span class="op">)</span> <span class="op">:])</span>;</span>
+<span id="cb20-37"><a href="#cb20-37" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb20-38"><a href="#cb20-38" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-39"><a href="#cb20-39" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="op">~</span>Variant<span class="op">()</span> <span class="kw">requires</span> <span class="op">(</span>std<span class="op">::</span>is_trivially_destructible_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb20-40"><a href="#cb20-40" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="op">~</span>Variant<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb20-41"><a href="#cb20-41" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> <span class="op">(</span>index_ <span class="op">!=</span> <span class="op">-</span><span class="dv">1</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb20-42"><a href="#cb20-42" aria-hidden="true" tabindex="-1"></a>            with_index<span class="op">([&amp;](</span><span class="kw">auto</span> I<span class="op">){</span></span>
+<span id="cb20-43"><a href="#cb20-43" aria-hidden="true" tabindex="-1"></a>                std<span class="op">::</span>destroy_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span>I<span class="op">)</span> <span class="op">:])</span>;</span>
+<span id="cb20-44"><a href="#cb20-44" aria-hidden="true" tabindex="-1"></a>            <span class="op">})</span>;</span>
+<span id="cb20-45"><a href="#cb20-45" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span></span>
+<span id="cb20-46"><a href="#cb20-46" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb20-47"><a href="#cb20-47" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-48"><a href="#cb20-48" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> I <span class="op">=</span> accepted_index<span class="op">&lt;</span>T<span class="op">&amp;&amp;&gt;&gt;</span></span>
+<span id="cb20-49"><a href="#cb20-49" aria-hidden="true" tabindex="-1"></a>        <span class="kw">requires</span> <span class="op">(!</span>std<span class="op">::</span>is_base_of_v<span class="op">&lt;</span>Variant, std<span class="op">::</span>decay_t<span class="op">&lt;</span>T<span class="op">&gt;&gt;)</span></span>
+<span id="cb20-50"><a href="#cb20-50" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">(</span>T<span class="op">&amp;&amp;</span> t<span class="op">)</span></span>
+<span id="cb20-51"><a href="#cb20-51" aria-hidden="true" tabindex="-1"></a>        <span class="op">:</span> storage_<span class="op">{.</span>empty<span class="op">={}}</span></span>
+<span id="cb20-52"><a href="#cb20-52" aria-hidden="true" tabindex="-1"></a>        , index_<span class="op">(-</span><span class="dv">1</span><span class="op">)</span></span>
+<span id="cb20-53"><a href="#cb20-53" aria-hidden="true" tabindex="-1"></a>    <span class="op">{</span></span>
+<span id="cb20-54"><a href="#cb20-54" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>construct_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span>I<span class="op">)</span> <span class="op">:]</span>, <span class="op">(</span>T<span class="op">&amp;&amp;)</span>t<span class="op">)</span>;</span>
+<span id="cb20-55"><a href="#cb20-55" aria-hidden="true" tabindex="-1"></a>        index_ <span class="op">=</span> <span class="op">(</span><span class="dt">int</span><span class="op">)</span>I;</span>
+<span id="cb20-56"><a href="#cb20-56" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb20-57"><a href="#cb20-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-58"><a href="#cb20-58" aria-hidden="true" tabindex="-1"></a>    <span class="co">// you can&#39;t actually express this constraint nicely until P2963</span></span>
+<span id="cb20-59"><a href="#cb20-59" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">(</span>Variant <span class="kw">const</span><span class="op">&amp;)</span> <span class="kw">requires</span> <span class="op">(</span>std<span class="op">::</span>is_trivially_copyable_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...)</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb20-60"><a href="#cb20-60" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> Variant<span class="op">(</span>Variant <span class="kw">const</span><span class="op">&amp;</span> rhs<span class="op">)</span></span>
+<span id="cb20-61"><a href="#cb20-61" aria-hidden="true" tabindex="-1"></a>            <span class="kw">requires</span> <span class="op">((</span>std<span class="op">::</span>is_copy_constructible_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...)</span></span>
+<span id="cb20-62"><a href="#cb20-62" aria-hidden="true" tabindex="-1"></a>                <span class="kw">and</span> <span class="kw">not</span> <span class="op">(</span>std<span class="op">::</span>is_trivially_copyable_v<span class="op">&lt;</span>Ts<span class="op">&gt;</span> <span class="kw">and</span> <span class="op">...))</span></span>
+<span id="cb20-63"><a href="#cb20-63" aria-hidden="true" tabindex="-1"></a>        <span class="op">:</span> storage_<span class="op">{.</span>empty<span class="op">={}}</span></span>
+<span id="cb20-64"><a href="#cb20-64" aria-hidden="true" tabindex="-1"></a>        , index_<span class="op">(-</span><span class="dv">1</span><span class="op">)</span></span>
+<span id="cb20-65"><a href="#cb20-65" aria-hidden="true" tabindex="-1"></a>    <span class="op">{</span></span>
+<span id="cb20-66"><a href="#cb20-66" aria-hidden="true" tabindex="-1"></a>        rhs<span class="op">.</span>with_index<span class="op">([&amp;](</span><span class="kw">auto</span> I<span class="op">){</span></span>
+<span id="cb20-67"><a href="#cb20-67" aria-hidden="true" tabindex="-1"></a>            <span class="kw">constexpr</span> <span class="kw">auto</span> field <span class="op">=</span> get_nth_field<span class="op">(</span>I<span class="op">)</span>;</span>
+<span id="cb20-68"><a href="#cb20-68" aria-hidden="true" tabindex="-1"></a>            std<span class="op">::</span>construct_at<span class="op">(&amp;</span>storage_<span class="op">.[:</span> field <span class="op">:]</span>, rhs<span class="op">.</span>storage_<span class="op">.[:</span> field <span class="op">:])</span>;</span>
+<span id="cb20-69"><a href="#cb20-69" aria-hidden="true" tabindex="-1"></a>            index_ <span class="op">=</span> I;</span>
+<span id="cb20-70"><a href="#cb20-70" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
+<span id="cb20-71"><a href="#cb20-71" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb20-72"><a href="#cb20-72" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-73"><a href="#cb20-73" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> index<span class="op">()</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="dt">int</span> <span class="op">{</span> <span class="cf">return</span> index_; <span class="op">}</span></span>
+<span id="cb20-74"><a href="#cb20-74" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-75"><a href="#cb20-75" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> F<span class="op">&gt;</span></span>
+<span id="cb20-76"><a href="#cb20-76" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> visit<span class="op">(</span>F<span class="op">&amp;&amp;</span> f<span class="op">)</span> <span class="kw">const</span> <span class="op">-&gt;</span> <span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb20-77"><a href="#cb20-77" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> <span class="op">(</span>index_ <span class="op">==</span> <span class="op">-</span><span class="dv">1</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb20-78"><a href="#cb20-78" aria-hidden="true" tabindex="-1"></a>            <span class="cf">throw</span> std<span class="op">::</span>bad_variant_access<span class="op">()</span>;</span>
+<span id="cb20-79"><a href="#cb20-79" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span></span>
+<span id="cb20-80"><a href="#cb20-80" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb20-81"><a href="#cb20-81" aria-hidden="true" tabindex="-1"></a>        <span class="cf">return</span> mp_with_index<span class="op">&lt;</span><span class="kw">sizeof</span><span class="op">...(</span>Ts<span class="op">)&gt;(</span>index_, <span class="op">[&amp;](</span><span class="kw">auto</span> I<span class="op">)</span> <span class="op">-&gt;</span> <span class="kw">decltype</span><span class="op">(</span><span class="kw">auto</span><span class="op">)</span> <span class="op">{</span></span>
+<span id="cb20-82"><a href="#cb20-82" aria-hidden="true" tabindex="-1"></a>            <span class="cf">return</span> std<span class="op">::</span>invoke<span class="op">((</span>F<span class="op">&amp;&amp;)</span>f,  storage_<span class="op">.[:</span> get_nth_field<span class="op">(</span>I<span class="op">)</span> <span class="op">:])</span>;</span>
+<span id="cb20-83"><a href="#cb20-83" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
+<span id="cb20-84"><a href="#cb20-84" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb20-85"><a href="#cb20-85" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 </blockquote>
 </div>
 <p>Effectively, <code class="sourceCode cpp">Variant<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
@@ -2247,8 +2254,8 @@ initialize members of a defined union using a splicer, as in:</p>
 </blockquote>
 </div>
 <p>Arguably, the answer should be yes - this would be consistent with
-how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>.</p>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/W74qxqnhf">EDG</a>, <a href="https://godbolt.org/z/h13oh4s6e">Clang</a>.</p>
+how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/W74qxqnhf">EDG</a>, <a href="https://godbolt.org/z/eqj6e3Tjr">Clang</a>.</p>
 <h2 data-number="3.10" id="struct-to-struct-of-arrays"><span class="header-section-number">3.10</span> Struct to Struct of Arrays<a href="#struct-to-struct-of-arrays" class="self-link"></a></h2>
 <div class="std">
 <blockquote>
@@ -2260,23 +2267,25 @@ how other accesses work. This is instead proposed in <span class="citation" data
 <span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> impl;</span>
 <span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="op">{</span></span>
-<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> old_members <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>T<span class="op">)</span>;</span>
-<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members <span class="op">=</span> <span class="op">{}</span>;</span>
-<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> old_members<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>        <span class="kw">auto</span> array_type <span class="op">=</span> substitute<span class="op">(^^</span>std<span class="op">::</span>array, <span class="op">{</span></span>
-<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>            type_of<span class="op">(</span>member<span class="op">)</span>,</span>
-<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a>            std<span class="op">::</span>meta<span class="op">::</span>reflect_value<span class="op">(</span>N<span class="op">)</span>,</span>
-<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
-<span id="cb23-16"><a href="#cb23-16" aria-hidden="true" tabindex="-1"></a>        <span class="kw">auto</span> mem_descr <span class="op">=</span> data_member_spec<span class="op">(</span>array_type, <span class="op">{.</span>name <span class="op">=</span> identifier_of<span class="op">(</span>member<span class="op">)})</span>;</span>
-<span id="cb23-17"><a href="#cb23-17" aria-hidden="true" tabindex="-1"></a>        new_members<span class="op">.</span>push_back<span class="op">(</span>mem_descr<span class="op">)</span>;</span>
-<span id="cb23-18"><a href="#cb23-18" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb23-19"><a href="#cb23-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb23-20"><a href="#cb23-20" aria-hidden="true" tabindex="-1"></a>    define_aggregate<span class="op">(^^</span>impl, new_members<span class="op">)</span>;</span>
-<span id="cb23-21"><a href="#cb23-21" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb23-22"><a href="#cb23-22" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb23-23"><a href="#cb23-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb23-24"><a href="#cb23-24" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
-<span id="cb23-25"><a href="#cb23-25" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> struct_of_arrays <span class="op">=</span> struct_of_arrays_impl<span class="op">&lt;</span>T, N<span class="op">&gt;::</span>impl;</span></code></pre></div>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> old_members <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>T, ctx<span class="op">)</span>;</span>
+<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members <span class="op">=</span> <span class="op">{}</span>;</span>
+<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> old_members<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb23-14"><a href="#cb23-14" aria-hidden="true" tabindex="-1"></a>        <span class="kw">auto</span> array_type <span class="op">=</span> substitute<span class="op">(^^</span>std<span class="op">::</span>array, <span class="op">{</span></span>
+<span id="cb23-15"><a href="#cb23-15" aria-hidden="true" tabindex="-1"></a>            type_of<span class="op">(</span>member<span class="op">)</span>,</span>
+<span id="cb23-16"><a href="#cb23-16" aria-hidden="true" tabindex="-1"></a>            std<span class="op">::</span>meta<span class="op">::</span>reflect_value<span class="op">(</span>N<span class="op">)</span>,</span>
+<span id="cb23-17"><a href="#cb23-17" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
+<span id="cb23-18"><a href="#cb23-18" aria-hidden="true" tabindex="-1"></a>        <span class="kw">auto</span> mem_descr <span class="op">=</span> data_member_spec<span class="op">(</span>array_type, <span class="op">{.</span>name <span class="op">=</span> identifier_of<span class="op">(</span>member<span class="op">)})</span>;</span>
+<span id="cb23-19"><a href="#cb23-19" aria-hidden="true" tabindex="-1"></a>        new_members<span class="op">.</span>push_back<span class="op">(</span>mem_descr<span class="op">)</span>;</span>
+<span id="cb23-20"><a href="#cb23-20" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb23-21"><a href="#cb23-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-22"><a href="#cb23-22" aria-hidden="true" tabindex="-1"></a>    define_aggregate<span class="op">(^^</span>impl, new_members<span class="op">)</span>;</span>
+<span id="cb23-23"><a href="#cb23-23" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb23-24"><a href="#cb23-24" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb23-25"><a href="#cb23-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb23-26"><a href="#cb23-26" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T, <span class="dt">size_t</span> N<span class="op">&gt;</span></span>
+<span id="cb23-27"><a href="#cb23-27" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> struct_of_arrays <span class="op">=</span> struct_of_arrays_impl<span class="op">&lt;</span>T, N<span class="op">&gt;::</span>impl;</span></code></pre></div>
 </blockquote>
 </div>
 <p>Example:</p>
@@ -2340,7 +2349,7 @@ has no linkage, whereas we wanted it to have external linkage. Hence the
 structure in the example above where we are instead defining a nested
 class in a class template — so that we have a type with external linkage
 but don’t run afoul of the “cone of instantiation” rule.</p>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/jWrPGhn5s">EDG</a>, <a href="https://godbolt.org/z/a1sTxnW4o">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/jWrPGhn5s">EDG</a>, <a href="https://godbolt.org/z/vqxzMoPcj">Clang</a>.</p>
 <h2 data-number="3.11" id="parsing-command-line-options-ii"><span class="header-section-number">3.11</span> Parsing Command-Line Options
 II<a href="#parsing-command-line-options-ii" class="self-link"></a></h2>
 <p>Now that we’ve seen a couple examples of using <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>define_aggregate</code>
@@ -2390,70 +2399,76 @@ example.</p>
 <span id="cb28-20"><a href="#cb28-20" aria-hidden="true" tabindex="-1"></a><span class="co">// }</span></span>
 <span id="cb28-21"><a href="#cb28-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> spec_to_opts<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info opts,</span>
 <span id="cb28-22"><a href="#cb28-22" aria-hidden="true" tabindex="-1"></a>                            std<span class="op">::</span>meta<span class="op">::</span>info spec<span class="op">)</span> <span class="op">-&gt;</span> std<span class="op">::</span>meta<span class="op">::</span>info <span class="op">{</span></span>
-<span id="cb28-23"><a href="#cb28-23" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members;</span>
-<span id="cb28-24"><a href="#cb28-24" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> nonstatic_data_members_of<span class="op">(</span>spec<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb28-25"><a href="#cb28-25" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> type_new <span class="op">=</span> template_arguments_of<span class="op">(</span>type_of<span class="op">(</span>member<span class="op">))[</span><span class="dv">0</span><span class="op">]</span>;</span>
-<span id="cb28-26"><a href="#cb28-26" aria-hidden="true" tabindex="-1"></a>    new_members<span class="op">.</span>push_back<span class="op">(</span>data_member_spec<span class="op">(</span>type_new, <span class="op">{.</span>name<span class="op">=</span>identifier_of<span class="op">(</span>member<span class="op">)}))</span>;</span>
-<span id="cb28-27"><a href="#cb28-27" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb28-28"><a href="#cb28-28" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> define_aggregate<span class="op">(</span>opts, new_members<span class="op">)</span>;</span>
-<span id="cb28-29"><a href="#cb28-29" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb28-30"><a href="#cb28-30" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-31"><a href="#cb28-31" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Clap <span class="op">{</span></span>
-<span id="cb28-32"><a href="#cb28-32" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> Spec<span class="op">&gt;</span></span>
-<span id="cb28-33"><a href="#cb28-33" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> parse<span class="op">(</span><span class="kw">this</span> Spec <span class="kw">const</span><span class="op">&amp;</span> spec, <span class="dt">int</span> argc, <span class="dt">char</span><span class="op">**</span> argv<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb28-34"><a href="#cb28-34" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>string_view<span class="op">&gt;</span> cmdline<span class="op">(</span>argv<span class="op">+</span><span class="dv">1</span>, argv<span class="op">+</span>argc<span class="op">)</span></span>
-<span id="cb28-35"><a href="#cb28-35" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-36"><a href="#cb28-36" aria-hidden="true" tabindex="-1"></a>    <span class="co">// check if cmdline contains --help, etc.</span></span>
+<span id="cb28-23"><a href="#cb28-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb28-24"><a href="#cb28-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-25"><a href="#cb28-25" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>meta<span class="op">::</span>info<span class="op">&gt;</span> new_members;</span>
+<span id="cb28-26"><a href="#cb28-26" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>info member <span class="op">:</span> nonstatic_data_members_of<span class="op">(</span>spec, ctx<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb28-27"><a href="#cb28-27" aria-hidden="true" tabindex="-1"></a>    <span class="kw">auto</span> type_new <span class="op">=</span> template_arguments_of<span class="op">(</span>type_of<span class="op">(</span>member<span class="op">))[</span><span class="dv">0</span><span class="op">]</span>;</span>
+<span id="cb28-28"><a href="#cb28-28" aria-hidden="true" tabindex="-1"></a>    new_members<span class="op">.</span>push_back<span class="op">(</span>data_member_spec<span class="op">(</span>type_new, <span class="op">{.</span>name<span class="op">=</span>identifier_of<span class="op">(</span>member<span class="op">)}))</span>;</span>
+<span id="cb28-29"><a href="#cb28-29" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb28-30"><a href="#cb28-30" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> define_aggregate<span class="op">(</span>opts, new_members<span class="op">)</span>;</span>
+<span id="cb28-31"><a href="#cb28-31" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb28-32"><a href="#cb28-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-33"><a href="#cb28-33" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Clap <span class="op">{</span></span>
+<span id="cb28-34"><a href="#cb28-34" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> Spec<span class="op">&gt;</span></span>
+<span id="cb28-35"><a href="#cb28-35" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> parse<span class="op">(</span><span class="kw">this</span> Spec <span class="kw">const</span><span class="op">&amp;</span> spec, <span class="dt">int</span> argc, <span class="dt">char</span><span class="op">**</span> argv<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb28-36"><a href="#cb28-36" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>vector<span class="op">&lt;</span>std<span class="op">::</span>string_view<span class="op">&gt;</span> cmdline<span class="op">(</span>argv<span class="op">+</span><span class="dv">1</span>, argv<span class="op">+</span>argc<span class="op">)</span></span>
 <span id="cb28-37"><a href="#cb28-37" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-38"><a href="#cb28-38" aria-hidden="true" tabindex="-1"></a>    <span class="kw">struct</span> Opts;</span>
-<span id="cb28-39"><a href="#cb28-39" aria-hidden="true" tabindex="-1"></a>    <span class="kw">consteval</span> <span class="op">{</span></span>
-<span id="cb28-40"><a href="#cb28-40" aria-hidden="true" tabindex="-1"></a>      spec_to_opts<span class="op">(^^</span>Opts, <span class="op">^^</span>Spec<span class="op">)</span>;</span>
-<span id="cb28-41"><a href="#cb28-41" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb28-42"><a href="#cb28-42" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-43"><a href="#cb28-43" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> <span class="op">[</span>sm, om<span class="op">]</span> <span class="op">:</span> std<span class="op">::</span>views<span class="op">::</span>zip<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>Spec<span class="op">)</span>,</span>
-<span id="cb28-44"><a href="#cb28-44" aria-hidden="true" tabindex="-1"></a>                                                            nonstatic_data_members_of<span class="op">(^^</span>Opts<span class="op">)))</span> <span class="op">{</span></span>
-<span id="cb28-45"><a href="#cb28-45" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> <span class="kw">const</span><span class="op">&amp;</span> cur <span class="op">=</span> spec<span class="op">.[:</span>sm<span class="op">:]</span>;</span>
-<span id="cb28-46"><a href="#cb28-46" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> <span class="kw">auto</span> type <span class="op">=</span> type_of<span class="op">(</span>om<span class="op">)</span>;</span>
-<span id="cb28-47"><a href="#cb28-47" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-48"><a href="#cb28-48" aria-hidden="true" tabindex="-1"></a>      <span class="co">// find the argument associated with this option</span></span>
-<span id="cb28-49"><a href="#cb28-49" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> it <span class="op">=</span> std<span class="op">::</span>ranges<span class="op">::</span>find_if<span class="op">(</span>cmdline,</span>
-<span id="cb28-50"><a href="#cb28-50" aria-hidden="true" tabindex="-1"></a>        <span class="op">[&amp;](</span>std<span class="op">::</span>string_view arg<span class="op">){</span></span>
-<span id="cb28-51"><a href="#cb28-51" aria-hidden="true" tabindex="-1"></a>          <span class="cf">return</span> <span class="op">(</span>cur<span class="op">.</span>use_short <span class="op">&amp;&amp;</span> arg<span class="op">.</span>size<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span> arg<span class="op">[</span><span class="dv">0</span><span class="op">]</span> <span class="op">==</span> <span class="ch">&#39;-&#39;</span> <span class="op">&amp;&amp;</span> arg<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">==</span> identifier_of<span class="op">(</span>sm<span class="op">)[</span><span class="dv">0</span><span class="op">])</span></span>
-<span id="cb28-52"><a href="#cb28-52" aria-hidden="true" tabindex="-1"></a>              <span class="op">||</span> <span class="op">(</span>cur<span class="op">.</span>use_long <span class="op">&amp;&amp;</span> arg<span class="op">.</span>starts_with<span class="op">(</span><span class="st">&quot;--&quot;</span><span class="op">)</span> <span class="op">&amp;&amp;</span> arg<span class="op">.</span>substr<span class="op">(</span><span class="dv">2</span><span class="op">)</span> <span class="op">==</span> identifier_of<span class="op">(</span>sm<span class="op">))</span>;</span>
-<span id="cb28-53"><a href="#cb28-53" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
-<span id="cb28-54"><a href="#cb28-54" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-55"><a href="#cb28-55" aria-hidden="true" tabindex="-1"></a>      <span class="co">// no such argument</span></span>
-<span id="cb28-56"><a href="#cb28-56" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> <span class="op">(</span>it <span class="op">==</span> cmdline<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb28-57"><a href="#cb28-57" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="kw">and</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>std<span class="op">::</span>optional<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb28-58"><a href="#cb28-58" aria-hidden="true" tabindex="-1"></a>          <span class="co">// the type is optional, so the argument is too</span></span>
-<span id="cb28-59"><a href="#cb28-59" aria-hidden="true" tabindex="-1"></a>          <span class="cf">continue</span>;</span>
-<span id="cb28-60"><a href="#cb28-60" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>cur<span class="op">.</span>initializer<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb28-61"><a href="#cb28-61" aria-hidden="true" tabindex="-1"></a>          <span class="co">// the type isn&#39;t optional, but an initializer is provided, use that</span></span>
-<span id="cb28-62"><a href="#cb28-62" aria-hidden="true" tabindex="-1"></a>          opts<span class="op">.[:</span>om<span class="op">:]</span> <span class="op">=</span> <span class="op">*</span>cur<span class="op">.</span>initializer;</span>
-<span id="cb28-63"><a href="#cb28-63" aria-hidden="true" tabindex="-1"></a>          <span class="cf">continue</span>;</span>
-<span id="cb28-64"><a href="#cb28-64" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb28-65"><a href="#cb28-65" aria-hidden="true" tabindex="-1"></a>          std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Missing required option {}</span><span class="sc">\n</span><span class="st">&quot;</span>, display_string_of<span class="op">(</span>sm<span class="op">))</span>;</span>
-<span id="cb28-66"><a href="#cb28-66" aria-hidden="true" tabindex="-1"></a>          std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
-<span id="cb28-67"><a href="#cb28-67" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span></span>
-<span id="cb28-68"><a href="#cb28-68" aria-hidden="true" tabindex="-1"></a>      <span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>it <span class="op">+</span> <span class="dv">1</span> <span class="op">==</span> cmdline<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb28-69"><a href="#cb28-69" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Option {} for {} is missing a value</span><span class="sc">\n</span><span class="st">&quot;</span>, <span class="op">*</span>it, display_string_of<span class="op">(</span>sm<span class="op">))</span>;</span>
-<span id="cb28-70"><a href="#cb28-70" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
-<span id="cb28-71"><a href="#cb28-71" aria-hidden="true" tabindex="-1"></a>      <span class="op">}</span></span>
-<span id="cb28-72"><a href="#cb28-72" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-73"><a href="#cb28-73" aria-hidden="true" tabindex="-1"></a>      <span class="co">// found our argument, try to parse it</span></span>
-<span id="cb28-74"><a href="#cb28-74" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> iss <span class="op">=</span> ispanstream<span class="op">(</span>it<span class="op">[</span><span class="dv">1</span><span class="op">])</span>;</span>
-<span id="cb28-75"><a href="#cb28-75" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> <span class="op">(</span>iss <span class="op">&gt;&gt;</span> opts<span class="op">.[:</span>om<span class="op">:]</span>; <span class="op">!</span>iss<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb28-76"><a href="#cb28-76" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Failed to parse {:?} into option {} of type {}</span><span class="sc">\n</span><span class="st">&quot;</span>,</span>
-<span id="cb28-77"><a href="#cb28-77" aria-hidden="true" tabindex="-1"></a>          it<span class="op">[</span><span class="dv">1</span><span class="op">]</span>, display_string_of<span class="op">(</span>sm<span class="op">)</span>, display_string_of<span class="op">(</span>type<span class="op">))</span>;</span>
-<span id="cb28-78"><a href="#cb28-78" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
-<span id="cb28-79"><a href="#cb28-79" aria-hidden="true" tabindex="-1"></a>      <span class="op">}</span></span>
-<span id="cb28-80"><a href="#cb28-80" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb28-81"><a href="#cb28-81" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> opts;</span>
-<span id="cb28-82"><a href="#cb28-82" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb28-83"><a href="#cb28-83" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<span id="cb28-38"><a href="#cb28-38" aria-hidden="true" tabindex="-1"></a>    <span class="co">// check if cmdline contains --help, etc.</span></span>
+<span id="cb28-39"><a href="#cb28-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-40"><a href="#cb28-40" aria-hidden="true" tabindex="-1"></a>    <span class="kw">struct</span> Opts;</span>
+<span id="cb28-41"><a href="#cb28-41" aria-hidden="true" tabindex="-1"></a>    <span class="kw">consteval</span> <span class="op">{</span></span>
+<span id="cb28-42"><a href="#cb28-42" aria-hidden="true" tabindex="-1"></a>      spec_to_opts<span class="op">(^^</span>Opts, <span class="op">^^</span>Spec<span class="op">)</span>;</span>
+<span id="cb28-43"><a href="#cb28-43" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb28-44"><a href="#cb28-44" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-45"><a href="#cb28-45" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb28-46"><a href="#cb28-46" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> <span class="op">[</span>sm, om<span class="op">]</span> <span class="op">:</span></span>
+<span id="cb28-47"><a href="#cb28-47" aria-hidden="true" tabindex="-1"></a>                  std<span class="op">::</span>meta<span class="op">::</span>define_static_array<span class="op">(</span></span>
+<span id="cb28-48"><a href="#cb28-48" aria-hidden="true" tabindex="-1"></a>                      std<span class="op">::</span>views<span class="op">::</span>zip<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>Spec, ctx<span class="op">)</span>,</span>
+<span id="cb28-49"><a href="#cb28-49" aria-hidden="true" tabindex="-1"></a>                                      nonstatic_data_members_of<span class="op">(^^</span>Opts, ctx<span class="op">))</span> <span class="op">|</span></span>
+<span id="cb28-50"><a href="#cb28-50" aria-hidden="true" tabindex="-1"></a>                      std<span class="op">::</span>views<span class="op">::</span>transform<span class="op">([](</span><span class="kw">auto</span> z<span class="op">)</span> <span class="op">{</span> <span class="cf">return</span> std<span class="op">::</span>pair<span class="op">(</span>get<span class="op">&lt;</span><span class="dv">0</span><span class="op">&gt;(</span>z<span class="op">)</span>, get<span class="op">&lt;</span><span class="dv">1</span><span class="op">&gt;(</span>z<span class="op">))</span>; <span class="op">})))</span> <span class="op">{</span></span>
+<span id="cb28-51"><a href="#cb28-51" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> <span class="kw">const</span><span class="op">&amp;</span> cur <span class="op">=</span> spec<span class="op">.[:</span>sm<span class="op">:]</span>;</span>
+<span id="cb28-52"><a href="#cb28-52" aria-hidden="true" tabindex="-1"></a>      <span class="kw">constexpr</span> <span class="kw">auto</span> type <span class="op">=</span> type_of<span class="op">(</span>om<span class="op">)</span>;</span>
+<span id="cb28-53"><a href="#cb28-53" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-54"><a href="#cb28-54" aria-hidden="true" tabindex="-1"></a>      <span class="co">// find the argument associated with this option</span></span>
+<span id="cb28-55"><a href="#cb28-55" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> it <span class="op">=</span> std<span class="op">::</span>ranges<span class="op">::</span>find_if<span class="op">(</span>cmdline,</span>
+<span id="cb28-56"><a href="#cb28-56" aria-hidden="true" tabindex="-1"></a>        <span class="op">[&amp;](</span>std<span class="op">::</span>string_view arg<span class="op">){</span></span>
+<span id="cb28-57"><a href="#cb28-57" aria-hidden="true" tabindex="-1"></a>          <span class="cf">return</span> <span class="op">(</span>cur<span class="op">.</span>use_short <span class="op">&amp;&amp;</span> arg<span class="op">.</span>size<span class="op">()</span> <span class="op">==</span> <span class="dv">2</span> <span class="op">&amp;&amp;</span> arg<span class="op">[</span><span class="dv">0</span><span class="op">]</span> <span class="op">==</span> <span class="ch">&#39;-&#39;</span> <span class="op">&amp;&amp;</span> arg<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">==</span> identifier_of<span class="op">(</span>sm<span class="op">)[</span><span class="dv">0</span><span class="op">])</span></span>
+<span id="cb28-58"><a href="#cb28-58" aria-hidden="true" tabindex="-1"></a>              <span class="op">||</span> <span class="op">(</span>cur<span class="op">.</span>use_long <span class="op">&amp;&amp;</span> arg<span class="op">.</span>starts_with<span class="op">(</span><span class="st">&quot;--&quot;</span><span class="op">)</span> <span class="op">&amp;&amp;</span> arg<span class="op">.</span>substr<span class="op">(</span><span class="dv">2</span><span class="op">)</span> <span class="op">==</span> identifier_of<span class="op">(</span>sm<span class="op">))</span>;</span>
+<span id="cb28-59"><a href="#cb28-59" aria-hidden="true" tabindex="-1"></a>        <span class="op">})</span>;</span>
+<span id="cb28-60"><a href="#cb28-60" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-61"><a href="#cb28-61" aria-hidden="true" tabindex="-1"></a>      <span class="co">// no such argument</span></span>
+<span id="cb28-62"><a href="#cb28-62" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> <span class="op">(</span>it <span class="op">==</span> cmdline<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb28-63"><a href="#cb28-63" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="kw">and</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>std<span class="op">::</span>optional<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb28-64"><a href="#cb28-64" aria-hidden="true" tabindex="-1"></a>          <span class="co">// the type is optional, so the argument is too</span></span>
+<span id="cb28-65"><a href="#cb28-65" aria-hidden="true" tabindex="-1"></a>          <span class="cf">continue</span>;</span>
+<span id="cb28-66"><a href="#cb28-66" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>cur<span class="op">.</span>initializer<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb28-67"><a href="#cb28-67" aria-hidden="true" tabindex="-1"></a>          <span class="co">// the type isn&#39;t optional, but an initializer is provided, use that</span></span>
+<span id="cb28-68"><a href="#cb28-68" aria-hidden="true" tabindex="-1"></a>          opts<span class="op">.[:</span>om<span class="op">:]</span> <span class="op">=</span> <span class="op">*</span>cur<span class="op">.</span>initializer;</span>
+<span id="cb28-69"><a href="#cb28-69" aria-hidden="true" tabindex="-1"></a>          <span class="cf">continue</span>;</span>
+<span id="cb28-70"><a href="#cb28-70" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb28-71"><a href="#cb28-71" aria-hidden="true" tabindex="-1"></a>          std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Missing required option {}</span><span class="sc">\n</span><span class="st">&quot;</span>, display_string_of<span class="op">(</span>sm<span class="op">))</span>;</span>
+<span id="cb28-72"><a href="#cb28-72" aria-hidden="true" tabindex="-1"></a>          std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
+<span id="cb28-73"><a href="#cb28-73" aria-hidden="true" tabindex="-1"></a>        <span class="op">}</span></span>
+<span id="cb28-74"><a href="#cb28-74" aria-hidden="true" tabindex="-1"></a>      <span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>it <span class="op">+</span> <span class="dv">1</span> <span class="op">==</span> cmdline<span class="op">.</span>end<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb28-75"><a href="#cb28-75" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Option {} for {} is missing a value</span><span class="sc">\n</span><span class="st">&quot;</span>, <span class="op">*</span>it, display_string_of<span class="op">(</span>sm<span class="op">))</span>;</span>
+<span id="cb28-76"><a href="#cb28-76" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
+<span id="cb28-77"><a href="#cb28-77" aria-hidden="true" tabindex="-1"></a>      <span class="op">}</span></span>
+<span id="cb28-78"><a href="#cb28-78" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb28-79"><a href="#cb28-79" aria-hidden="true" tabindex="-1"></a>      <span class="co">// found our argument, try to parse it</span></span>
+<span id="cb28-80"><a href="#cb28-80" aria-hidden="true" tabindex="-1"></a>      <span class="kw">auto</span> iss <span class="op">=</span> ispanstream<span class="op">(</span>it<span class="op">[</span><span class="dv">1</span><span class="op">])</span>;</span>
+<span id="cb28-81"><a href="#cb28-81" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> <span class="op">(</span>iss <span class="op">&gt;&gt;</span> opts<span class="op">.[:</span>om<span class="op">:]</span>; <span class="op">!</span>iss<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb28-82"><a href="#cb28-82" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>print<span class="op">(</span>stderr, <span class="st">&quot;Failed to parse {:?} into option {} of type {}</span><span class="sc">\n</span><span class="st">&quot;</span>,</span>
+<span id="cb28-83"><a href="#cb28-83" aria-hidden="true" tabindex="-1"></a>          it<span class="op">[</span><span class="dv">1</span><span class="op">]</span>, display_string_of<span class="op">(</span>sm<span class="op">)</span>, display_string_of<span class="op">(</span>type<span class="op">))</span>;</span>
+<span id="cb28-84"><a href="#cb28-84" aria-hidden="true" tabindex="-1"></a>        std<span class="op">::</span>exit<span class="op">(</span>EXIT_FAILURE<span class="op">)</span>;</span>
+<span id="cb28-85"><a href="#cb28-85" aria-hidden="true" tabindex="-1"></a>      <span class="op">}</span></span>
+<span id="cb28-86"><a href="#cb28-86" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb28-87"><a href="#cb28-87" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> opts;</span>
+<span id="cb28-88"><a href="#cb28-88" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb28-89"><a href="#cb28-89" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
 </blockquote>
 </div>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/4aseo5eGq">EDG</a>, <a href="https://godbolt.org/z/3qG5roer4">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/4aseo5eGq">EDG</a>, <a href="https://godbolt.org/z/Yjv1dM4eK">Clang</a>.</p>
 <h2 data-number="3.12" id="a-universal-formatter"><span class="header-section-number">3.12</span> A Universal Formatter<a href="#a-universal-formatter" class="self-link"></a></h2>
 <p>This example is taken from Boost.Describe:</p>
 <div class="std">
@@ -2474,40 +2489,43 @@ example.</p>
 <span id="cb29-14"><a href="#cb29-14" aria-hidden="true" tabindex="-1"></a>      first <span class="op">=</span> <span class="kw">false</span>;</span>
 <span id="cb29-15"><a href="#cb29-15" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span>;</span>
 <span id="cb29-16"><a href="#cb29-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-17"><a href="#cb29-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> base <span class="op">:</span> bases_of<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb29-18"><a href="#cb29-18" aria-hidden="true" tabindex="-1"></a>      delim<span class="op">()</span>;</span>
-<span id="cb29-19"><a href="#cb29-19" aria-hidden="true" tabindex="-1"></a>      out <span class="op">=</span> std<span class="op">::</span>format_to<span class="op">(</span>out, <span class="st">&quot;{}&quot;</span>, <span class="op">(</span><span class="kw">typename</span> <span class="op">[:</span> type_of<span class="op">(</span>base<span class="op">)</span> <span class="op">:]</span> <span class="kw">const</span><span class="op">&amp;)(</span>t<span class="op">))</span>;</span>
-<span id="cb29-20"><a href="#cb29-20" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb29-21"><a href="#cb29-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-22"><a href="#cb29-22" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> mem <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb29-23"><a href="#cb29-23" aria-hidden="true" tabindex="-1"></a>      delim<span class="op">()</span>;</span>
-<span id="cb29-24"><a href="#cb29-24" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>string_view mem_label <span class="op">=</span> has_identifier<span class="op">(</span>mem<span class="op">)</span> <span class="op">?</span> identifier_of<span class="op">(</span>mem<span class="op">)</span></span>
-<span id="cb29-25"><a href="#cb29-25" aria-hidden="true" tabindex="-1"></a>                                                       <span class="op">:</span> <span class="st">&quot;(unnamed-member)&quot;</span>;</span>
-<span id="cb29-26"><a href="#cb29-26" aria-hidden="true" tabindex="-1"></a>      out <span class="op">=</span> std<span class="op">::</span>format_to<span class="op">(</span>out, <span class="st">&quot;.{}={}&quot;</span>, mem_label, t<span class="op">.[:</span>mem<span class="op">:])</span>;</span>
-<span id="cb29-27"><a href="#cb29-27" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb29-28"><a href="#cb29-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-29"><a href="#cb29-29" aria-hidden="true" tabindex="-1"></a>    <span class="op">*</span>out<span class="op">++</span> <span class="op">=</span> <span class="ch">&#39;}&#39;</span>;</span>
-<span id="cb29-30"><a href="#cb29-30" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> out;</span>
-<span id="cb29-31"><a href="#cb29-31" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb29-32"><a href="#cb29-32" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb29-33"><a href="#cb29-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-34"><a href="#cb29-34" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> B <span class="op">{</span> <span class="dt">int</span> m0 <span class="op">=</span> <span class="dv">0</span>; <span class="op">}</span>;</span>
-<span id="cb29-35"><a href="#cb29-35" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> X <span class="op">{</span> <span class="dt">int</span> m1 <span class="op">=</span> <span class="dv">1</span>; <span class="op">}</span>;</span>
-<span id="cb29-36"><a href="#cb29-36" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Y <span class="op">{</span> <span class="dt">int</span> m2 <span class="op">=</span> <span class="dv">2</span>; <span class="op">}</span>;</span>
-<span id="cb29-37"><a href="#cb29-37" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> Z <span class="op">:</span> <span class="kw">public</span> X, <span class="kw">private</span> Y <span class="op">{</span> <span class="dt">int</span> m3 <span class="op">=</span> <span class="dv">3</span>; <span class="dt">int</span> m4 <span class="op">=</span> <span class="dv">4</span>; <span class="op">}</span>;</span>
-<span id="cb29-38"><a href="#cb29-38" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-39"><a href="#cb29-39" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>B<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb29-40"><a href="#cb29-40" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>X<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb29-41"><a href="#cb29-41" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>Y<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb29-42"><a href="#cb29-42" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>Z<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb29-43"><a href="#cb29-43" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-44"><a href="#cb29-44" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb29-45"><a href="#cb29-45" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>println<span class="op">(</span><span class="st">&quot;{}&quot;</span>, Z<span class="op">())</span>;</span>
-<span id="cb29-46"><a href="#cb29-46" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Z{X{B{.m0=0}, .m1 = 1}, Y{{.m0=0}, .m2 = 2}, .m3 = 3, .m4 = 4}</span></span>
-<span id="cb29-47"><a href="#cb29-47" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb29-17"><a href="#cb29-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>unchecked<span class="op">()</span>;</span>
+<span id="cb29-18"><a href="#cb29-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-19"><a href="#cb29-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> base <span class="op">:</span> define_static_array<span class="op">(</span>bases_of<span class="op">(^^</span>T, ctx<span class="op">)))</span> <span class="op">{</span></span>
+<span id="cb29-20"><a href="#cb29-20" aria-hidden="true" tabindex="-1"></a>      delim<span class="op">()</span>;</span>
+<span id="cb29-21"><a href="#cb29-21" aria-hidden="true" tabindex="-1"></a>      out <span class="op">=</span> std<span class="op">::</span>format_to<span class="op">(</span>out, <span class="st">&quot;{}&quot;</span>, <span class="op">(</span><span class="kw">typename</span> <span class="op">[:</span> type_of<span class="op">(</span>base<span class="op">)</span> <span class="op">:]</span> <span class="kw">const</span><span class="op">&amp;)(</span>t<span class="op">))</span>;</span>
+<span id="cb29-22"><a href="#cb29-22" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb29-23"><a href="#cb29-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-24"><a href="#cb29-24" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> mem <span class="op">:</span></span>
+<span id="cb29-25"><a href="#cb29-25" aria-hidden="true" tabindex="-1"></a>                  define_static_array<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>T, ctx<span class="op">)))</span> <span class="op">{</span></span>
+<span id="cb29-26"><a href="#cb29-26" aria-hidden="true" tabindex="-1"></a>      delim<span class="op">()</span>;</span>
+<span id="cb29-27"><a href="#cb29-27" aria-hidden="true" tabindex="-1"></a>      std<span class="op">::</span>string_view mem_label <span class="op">=</span> has_identifier<span class="op">(</span>mem<span class="op">)</span> <span class="op">?</span> identifier_of<span class="op">(</span>mem<span class="op">)</span></span>
+<span id="cb29-28"><a href="#cb29-28" aria-hidden="true" tabindex="-1"></a>                                                       <span class="op">:</span> <span class="st">&quot;(unnamed-member)&quot;</span>;</span>
+<span id="cb29-29"><a href="#cb29-29" aria-hidden="true" tabindex="-1"></a>      out <span class="op">=</span> std<span class="op">::</span>format_to<span class="op">(</span>out, <span class="st">&quot;.{}={}&quot;</span>, mem_label, t<span class="op">.[:</span>mem<span class="op">:])</span>;</span>
+<span id="cb29-30"><a href="#cb29-30" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb29-31"><a href="#cb29-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-32"><a href="#cb29-32" aria-hidden="true" tabindex="-1"></a>    <span class="op">*</span>out<span class="op">++</span> <span class="op">=</span> <span class="ch">&#39;}&#39;</span>;</span>
+<span id="cb29-33"><a href="#cb29-33" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> out;</span>
+<span id="cb29-34"><a href="#cb29-34" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb29-35"><a href="#cb29-35" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb29-36"><a href="#cb29-36" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-37"><a href="#cb29-37" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> B <span class="op">{</span> <span class="dt">int</span> m0 <span class="op">=</span> <span class="dv">0</span>; <span class="op">}</span>;</span>
+<span id="cb29-38"><a href="#cb29-38" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> X <span class="op">{</span> <span class="dt">int</span> m1 <span class="op">=</span> <span class="dv">1</span>; <span class="op">}</span>;</span>
+<span id="cb29-39"><a href="#cb29-39" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Y <span class="op">{</span> <span class="dt">int</span> m2 <span class="op">=</span> <span class="dv">2</span>; <span class="op">}</span>;</span>
+<span id="cb29-40"><a href="#cb29-40" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> Z <span class="op">:</span> <span class="kw">public</span> X, <span class="kw">private</span> Y <span class="op">{</span> <span class="dt">int</span> m3 <span class="op">=</span> <span class="dv">3</span>; <span class="dt">int</span> m4 <span class="op">=</span> <span class="dv">4</span>; <span class="op">}</span>;</span>
+<span id="cb29-41"><a href="#cb29-41" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-42"><a href="#cb29-42" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>B<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb29-43"><a href="#cb29-43" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>X<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb29-44"><a href="#cb29-44" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>Y<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb29-45"><a href="#cb29-45" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;&gt;</span> <span class="kw">struct</span> std<span class="op">::</span>formatter<span class="op">&lt;</span>Z<span class="op">&gt;</span> <span class="op">:</span> universal_formatter <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb29-46"><a href="#cb29-46" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-47"><a href="#cb29-47" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb29-48"><a href="#cb29-48" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>println<span class="op">(</span><span class="st">&quot;{}&quot;</span>, Z<span class="op">())</span>;</span>
+<span id="cb29-49"><a href="#cb29-49" aria-hidden="true" tabindex="-1"></a>      <span class="co">// Z{X{B{.m0=0}, .m1 = 1}, Y{{.m0=0}, .m2 = 2}, .m3 = 3, .m4 = 4}</span></span>
+<span id="cb29-50"><a href="#cb29-50" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/drv1nbsf3">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/99dTErdG6">Clang</a>.</p>
 <p>Note that currently, we do not have the ability to access a base
 class subobject using the <code class="sourceCode cpp">t<span class="op">.[:</span> base <span class="op">:]</span></code>
 syntax - which means that the only way to get at the base is to use a
@@ -2528,80 +2546,91 @@ requires writing
 since this isn’t a type-only context.</p>
 <h2 data-number="3.13" id="implementing-member-wise-hash_append"><span class="header-section-number">3.13</span> Implementing member-wise
 <code class="sourceCode cpp">hash_append</code><a href="#implementing-member-wise-hash_append" class="self-link"></a></h2>
-<p>Based on the <span class="citation" data-cites="N3980"><a href="https://wg21.link/n3980" role="doc-biblioref">[N3980]</a></span>
+<p>Based on the <span class="citation" data-cites="N3980">[<a href="https://wg21.link/n3980" role="doc-biblioref">N3980</a>]</span>
 API:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb30"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> H, <span class="kw">typename</span> T<span class="op">&gt;</span> <span class="kw">requires</span> std<span class="op">::</span>is_standard_layout_v<span class="op">&lt;</span>T<span class="op">&gt;</span></span>
 <span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hash_append<span class="op">(</span>H<span class="op">&amp;</span> algo, T <span class="kw">const</span><span class="op">&amp;</span> t<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> mem <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>      hash_append<span class="op">(</span>algo, t<span class="op">.[:</span>mem<span class="op">:])</span>;</span>
-<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>unchecked<span class="op">()</span>;</span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="cf">for</span> <span class="op">(</span><span class="kw">constexpr</span> <span class="kw">auto</span> mem <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>T, ctx<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>      hash_append<span class="op">(</span>algo, t<span class="op">.[:</span>mem<span class="op">:])</span>;</span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
+<p>Of course, any production-ready
+<code class="sourceCode cpp">hash_append</code> would include a facility
+for classes to opt members in and out of participation in hashing.
+Annotations as proposed by <span class="citation" data-cites="P3394">[<a href="#ref-P3394" role="doc-biblioref"><strong>P3394?</strong></a>]</span> provides just
+such a mechanism.</p>
 <h2 data-number="3.14" id="converting-a-struct-to-a-tuple"><span class="header-section-number">3.14</span> Converting a Struct to a
 Tuple<a href="#converting-a-struct-to-a-tuple" class="self-link"></a></h2>
-<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R5"><a href="https://wg21.link/p1061r5" role="doc-biblioref">[P1061R5]</a></span>, but can also be written using
+<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R5">[<a href="https://wg21.link/p1061r5" role="doc-biblioref">P1061R5</a>]</span>, but can also be written using
 <code class="sourceCode cpp">std<span class="op">::</span>make_index_sequence</code>:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb31"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> struct_to_tuple<span class="op">(</span>T <span class="kw">const</span><span class="op">&amp;</span> t<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> members <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>T<span class="op">)</span>;</span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
 <span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> indices <span class="op">=</span> <span class="op">[]{</span></span>
-<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>array<span class="op">&lt;</span><span class="dt">int</span>, members<span class="op">.</span>size<span class="op">()&gt;</span> indices;</span>
-<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>ranges<span class="op">::</span>iota<span class="op">(</span>indices, <span class="dv">0</span><span class="op">)</span>;</span>
-<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> indices;</span>
-<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">}()</span>;</span>
-<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> <span class="op">[...</span>Is<span class="op">]</span> <span class="op">=</span> indices;</span>
-<span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>make_tuple<span class="op">(</span>t<span class="op">.[:</span> members<span class="op">[</span>Is<span class="op">]</span> <span class="op">:]...)</span>;</span>
-<span id="cb31-13"><a href="#cb31-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> std<span class="op">::</span><span class="dt">size_t</span> N <span class="op">=</span> nonstatic_data_members_of<span class="op">(^^</span>T, ctx<span class="op">).</span>size<span class="op">()</span>;</span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> members <span class="op">=</span> nonstatic_data_members<span class="op">(^^</span>T, ctx<span class="op">)</span>;</span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> indices <span class="op">=</span> <span class="op">[]{</span></span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>array<span class="op">&lt;</span><span class="dt">int</span>, N<span class="op">&gt;</span> indices;</span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a>    std<span class="op">::</span>ranges<span class="op">::</span>iota<span class="op">(</span>indices, <span class="dv">0</span><span class="op">)</span>;</span>
+<span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> indices;</span>
+<span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a>  <span class="op">}()</span>;</span>
+<span id="cb31-13"><a href="#cb31-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-14"><a href="#cb31-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> <span class="op">[...</span>Is<span class="op">]</span> <span class="op">=</span> indices;</span>
+<span id="cb31-15"><a href="#cb31-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> std<span class="op">::</span>make_tuple<span class="op">(</span>t<span class="op">.[:</span> members<span class="op">[</span>Is<span class="op">]</span> <span class="op">:]...)</span>;</span>
+<span id="cb31-16"><a href="#cb31-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <p>An alternative approach is:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb32"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> type_struct_to_tuple<span class="op">(</span>info type<span class="op">)</span> <span class="op">-&gt;</span> info <span class="op">{</span></span>
-<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> substitute<span class="op">(^^</span>std<span class="op">::</span>tuple,</span>
-<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>                    nonstatic_data_members_of<span class="op">(</span>type<span class="op">)</span></span>
-<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span> std<span class="op">::</span>views<span class="op">::</span>transform<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>type_of<span class="op">)</span></span>
-<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span> std<span class="op">::</span>views<span class="op">::</span>transform<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>remove_cvref<span class="op">)</span></span>
-<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span> std<span class="op">::</span>ranges<span class="op">::</span>to<span class="op">&lt;</span>std<span class="op">::</span>vector<span class="op">&gt;())</span>;</span>
-<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> To, <span class="kw">typename</span> From, std<span class="op">::</span>meta<span class="op">::</span>info <span class="op">...</span> members<span class="op">&gt;</span></span>
-<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> struct_to_tuple_helper<span class="op">(</span>From <span class="kw">const</span><span class="op">&amp;</span> from<span class="op">)</span> <span class="op">-&gt;</span> To <span class="op">{</span></span>
-<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> To<span class="op">(</span>from<span class="op">.[:</span>members<span class="op">:]...)</span>;</span>
-<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb32-13"><a href="#cb32-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">typename</span> From<span class="op">&gt;</span></span>
-<span id="cb32-15"><a href="#cb32-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> get_struct_to_tuple_helper<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb32-16"><a href="#cb32-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> To <span class="op">=</span> <span class="op">[:</span> type_struct_to_tuple<span class="op">(^^</span>From<span class="op">):</span> <span class="op">]</span>;</span>
-<span id="cb32-17"><a href="#cb32-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-18"><a href="#cb32-18" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector args <span class="op">=</span> <span class="op">{^^</span>To, <span class="op">^^</span>From<span class="op">}</span>;</span>
-<span id="cb32-19"><a href="#cb32-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span><span class="kw">auto</span> mem <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>From<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb32-20"><a href="#cb32-20" aria-hidden="true" tabindex="-1"></a>    args<span class="op">.</span>push_back<span class="op">(</span>reflect_value<span class="op">(</span>mem<span class="op">))</span>;</span>
-<span id="cb32-21"><a href="#cb32-21" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb32-22"><a href="#cb32-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-23"><a href="#cb32-23" aria-hidden="true" tabindex="-1"></a>  <span class="co">/*</span></span>
-<span id="cb32-24"><a href="#cb32-24" aria-hidden="true" tabindex="-1"></a><span class="co">  Alternatively, with Ranges:</span></span>
-<span id="cb32-25"><a href="#cb32-25" aria-hidden="true" tabindex="-1"></a><span class="co">  args.append_range(</span></span>
-<span id="cb32-26"><a href="#cb32-26" aria-hidden="true" tabindex="-1"></a><span class="co">    nonstatic_data_members_of(^^From)</span></span>
-<span id="cb32-27"><a href="#cb32-27" aria-hidden="true" tabindex="-1"></a><span class="co">    | std::views::transform(std::meta::reflect_value)</span></span>
-<span id="cb32-28"><a href="#cb32-28" aria-hidden="true" tabindex="-1"></a><span class="co">    );</span></span>
-<span id="cb32-29"><a href="#cb32-29" aria-hidden="true" tabindex="-1"></a><span class="co">  */</span></span>
-<span id="cb32-30"><a href="#cb32-30" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-31"><a href="#cb32-31" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> extract<span class="op">&lt;</span>To<span class="op">(*)(</span>From <span class="kw">const</span><span class="op">&amp;)&gt;(</span></span>
-<span id="cb32-32"><a href="#cb32-32" aria-hidden="true" tabindex="-1"></a>    substitute<span class="op">(^^</span>struct_to_tuple_helper, args<span class="op">))</span>;</span>
-<span id="cb32-33"><a href="#cb32-33" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb32-34"><a href="#cb32-34" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-35"><a href="#cb32-35" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> From<span class="op">&gt;</span></span>
-<span id="cb32-36"><a href="#cb32-36" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> struct_to_tuple<span class="op">(</span>From <span class="kw">const</span><span class="op">&amp;</span> from<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb32-37"><a href="#cb32-37" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> get_struct_to_tuple_helper<span class="op">&lt;</span>From<span class="op">&gt;()(</span>from<span class="op">)</span>;</span>
-<span id="cb32-38"><a href="#cb32-38" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> substitute<span class="op">(^^</span>std<span class="op">::</span>tuple,</span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>                    nonstatic_data_members_of<span class="op">(</span>type, ctx<span class="op">)</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span> std<span class="op">::</span>views<span class="op">::</span>transform<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>type_of<span class="op">)</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span> std<span class="op">::</span>views<span class="op">::</span>transform<span class="op">(</span>std<span class="op">::</span>meta<span class="op">::</span>remove_cvref<span class="op">)</span></span>
+<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>                    <span class="op">|</span> std<span class="op">::</span>ranges<span class="op">::</span>to<span class="op">&lt;</span>std<span class="op">::</span>vector<span class="op">&gt;())</span>;</span>
+<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> To, <span class="kw">typename</span> From, std<span class="op">::</span>meta<span class="op">::</span>info <span class="op">...</span> members<span class="op">&gt;</span></span>
+<span id="cb32-11"><a href="#cb32-11" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> struct_to_tuple_helper<span class="op">(</span>From <span class="kw">const</span><span class="op">&amp;</span> from<span class="op">)</span> <span class="op">-&gt;</span> To <span class="op">{</span></span>
+<span id="cb32-12"><a href="#cb32-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> To<span class="op">(</span>from<span class="op">.[:</span>members<span class="op">:]...)</span>;</span>
+<span id="cb32-13"><a href="#cb32-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-15"><a href="#cb32-15" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">typename</span> From<span class="op">&gt;</span></span>
+<span id="cb32-16"><a href="#cb32-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="kw">auto</span> get_struct_to_tuple_helper<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb32-17"><a href="#cb32-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> To <span class="op">=</span> <span class="op">[:</span> type_struct_to_tuple<span class="op">(^^</span>From<span class="op">):</span> <span class="op">]</span>;</span>
+<span id="cb32-18"><a href="#cb32-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb32-19"><a href="#cb32-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-20"><a href="#cb32-20" aria-hidden="true" tabindex="-1"></a>  std<span class="op">::</span>vector args <span class="op">=</span> <span class="op">{^^</span>To, <span class="op">^^</span>From<span class="op">}</span>;</span>
+<span id="cb32-21"><a href="#cb32-21" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> <span class="op">(</span><span class="kw">auto</span> mem <span class="op">:</span> nonstatic_data_members_of<span class="op">(^^</span>From, ctx<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb32-22"><a href="#cb32-22" aria-hidden="true" tabindex="-1"></a>    args<span class="op">.</span>push_back<span class="op">(</span>reflect_value<span class="op">(</span>mem<span class="op">))</span>;</span>
+<span id="cb32-23"><a href="#cb32-23" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb32-24"><a href="#cb32-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-25"><a href="#cb32-25" aria-hidden="true" tabindex="-1"></a>  <span class="co">/*</span></span>
+<span id="cb32-26"><a href="#cb32-26" aria-hidden="true" tabindex="-1"></a><span class="co">  Alternatively, with Ranges:</span></span>
+<span id="cb32-27"><a href="#cb32-27" aria-hidden="true" tabindex="-1"></a><span class="co">  args.append_range(</span></span>
+<span id="cb32-28"><a href="#cb32-28" aria-hidden="true" tabindex="-1"></a><span class="co">    nonstatic_data_members_of(^^From, ctx)</span></span>
+<span id="cb32-29"><a href="#cb32-29" aria-hidden="true" tabindex="-1"></a><span class="co">    | std::views::transform(std::meta::reflect_value)</span></span>
+<span id="cb32-30"><a href="#cb32-30" aria-hidden="true" tabindex="-1"></a><span class="co">    );</span></span>
+<span id="cb32-31"><a href="#cb32-31" aria-hidden="true" tabindex="-1"></a><span class="co">  */</span></span>
+<span id="cb32-32"><a href="#cb32-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-33"><a href="#cb32-33" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> extract<span class="op">&lt;</span>To<span class="op">(*)(</span>From <span class="kw">const</span><span class="op">&amp;)&gt;(</span></span>
+<span id="cb32-34"><a href="#cb32-34" aria-hidden="true" tabindex="-1"></a>    substitute<span class="op">(^^</span>struct_to_tuple_helper, args<span class="op">))</span>;</span>
+<span id="cb32-35"><a href="#cb32-35" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb32-36"><a href="#cb32-36" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb32-37"><a href="#cb32-37" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> From<span class="op">&gt;</span></span>
+<span id="cb32-38"><a href="#cb32-38" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> struct_to_tuple<span class="op">(</span>From <span class="kw">const</span><span class="op">&amp;</span> from<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb32-39"><a href="#cb32-39" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> get_struct_to_tuple_helper<span class="op">&lt;</span>From<span class="op">&gt;()(</span>from<span class="op">)</span>;</span>
+<span id="cb32-40"><a href="#cb32-40" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <p>Here, <code class="sourceCode cpp">type_struct_to_tuple</code> takes
@@ -2634,7 +2663,7 @@ correct specialization of
 <code class="sourceCode cpp">struct_to_tuple_helper</code>, which we can
 simply invoke.</p>
 <p>On Compiler Explorer (with a different implementation than either of
-the above): <a href="https://godbolt.org/z/1Tffn4vzn">EDG</a>, <a href="https://godbolt.org/z/9WzGM93dM">Clang</a>.</p>
+the above): <a href="https://godbolt.org/z/1Tffn4vzn">EDG</a>, <a href="https://godbolt.org/z/dn58s5Pvz">Clang</a>.</p>
 <h2 data-number="3.15" id="implementing-tuple_cat"><span class="header-section-number">3.15</span> Implementing
 <code class="sourceCode cpp">tuple_cat</code><a href="#implementing-tuple_cat" class="self-link"></a></h2>
 <p>Courtesy of Tomasz Kaminski, <a href="https://godbolt.org/z/M38b3a7z4">on compiler explorer</a>:</p>
@@ -2733,15 +2762,16 @@ pattern already shown with
 <span id="cb35-22"><a href="#cb35-22" aria-hidden="true" tabindex="-1"></a>  make_named_tuple<span class="op">(^^</span>R, pair<span class="op">&lt;</span><span class="dt">int</span>, <span class="st">&quot;x&quot;</span><span class="op">&gt;{}</span>, pair<span class="op">&lt;</span><span class="dt">double</span>, <span class="st">&quot;y&quot;</span><span class="op">&gt;{})</span>;</span>
 <span id="cb35-23"><a href="#cb35-23" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
 <span id="cb35-24"><a href="#cb35-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb35-25"><a href="#cb35-25" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R<span class="op">)[</span><span class="dv">0</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb35-26"><a href="#cb35-26" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R<span class="op">)[</span><span class="dv">1</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">double</span><span class="op">)</span>;</span>
-<span id="cb35-27"><a href="#cb35-27" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb35-28"><a href="#cb35-28" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb35-29"><a href="#cb35-29" aria-hidden="true" tabindex="-1"></a>    <span class="op">[[</span><span class="at">maybe_unused</span><span class="op">]]</span> <span class="kw">auto</span> r <span class="op">=</span> R<span class="op">{.</span>x<span class="op">=</span><span class="dv">1</span>, <span class="op">.</span>y<span class="op">=</span><span class="fl">2.0</span><span class="op">}</span>;</span>
-<span id="cb35-30"><a href="#cb35-30" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb35-25"><a href="#cb35-25" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb35-26"><a href="#cb35-26" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R, ctx<span class="op">)[</span><span class="dv">0</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb35-27"><a href="#cb35-27" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R, ctx<span class="op">)[</span><span class="dv">1</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">double</span><span class="op">)</span>;</span>
+<span id="cb35-28"><a href="#cb35-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb35-29"><a href="#cb35-29" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb35-30"><a href="#cb35-30" aria-hidden="true" tabindex="-1"></a>    <span class="op">[[</span><span class="at">maybe_unused</span><span class="op">]]</span> <span class="kw">auto</span> r <span class="op">=</span> R<span class="op">{.</span>x<span class="op">=</span><span class="dv">1</span>, <span class="op">.</span>y<span class="op">=</span><span class="fl">2.0</span><span class="op">}</span>;</span>
+<span id="cb35-31"><a href="#cb35-31" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
-<p>On Compiler Explorer: <a href="https://godbolt.org/z/64qTe4KG1">EDG</a>, <a href="https://godbolt.org/z/76qM1xqvn">Clang</a>.</p>
+<p>On Compiler Explorer: <a href="https://godbolt.org/z/64qTe4KG1">EDG</a>, <a href="https://godbolt.org/z/rPM5xsbvW">Clang</a>.</p>
 <p>Alternatively, can side-step the question of non-type template
 parameters entirely by keeping everything in the value domain:</p>
 <div class="std">
@@ -2760,12 +2790,13 @@ parameters entirely by keeping everything in the value domain:</p>
 <span id="cb36-12"><a href="#cb36-12" aria-hidden="true" tabindex="-1"></a>  make_named_tuple<span class="op">(^^</span>R, <span class="op">{{^^</span><span class="dt">int</span>, <span class="st">&quot;x&quot;</span><span class="op">}</span>, <span class="op">{^^</span><span class="dt">double</span>, <span class="st">&quot;y&quot;</span><span class="op">}})</span>;</span>
 <span id="cb36-13"><a href="#cb36-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
 <span id="cb36-14"><a href="#cb36-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb36-15"><a href="#cb36-15" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R<span class="op">)[</span><span class="dv">0</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
-<span id="cb36-16"><a href="#cb36-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R<span class="op">)[</span><span class="dv">1</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">double</span><span class="op">)</span>;</span>
-<span id="cb36-17"><a href="#cb36-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb36-18"><a href="#cb36-18" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb36-19"><a href="#cb36-19" aria-hidden="true" tabindex="-1"></a>    <span class="op">[[</span><span class="at">maybe_unused</span><span class="op">]]</span> <span class="kw">auto</span> r <span class="op">=</span> R<span class="op">{.</span>x<span class="op">=</span><span class="dv">1</span>, <span class="op">.</span>y<span class="op">=</span><span class="fl">2.0</span><span class="op">}</span>;</span>
-<span id="cb36-20"><a href="#cb36-20" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<span id="cb36-15"><a href="#cb36-15" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb36-16"><a href="#cb36-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R, ctx<span class="op">)[</span><span class="dv">0</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
+<span id="cb36-17"><a href="#cb36-17" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(</span>nonstatic_data_members_of<span class="op">(^^</span>R, ctx<span class="op">)[</span><span class="dv">1</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span><span class="dt">double</span><span class="op">)</span>;</span>
+<span id="cb36-18"><a href="#cb36-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb36-19"><a href="#cb36-19" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb36-20"><a href="#cb36-20" aria-hidden="true" tabindex="-1"></a>    <span class="op">[[</span><span class="at">maybe_unused</span><span class="op">]]</span> <span class="kw">auto</span> r <span class="op">=</span> R<span class="op">{.</span>x<span class="op">=</span><span class="dv">1</span>, <span class="op">.</span>y<span class="op">=</span><span class="fl">2.0</span><span class="op">}</span>;</span>
+<span id="cb36-21"><a href="#cb36-21" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </blockquote>
 </div>
 <p>On Compiler Explorer: <a href="https://godbolt.org/z/oY6ETbv9x">EDG
@@ -2890,10 +2921,10 @@ metafunction can also be used to map a reflection of an object to a
 reflection of its value.</p>
 <h3 data-number="4.1.1" id="syntax-discussion"><span class="header-section-number">4.1.1</span> Syntax discussion<a href="#syntax-discussion" class="self-link"></a></h3>
 <p>The original TS landed on <code class="sourceCode cpp"><span class="cf">reflexpr</span><span class="op">(...)</span></code>
-as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that syntax as well.
-As more examples were discussed, it became clear that that syntax was
-both (a) too “heavy” and (b) insufficiently distinct from a function
-call. SG7 eventually agreed upon the prefix
+as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that syntax as well. As
+more examples were discussed, it became clear that that syntax was both
+(a) too “heavy” and (b) insufficiently distinct from a function call.
+SG7 eventually agreed upon the prefix
 <code class="sourceCode cpp"><span class="op">^</span></code> operator.
 The “upward arrow” interpretation of the caret matches the “lift” or
 “raise” verbs that are sometimes used to describe the reflection
@@ -2924,8 +2955,8 @@ lifting, <code class="sourceCode cpp">\</code> and
 syntax.</p>
 <p>In Wrocław 2024, SG7 and EWG voted to adopt
 <code class="sourceCode cpp"><span class="op">^^</span></code> as the
-new reflection operator (as proposed by <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span>). The R8 revision of this
-paper integrates that change.</p>
+new reflection operator (as proposed by <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span>). The R8 revision of this paper
+integrates that change.</p>
 <h2 data-number="4.2" id="splicers"><span class="header-section-number">4.2</span> Splicers
 (<code class="sourceCode cpp"><span class="op">[:</span></code>…<code class="sourceCode cpp"><span class="op">:]</span></code>)<a href="#splicers" class="self-link"></a></h2>
 <p>A reflection can be “spliced” into source code using one of several
@@ -3176,8 +3207,8 @@ extension in a future paper.</p>
 (described in more detail below). However, there are many cases where we
 don’t have a single reflection, we have a range of reflections - and we
 want to splice them all in one go. For that, the predecessor to this
-paper, <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span>, proposed an additional form
-of splicer: a range splicer.</p>
+paper, <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span>, proposed an additional form of
+splicer: a range splicer.</p>
 <p>Construct the <a href="#converting-a-struct-to-a-tuple">struct-to-tuple</a> example from
 above. It was demonstrated using a single splice, but it would be
 simpler if we had a range splice:</p>
@@ -3263,7 +3294,7 @@ Which is enough for a tolerable implementation:</p>
 <h3 data-number="4.2.4" id="syntax-discussion-1"><span class="header-section-number">4.2.4</span> Syntax discussion<a href="#syntax-discussion-1" class="self-link"></a></h3>
 <p>Early discussions of splice-like constructs (related to the TS
 design) considered using <code class="sourceCode cpp"><span class="cf">unreflexpr</span><span class="op">(...)</span></code>
-for that purpose. <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that option for
+for that purpose. <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that option for
 <em>expression</em> splicing, observing that a single splicing syntax
 could not viably be parsed (some disambiguation is needed to distinguish
 types and templates). SG-7 eventually agreed to adopt the <code class="sourceCode cpp"><span class="op">[:</span> <span class="op">...</span> <span class="op">:]</span></code>
@@ -3344,7 +3375,7 @@ document templates:</p>
 need syntax for in the future:</p>
 <ul>
 <li>code injection (of whatever form), and</li>
-<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1"><a href="https://wg21.link/p1887r1" role="doc-biblioref">[P1887R1]</a></span> suggested
+<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1">[<a href="https://wg21.link/p1887r1" role="doc-biblioref">P1887R1</a>]</span> suggested
 <code class="sourceCode cpp"><span class="op">+</span></code> as an
 annotation introducer, but
 <code class="sourceCode cpp"><span class="op">+</span></code> can begin
@@ -3563,7 +3594,7 @@ example:</p>
 </div>
 <p>Hence this proposal also introduces constraints on constant
 evaluation as follows…</p>
-<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]</a></span>) have the property that their
+<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span>) have the property that their
 evaluation must occur and must succeed in a valid C++ program. We
 require that a programmer can count on those evaluations occurring
 exactly once and completing at translation time.</p>
@@ -3574,15 +3605,14 @@ source constructs lexically following them.</p>
 <p>Those constraints are mostly intuitive, but they are a significant
 change to the underlying principles of the current standard in this
 respect.</p>
-<p><span class="title"><span class="citation" data-cites="P2758R4"><a href="https://wg21.link/p2758r4" role="doc-biblioref">[P2758R4]
-(Emitting messages at compile time)</a></span></span> also has to deal
-with side effects during constant evaluation. However, those effects
-(“output”) are of a slightly different nature in the sense that they can
-be buffered until a manifestly constant-evaluated expression/conversion
-has completed. “Buffering” a class type completion is not practical
-(e.g., because other metafunctions may well depend on the completed
-class type). Still, we are not aware of incompatibilities between our
-proposal and P2758.</p>
+<p><span class="title"><span class="citation" data-cites="P2758R4">[<a href="#ref-P2758R4" role="doc-biblioref"><strong>P2758R4?</strong></a>]</span></span> also
+has to deal with side effects during constant evaluation. However, those
+effects (“output”) are of a slightly different nature in the sense that
+they can be buffered until a manifestly constant-evaluated
+expression/conversion has completed. “Buffering” a class type completion
+is not practical (e.g., because other metafunctions may well depend on
+the completed class type). Still, we are not aware of incompatibilities
+between our proposal and P2758.</p>
 <h3 data-number="4.4.2" id="error-handling-in-reflection"><span class="header-section-number">4.4.2</span> Error-Handling in
 Reflection<a href="#error-handling-in-reflection" class="self-link"></a></h3>
 <p>Earlier revisions of this proposal suggested several possible
@@ -3655,7 +3685,7 @@ constant expressions (we would of course still keep the requirement that
 the constraint is a
 <code class="sourceCode cpp"><span class="dt">bool</span></code>).</p></li>
 </ul>
-<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1"><a href="https://wg21.link/p3068r1" role="doc-biblioref">[P3068R1]</a></span> has proposed the introduction
+<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1">[<a href="https://wg21.link/p3068r1" role="doc-biblioref">P3068R1</a>]</span> has proposed the introduction
 of constexpr exceptions. The proposal addresses hurdles like compiler
 modes that disable exception support, and a Clang-based implementation
 is underway. We believe this to be the most desirable error-handling
@@ -4015,14 +4045,14 @@ translated to a different presentation (as in (2)).</p></li>
 to evaluate if the identifier cannot be represented in the ordinary
 literal encoding.</p>
 <h3 data-number="4.4.6" id="reflecting-names"><span class="header-section-number">4.4.6</span> Reflecting names<a href="#reflecting-names" class="self-link"></a></h3>
-<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>) included a metafunction
-called <code class="sourceCode cpp">name_of</code>, which we defined to
-return a <code class="sourceCode cpp">string_view</code> containing the
-“name” of the reflected entity. As the paper evolved, it became
-necessary to sharpen the specification of what this “name” contains.
-Subsequent revisions (beginning with P2996R2, presented in Tokyo)
-specified that <code class="sourceCode cpp">name_of</code> returns the
-unqualified name, whereas a new
+<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>) included a metafunction called
+<code class="sourceCode cpp">name_of</code>, which we defined to return
+a <code class="sourceCode cpp">string_view</code> containing the “name”
+of the reflected entity. As the paper evolved, it became necessary to
+sharpen the specification of what this “name” contains. Subsequent
+revisions (beginning with P2996R2, presented in Tokyo) specified that
+<code class="sourceCode cpp">name_of</code> returns the unqualified
+name, whereas a new
 <code class="sourceCode cpp">qualified_name_of</code> would give the
 fully qualified name.</p>
 <p>Most would agree that <code class="sourceCode cpp">qualified_name_of<span class="op">(^^</span><span class="dt">size_t</span><span class="op">)</span></code>
@@ -4410,9 +4440,9 @@ side-effect.</p>
 <code class="sourceCode cpp">define_aggregate</code> can be used, we are
 not aware of any motivating use cases for P2996 that are harmed. Worth
 mentioning, however: the rule has more dire implications for other code
-injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2"><a href="https://wg21.link/p3294r2" role="doc-biblioref">[P3294R2]</a></span> (“<em>Code Injection With
-Token Sequences</em>”). With this rule as it is, it becomes impossible
-for e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
+injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2">[<a href="https://wg21.link/p3294r2" role="doc-biblioref">P3294R2</a>]</span> (“<em>Code Injection With Token
+Sequences</em>”). With this rule as it is, it becomes impossible for
+e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
 to produce an injected declaration of <code class="sourceCode cpp">std<span class="op">::</span>formatter<span class="op">&lt;</span>TCls<span class="op">&lt;</span>Foo<span class="op">&gt;&gt;</span></code>
 (since the target scope would be the global namespace).</p>
 <p>In this context, we do believe that relaxations of the rule can be
@@ -4434,8 +4464,7 @@ implementations<a href="#freestanding-implementations" class="self-link"></a></h
 return a
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>
 value. Unfortunately, that means that they are currently not usable in a
-freestanding environment, but <span class="citation" data-cites="P3295R0"><a href="https://wg21.link/p3295r0" role="doc-biblioref">[P3295R0]</a></span> currently proposes
-freestanding
+freestanding environment, but <span class="citation" data-cites="P3295R0">[<a href="https://wg21.link/p3295r0" role="doc-biblioref">P3295R0</a>]</span> currently proposes freestanding
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>,
 <code class="sourceCode cpp">std<span class="op">::</span>string</code>,
 and <code class="sourceCode cpp">std<span class="op">::</span>allocator</code> in
@@ -5319,7 +5348,7 @@ complete definition of <code class="sourceCode cpp">T</code>, and they
 both afterwards <code class="sourceCode cpp"><span class="pp">#include </span><span class="im">&quot;cls.h&quot;</span></code>,
 the result will be an ODR violation.</p>
 <p>Additional papers are already in flight proposing additional
-metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2"><a href="https://wg21.link/p3096r2" role="doc-biblioref">[P3096R2]</a></span> proposes the
+metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2">[<a href="https://wg21.link/p3096r2" role="doc-biblioref">P3096R2</a>]</span> proposes the
 <code class="sourceCode cpp">parameters_of</code> metafunction. This
 feature is important for generating language bindings (e.g., Python,
 JavaScript), but since parameter names can differ between declarations,
@@ -5384,7 +5413,7 @@ follows:</p>
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_6" id="pnum_6">7-8</a></span>
 Whitespace characters separating tokens are no longer significant. Each
-preprocessing token is converted into a token (<span>5.10 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). The
+preprocessing token is converted into a token (<span>5.6 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). The
 resulting tokens constitute a translation unit and are syntactically and
 semantically analyzed and translated.</p>
 <p><span class="note3"><span>[ <em>Note 3:</em> </span>The process of
@@ -5510,7 +5539,7 @@ image which contains information needed for execution in its execution
 environment.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.5
+<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.4
 <a href="https://wg21.link/lex.pptoken">[lex.pptoken]</a></span>
 Preprocessing tokens<a href="#lex.pptoken-preprocessing-tokens" class="self-link"></a></h3>
 <p>Add a bullet after bullet (4.2):</p>
@@ -5556,11 +5585,11 @@ note</em> ]</span></span></span></p></li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
+<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
 Operators and punctuators<a href="#lex.operators-operators-and-punctuators" class="self-link"></a></h3>
 <p>Change the grammar for
 <code class="sourceCode cpp"><em>operator-or-punctuator</em></code> in
-paragraph 1 of <span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
+paragraph 1 of <span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
 include the reflection operator and the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>
 delimiters:</p>
@@ -5758,7 +5787,7 @@ follows:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_33" id="pnum_33">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an
-<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.5
+<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.4
 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>)
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code>
@@ -6311,7 +6340,7 @@ is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
 <ul>
 <li>a value of structural type (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>),</li>
-<li>an object with static storage duration (<span>6.7.6 <a href="https://wg21.link/basic.stc">[basic.stc]</a></span>),</li>
+<li>an object with static storage duration (<span>6.7.5 <a href="https://wg21.link/basic.stc">[basic.stc]</a></span>),</li>
 <li>a variable (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>),</li>
 <li>a structured binding (<span>9.6 <a href="https://wg21.link/dcl.struct.bind">[dcl.struct.bind]</a></span>),</li>
 <li>a function (<span>9.3.4.6 <a href="https://wg21.link/dcl.fct">[dcl.fct]</a></span>),</li>
@@ -6527,7 +6556,7 @@ the grammar for
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
 <p>Modify paragraph 2 to avoid transforming non-static members into
@@ -6539,7 +6568,7 @@ implicit member accesses when named as operands to
 If an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><em>E</em></code> denotes a non-static
 non-type member of some class <code class="sourceCode cpp">C</code> at a
-point where the current class (<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
+point where the current class (<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
 <code class="sourceCode cpp">X</code> and</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(2.1)</a></span>
@@ -6569,7 +6598,7 @@ transformed into a class member access expression using <code class="sourceCode 
 as the object expression.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.4.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
 Unqualified names<a href="#expr.prim.id.unqual-unqualified-names" class="self-link"></a></h3>
 <p>Modify paragraph 4 to allow
 <code class="sourceCode cpp"><em>splice-expression</em></code>s to be
@@ -6619,7 +6648,7 @@ the <code class="sourceCode cpp"><em>throw-expression</em></code>.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -6810,7 +6839,7 @@ not declarative, the entity shall not be a template.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.6.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
+<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
 Closure types<a href="#expr.prim.lambda.closure-closure-types" class="self-link"></a></h3>
 <p>We have to say that a closure type is not complete until the
 <code class="sourceCode cpp"><span class="op">}</span></code>:</p>
@@ -6863,7 +6892,7 @@ conversion function template has the same invented template parameter
 list, […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.lambda.capture-captures"><span>7.5.6.3 <a href="https://wg21.link/expr.prim.lambda.capture">[expr.prim.lambda.capture]</a></span>
+<h3 class="unnumbered" id="expr.prim.lambda.capture-captures"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.lambda.capture">[expr.prim.lambda.capture]</a></span>
 Captures<a href="#expr.prim.lambda.capture-captures" class="self-link"></a></h3>
 <p>Modify bullet 7.1 as follows:</p>
 <div class="std">
@@ -6950,7 +6979,7 @@ splices:</p>
 </div>
 </blockquote>
 </div>
-<h3 data-number="5.1.1" id="expr.prim.req.type-type-requirements"><span class="header-section-number">5.1.1</span> <span>7.5.8.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
+<h3 data-number="5.1.1" id="expr.prim.req.type-type-requirements"><span class="header-section-number">5.1.1</span> <span>7.5.7.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
 Type requirements<a href="#expr.prim.req.type-type-requirements" class="self-link"></a></h3>
 <p>Allow splices in type requirements:</p>
 <div class="std">
@@ -6992,7 +7021,7 @@ of its
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -7129,7 +7158,7 @@ designates a non-static data member and it appears in an unevaluated
 operand.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 3:</em> </span>The implicit
-transformation (<span>7.5.5 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
+transformation (<span>7.5.4 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
 an <code class="sourceCode cpp"><em>id-expression</em></code> denoting a
 non-static member becomes a class member access does not apply to a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.<span>
@@ -7794,7 +7823,7 @@ each constituent reference refers to an object or a non-immediate
 function,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(22.4)</a></span>
 no constituent value of scalar type is an indeterminate value
-(<span>6.7.5 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
+(<span>6.7.4 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(22.5)</a></span>
 no constituent value of pointer type is a pointer to an immediate
 function or an invalid pointer value ([basic.compound]), <span class="rm" style="color: #bf0303"><del>and</del></span></li>
@@ -9300,7 +9329,7 @@ augmented by the addition of an implied function argument as in a
 qualified function call. If the current class is, or is derived from,
 <code class="sourceCode cpp">T</code>, and the keyword
 <code class="sourceCode cpp"><span class="kw">this</span></code>
-(<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
+(<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
 refers to it, then the implied object argument is <code class="sourceCode cpp"><span class="op">(*</span><span class="kw">this</span><span class="op">)</span></code>.
 Otherwise, a contrived object of type
 <code class="sourceCode cpp">T</code> becomes the implied object
@@ -13250,7 +13279,7 @@ be used to query the properties of a type at compile time.</p>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
-the function is a non-constant library call (<span>3.35 <a href="https://wg21.link/defns.nonconst.libcall">[defns.nonconst.libcall]</a></span>)
+the function is a non-constant library call (<span>3.34 <a href="https://wg21.link/defns.nonconst.libcall">[defns.nonconst.libcall]</a></span>)
 if that argument is not a reflection of a type or type alias. For each
 function taking an argument named
 <code class="sourceCode cpp">type_args</code>, a call to the function is
@@ -13730,13 +13759,13 @@ respectively. Equivalent to <code class="sourceCode cpp"><span class="cf">return
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
+<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
 template <code class="sourceCode cpp">bit_cast</code><a href="#bit.cast-function-template-bit_cast" class="self-link"></a></h3>
 <p>And we have adjust the requirements of
 <code class="sourceCode cpp">bit_cast</code> to not allow casting to or
 from
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>,
-in <span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
+in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
 as a mandates:</p>
 <div class="std">
 <blockquote>
@@ -13867,7 +13896,7 @@ makes sense to provide one?</p>
 </div>
 <h1 data-number="6" style="border-bottom:1px solid #cccccc" id="appendix-design-changes-approved-in-hagenberg"><span class="header-section-number">6</span> Appendix: Design changes approved
 in Hagenberg<a href="#appendix-design-changes-approved-in-hagenberg" class="self-link"></a></h1>
-<p><span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span> was forwarded to CWG in
+<p><span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span> was forwarded to CWG in
 St. Louis (June 2024). In the time after, some minor design changes were
 shown to be necessary. The following changes were confirmed by EWG
 during the Hagenberg 2025 meeting.</p>
@@ -13988,9 +14017,10 @@ Reflections of concepts cannot be spliced.
 <code class="sourceCode cpp"><em>type-constraint</em></code>s and
 <code class="sourceCode cpp"><em>concept-id</em></code>s.</li>
 <li><strong>D2996R10</strong>: Splicing a concept is ill-formed.</li>
-<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5"><a href="https://wg21.link/p2841r5" role="doc-biblioref">[P2841R5]</a></span> has already done the work to
-figure out dependent concepts. CWG requested that we wait for that to
-land first, and revisit concept splicers in a future paper.</li>
+<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5">[<a href="#ref-P2841R5" role="doc-biblioref"><strong>P2841R5?</strong></a>]</span> has already
+done the work to figure out dependent concepts. CWG requested that we
+wait for that to land first, and revisit concept splicers in a future
+paper.</li>
 <li><strong>Instead</strong>: For the case of a
 <code class="sourceCode cpp"><em>concept-id</em></code>,
 <code class="sourceCode cpp">substitute</code> can still check whether a
@@ -14098,18 +14128,10 @@ Non-transient constexpr allocation using propconst. <a href="https://wg21.link/p
 [P2686R5] Corentin Jabot, Brian Bi. 2024-11-12. constexpr structured
 bindings and references to constexpr variables. <a href="https://wg21.link/p2686r5"><div class="csl-block">https://wg21.link/p2686r5</div></a>
 </div>
-<div id="ref-P2758R4" class="csl-entry" role="doc-biblioentry">
-[P2758R4] Barry Revzin. 2025-01-07. Emitting messages at compile time.
-<a href="https://wg21.link/p2758r4"><div class="csl-block">https://wg21.link/p2758r4</div></a>
-</div>
 <div id="ref-P2786R13" class="csl-entry" role="doc-biblioentry">
 [P2786R13] Alisdair Meredith, Mungo Gill, Joshua Berne, Corentin Jabot,
 Pablo Halpern, and Lori Hughes. 2025-02-14. Trivial Relocatability For
 C++26. <a href="https://wg21.link/p2786r13"><div class="csl-block">https://wg21.link/p2786r13</div></a>
-</div>
-<div id="ref-P2841R5" class="csl-entry" role="doc-biblioentry">
-[P2841R5] Corentin Jabot, Gašper Ažman, James Touton. 2024-10-16.
-Concept and variable-template template-parameters. <a href="https://wg21.link/p2841r5"><div class="csl-block">https://wg21.link/p2841r5</div></a>
 </div>
 <div id="ref-P2996R0" class="csl-entry" role="doc-biblioentry">
 [P2996R0] Barry Revzin, Wyatt Childers, Peter Dimov, Andrew Sutton,
@@ -14156,7 +14178,7 @@ C++26. <a href="https://wg21.link/p2996r7"><div class="csl-block">https://wg21.l
 </div>
 <div id="ref-P2996R8" class="csl-entry" role="doc-biblioentry">
 [P2996R8] Barry Revzin, Wyatt Childers, Peter Dimov, Andrew Sutton,
-Faisal Vali, Daveed Vandevoorde, Dan Katz. 2024-12-17. Reflection for
+Faisal Vali, Daveed Vandevoorde, Dan Katz. 2024-12-16. Reflection for
 C++26. <a href="https://wg21.link/p2996r8"><div class="csl-block">https://wg21.link/p2996r8</div></a>
 </div>
 <div id="ref-P2996R9" class="csl-entry" role="doc-biblioentry">

--- a/2996_reflection/d2996r11.html
+++ b/2996_reflection/d2996r11.html
@@ -2562,7 +2562,7 @@ API:</p>
 <p>Of course, any production-ready
 <code class="sourceCode cpp">hash_append</code> would include a facility
 for classes to opt members in and out of participation in hashing.
-Annotations as proposed by <span class="citation" data-cites="P3394">[<a href="#ref-P3394" role="doc-biblioref"><strong>P3394?</strong></a>]</span> provides just
+Annotations as proposed by <span class="citation" data-cites="P3394R2">[<a href="#ref-P3394R2" role="doc-biblioref"><strong>P3394R2?</strong></a>]</span> provides just
 such a mechanism.</p>
 <h2 data-number="3.14" id="converting-a-struct-to-a-tuple"><span class="header-section-number">3.14</span> Converting a Struct to a
 Tuple<a href="#converting-a-struct-to-a-tuple" class="self-link"></a></h2>
@@ -12873,42 +12873,44 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb247-3"><a href="#cb247-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
 <span id="cb247-4"><a href="#cb247-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
 <span id="cb247-5"><a href="#cb247-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">1</a></span>
+<em>Constant When</em>: Let</p>
 <div class="sourceCode" id="cb248"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb248-1"><a href="#cb248-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb248-2"><a href="#cb248-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb249"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb249-1"><a href="#cb249-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb249-2"><a href="#cb249-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be
 the sequence of entities, values, and objects represented by the
 elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">7</a></span>
 <em>Returns</em>: A reflection representing <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">8</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>The specialization
 <code class="sourceCode cpp">Z<span class="op">&lt;</span>Args<span class="op">..&gt;</span></code>
 is only instantiated if the deduction of a placeholder type necessarily
@@ -12922,7 +12924,7 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">1</a></span>
 An object <code class="sourceCode cpp"><em>O</em></code> of type
 <code class="sourceCode cpp"><em>T</em></code> is
 <em>meta-reflectable</em> if an lvalue expression denoting
@@ -12932,51 +12934,51 @@ constant template argument for a constant template parameter of type
 ([temp.arg.nontype]).</p>
 <div class="sourceCode" id="cb250"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb250-1"><a href="#cb250-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb250-2"><a href="#cb250-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">2</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a structural
 type that is neither a reference type nor an array type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the value computed
 by an lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">(4.1)</a></span>
 <code class="sourceCode cpp"><em>V</em></code> satisfies the constraints
 for a value computed by a prvalue constant expression
 ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">(4.2)</a></span>
 no constituent reference of
 <code class="sourceCode cpp"><em>V</em></code> refers to an object that
 is not meta-reflectable, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">(4.3)</a></span>
 no constituent value of <code class="sourceCode cpp"><em>V</em></code>
 of pointer type is a pointer to an object that is not
 meta-reflectable.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">5</a></span>
 <em>Returns</em>: A reflection of
 <code class="sourceCode cpp"><em>V</em></code>. The type of the
 represented value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb251"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb251-1"><a href="#cb251-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb251-2"><a href="#cb251-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">6</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates a meta-reflectable object.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">8</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb252"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb252-1"><a href="#cb252-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb252-2"><a href="#cb252-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> fn<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">9</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">10</a></span>
 <em>Returns</em>: A reflection of the function designated by
 <code class="sourceCode cpp">fn</code>.</p>
 </div>
@@ -13004,19 +13006,19 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <span id="cb253-15"><a href="#cb253-15" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> bit_width;</span>
 <span id="cb253-16"><a href="#cb253-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
 <span id="cb253-17"><a href="#cb253-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">data_member_options<span class="op">::</span><em>name-type</em></code>
 are consteval-only types ([basic.types.general]), and are not structural
 types ([temp.param]).</p>
 <div class="sourceCode" id="cb254"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb254-1"><a href="#cb254-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb254-2"><a href="#cb254-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="sourceCode" id="cb255"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb255-2"><a href="#cb255-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="note">
@@ -13038,63 +13040,63 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb257"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb257-1"><a href="#cb257-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb257-2"><a href="#cb257-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp">cv <em>T</em></code>
 where <code class="sourceCode cpp"><em>T</em></code> is either an object
 type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">(4.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">(4.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">(4.4.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">(4.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">(4.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">(4.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">(4.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">(4.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">(4.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em></code> equals
 <code class="sourceCode cpp"><span class="dv">0</span></code> then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value; and</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13103,31 +13105,31 @@ contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type represented
 by <code class="sourceCode cpp">delias<span class="op">(</span>type<span class="op">)</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 or ⊥ if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 does not contain a value, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">6</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>; it can also be
@@ -13137,7 +13139,7 @@ queried by certain other functions in
 <code class="sourceCode cpp">identifier_of</code>).<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb258"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb258-1"><a href="#cb258-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
@@ -13145,7 +13147,7 @@ description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb259"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb259-1"><a href="#cb259-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb259-2"><a href="#cb259-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">8</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -13153,24 +13155,24 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">(8.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">(8.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context; <span class="note"><span>[ <em>Note
 3:</em> </span><code class="sourceCode cpp"><em>C</em></code> can be a
 class template specialization for which there is a reachable definition
 of the primary class template. In this case, an explicit specialization
 is injected.<span> — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">(8.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">(8.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>;</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">(8.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">(8.3)</a></span>
 <code class="sourceCode cpp">is_complete_type<span class="op">(</span>type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>; and</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">(8.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">(8.4)</a></span>
 for every pair
 (<code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>) where
@@ -13179,11 +13181,11 @@ for every pair
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 then either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">(8.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">(8.4.1)</a></span>
 <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">(8.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">(8.4.2)</a></span>
 or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">==</span> <span class="st">u8&quot;_&quot;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 <span class="note"><span>[ <em>Note 4:</em> </span>Every provided
@@ -13191,7 +13193,7 @@ identifier is unique or <code class="sourceCode cpp"><span class="st">&quot;_&qu
 — <em>end note</em> ]</span></span></li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">9</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -13202,28 +13204,28 @@ values such that <code class="sourceCode cpp">data_member_spec<span class="op">(
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">(10.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">(10.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the core constant expression currently under
 evaluation.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization,
 that is not a local class, of a templated class
 <code class="sourceCode cpp"><em>T</em></code>; then
 <code class="sourceCode cpp"><em>D</em></code> is an explicit
 specialization of
 <code class="sourceCode cpp"><em>T</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">(10.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(10.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>. For every
@@ -13234,27 +13236,27 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(10.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">(10.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">(10.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">(10.5.1)</a></span>
 It has the type represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">(10.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">(10.5.2)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, it
 is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">(10.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">(10.5.3)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value, it is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">(10.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(10.5.4)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value, it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(*</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(10.5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">(10.5.5)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>name</code>
 does not contain a value, it is an unnamed bit-field. Otherwise, it is a
 non-static data member with an identifier determined by the character
@@ -13262,7 +13264,7 @@ sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op"
 in UTF-8.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -13272,10 +13274,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -13294,7 +13296,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -13315,7 +13317,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb260-13"><a href="#cb260-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb260-14"><a href="#cb260-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb260-15"><a href="#cb260-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb261"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb261-1"><a href="#cb261-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -13341,7 +13343,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -13362,7 +13364,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -13371,7 +13373,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TYPE</em></code>
@@ -13380,7 +13382,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -13466,12 +13468,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb264"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb265"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
@@ -13485,17 +13487,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">1</a></span>
 The consteval functions specified in this subclause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type</code>
 defined in this subclause with type <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>meta<span class="op">::</span>info, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -13505,7 +13507,7 @@ each binary function template <code class="sourceCode cpp">meta<span class="op">
 <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -13532,7 +13534,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb266-15"><a href="#cb266-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb266-16"><a href="#cb266-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb266-17"><a href="#cb266-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -13554,7 +13556,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -13566,7 +13568,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -13587,7 +13589,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -13605,7 +13607,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -13622,7 +13624,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -13639,7 +13641,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -13666,7 +13668,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -13674,7 +13676,7 @@ defined in this subclause with type <code class="sourceCode cpp">meta<span class
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>equal<span class="op">(</span>r, vector<span class="op">{^^</span>T<span class="op">...})</span></code>
@@ -13683,7 +13685,7 @@ each unary function template <code class="sourceCode cpp">meta<span class="op">:
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -13703,7 +13705,7 @@ returns the reflection of the corresponding type denoted by <code class="sourceC
 <span id="cb272-9"><a href="#cb272-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb272-10"><a href="#cb272-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb272-11"><a href="#cb272-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb273"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb273-1"><a href="#cb273-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -13725,21 +13727,21 @@ Miscellaneous Reflection Queries<a href="#meta.reflection.misc-miscellaneous-ref
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 value <code class="sourceCode cpp">I</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp">info<span class="op">(</span><span class="dt">size_t</span>, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^^</span>T<span class="op">)</span></code>
 returns a reflection representing the type denoted by <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">3</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, <code class="sourceCode cpp">meta<span class="op">::</span>type_order<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 returns <code class="sourceCode cpp">type_order_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
@@ -13771,31 +13773,31 @@ as a mandates:</p>
 <blockquote>
 <div class="sourceCode" id="cb276"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb276-1"><a href="#cb276-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> To, <span class="kw">class</span> From<span class="op">&gt;</span></span>
 <span id="cb276-2"><a href="#cb276-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> To bit_cast<span class="op">(</span><span class="kw">const</span> From<span class="op">&amp;</span> from<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">1</a></span>
 <em>Constraints</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">(1.1)</a></span>
 <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>To<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span>From<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">(1.2)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>To<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">(1.3)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>From<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
 </ul>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">*</a></span>
 <em>Mandates</em>: Neither <code class="sourceCode cpp">To</code> nor
 <code class="sourceCode cpp">From</code> are consteval-only types
 ([expr.const]).</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">2</a></span>
 <em>Returns</em>: […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">3</a></span>
 <span class="rm" style="color: #bf0303"><del><em>Remarks</em></del></span> <span class="addu"><em>Constant When</em></span>: <span class="rm" style="color: #bf0303"><del>This function is constexpr if and only
 if</del></span> <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -13803,23 +13805,23 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -13902,7 +13904,7 @@ shown to be necessary. The following changes were confirmed by EWG
 during the Hagenberg 2025 meeting.</p>
 <p>One small change was needed to the reflection operator.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">1</a></span>
 Application of the
 <code class="sourceCode cpp"><span class="op">^^</span></code> operator
 to a non-type template parameter
@@ -13931,7 +13933,7 @@ as appropriate.</li>
 <p>A few changes were needed to “consteval-only types” to ensure that
 objects of such types cannot reach runtime.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">2</a></span>
 Relaxed linkage restrictions on objects of consteval-only types
 <ul>
 <li><strong>P2996R4</strong>: Rigid rules prevented objects of
@@ -13949,7 +13951,7 @@ imported across TUs and modules without issue.
 <li>Try it with <a href="https://godbolt.org/z/Y8cdd9sGo">Clang</a>.</li>
 </ul></li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">3</a></span>
 Immediate-escalation of expressions of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Every expression of consteval-only type
@@ -13959,7 +13961,7 @@ to persist to runtime (e.g., passing a reference to a <code class="sourceCode cp
 to a runtime function).</li>
 <li>Fully implemented; try it with Clang <a href="https://godbolt.org/z/5sfe7vdzE">here</a> and <a href="https://godbolt.org/z/T3MY1Yqo4">here</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">4</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">4</a></span>
 Immediate-escalation of non-constexpr variables of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Immediate-escalating functions containing
@@ -13970,7 +13972,7 @@ of consteval-only type (for which an expression does not necessarily
 appear) from reaching runtime.</li>
 <li>Fully implemented; try it with <a href="https://godbolt.org/z/3asrnK13G">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">5</a></span>
 No “erasure” of consteval-only-ness from results of constant
 expressions.
 <ul>
@@ -13989,7 +13991,7 @@ seen <a href="https://godbolt.org/z/E4faezfr3">here</a>).</li>
 </ul>
 <p>Two changes were needed for splicers.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">6</a></span>
 A slight syntactic change is needed for template splicers.
 <ul>
 <li><strong>P2994R4</strong>:
@@ -14010,7 +14012,7 @@ were supposed to work.</li>
 </ul></li>
 <li>Try it on godbolt with <a href="https://godbolt.org/z/GKj5of839">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">7</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">7</a></span>
 Reflections of concepts cannot be spliced.
 <ul>
 <li><strong>P2996R4</strong>: Concepts could be spliced within both
@@ -14034,7 +14036,7 @@ after P2996R4. When the evaluation of an expression calls
 evaluation produces an <em>injected declaration</em> of the completed
 type (try it on <a href="https://godbolt.org/z/PTeb9qqcW">godbolt</a>).</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">1</a></span>
 Recent revisions lock down the context from which
 <code class="sourceCode cpp">define_aggregate</code> can be called.
 <ul>
@@ -14053,7 +14055,7 @@ for code injection due to e.g., template instantiation behavior,
 immediate-escalating expression behavior, etc.</li>
 <li>Fully implemented with Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">2</a></span>
 The scope that a given expression can inject a declaration <em>into</em>
 has been constrained.
 <ul>
@@ -14068,7 +14070,7 @@ use <code class="sourceCode cpp">define_aggregate</code> to observe
 failed substitutions, overload resolution order, etc.</li>
 <li>Fully implemented in Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">3</a></span>
 Strengthening order of evaluation for core constant expressions removes
 the need for more IFNDR.
 <ul>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -1228,7 +1228,7 @@ void hash_append(H& algo, T const& t) {
 ```
 :::
 
-Of course, any production-ready `hash_append` would include a facility for classes to opt members in and out of participation in hashing. Annotations as proposed by [@P3394] provides just such a mechanism.
+Of course, any production-ready `hash_append` would include a facility for classes to opt members in and out of participation in hashing. Annotations as proposed by [@P3394R2] provides just such a mechanism.
 
 ## Converting a Struct to a Tuple
 
@@ -7236,6 +7236,8 @@ concept reflection_range =
   same_as<ranges::range_value_t<R>, info> &&
   same_as<remove_cvref_t<ranges::range_reference_t<R>>, info>;
 ```
+
+[1]{.pnum} *Constant When*: Let 
 
 ```cpp
 template <reflection_range R = initializer_list<info>>


### PR DESCRIPTION
- Use `template for` in clang.
- Use `access_context` in clang and in paper.