### PR TITLE
Post-CWG updates for 2025-04-25.

### DIFF
--- a/2996_reflection/d2996r12.html
+++ b/2996_reflection/d2996r12.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-04-30" />
+  <meta name="dcterms.date" content="2025-05-01" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -575,7 +575,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-04-30</td>
+    <td>2025-05-01</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -12147,8 +12147,8 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value, object,
 variable, function that is not a constructor or destructor, enumerator,
-non-static data member, bit-field, direct base class relationship, or
-data member description. Otherwise,
+non-static data member, unnamed bit-field, direct base class
+relationship, or data member description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
@@ -12159,8 +12159,9 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a value, object,
-variable, function, non-static data member, or bit-field, then the type
-of what is represented by <code class="sourceCode cpp">r</code>.</li>
+variable, function, non-static data member, or unnamed bit-field, then
+the type of what is represented by
+<code class="sourceCode cpp">r</code>.</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator <code class="sourceCode cpp"><em>N</em></code> of an

--- a/2996_reflection/d2996r12.html
+++ b/2996_reflection/d2996r12.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-04-25" />
+  <meta name="dcterms.date" content="2025-04-30" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -575,7 +575,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-04-25</td>
+    <td>2025-04-30</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -761,10 +761,10 @@ definitions<span></span></a></li>
 <li><a href="#lex.phases-phases-of-translation" id="toc-lex.phases-phases-of-translation"><span>5.2
 <span>[lex.phases]</span></span> Phases of
 translation<span></span></a></li>
-<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.5
+<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.4
 <span>[lex.pptoken]</span></span> Preprocessing
 tokens<span></span></a></li>
-<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.8
+<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.12
 <span>[lex.operators]</span></span> Operators and
 punctuators<span></span></a></li>
 <li><a href="#basic.pre-preamble" id="toc-basic.pre-preamble"><span>6.1
@@ -806,18 +806,18 @@ dependence<span></span></a></li>
 <li><a href="#expr.prim-primary-expressions" id="toc-expr.prim-primary-expressions"><span>7.5
 <span>[expr.prim]</span></span> Primary
 expressions<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.5.2
+<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.4.2
 <span>[expr.prim.id.unqual]</span></span> Unqualified
 names<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
-<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.6.2
+<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.5.2
 <span>[expr.prim.lambda.closure]</span></span> Closure
 types<span></span></a></li>
-<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span>7.5.8.3
+<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span>7.5.7.3
 <span>[expr.prim.req.type]</span></span> Type
 requirements<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
@@ -862,31 +862,31 @@ Functions<span></span></a></li>
 <li><a href="#dcl.fct.default-default-arguments" id="toc-dcl.fct.default-default-arguments"><span>9.3.4.7
 <span>[dcl.fct.default]</span></span> Default
 arguments<span></span></a></li>
-<li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.5.1
+<li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.4.1
 <span>[dcl.init.general]</span></span> Initializers
 (General)<span></span></a></li>
-<li><a href="#dcl.fct.def.general-function-definitions" id="toc-dcl.fct.def.general-function-definitions"><span>9.6.1
+<li><a href="#dcl.fct.def.general-function-definitions" id="toc-dcl.fct.def.general-function-definitions"><span>9.5.1
 <span>[dcl.fct.def.general]</span></span> Function
 definitions<span></span></a></li>
-<li><a href="#dcl.fct.def.delete-deleted-definitions" id="toc-dcl.fct.def.delete-deleted-definitions"><span>9.6.3
+<li><a href="#dcl.fct.def.delete-deleted-definitions" id="toc-dcl.fct.def.delete-deleted-definitions"><span>9.5.3
 <span>[dcl.fct.def.delete]</span></span> Deleted
 definitions<span></span></a></li>
-<li><a href="#enum.udecl-the-using-enum-declaration" id="toc-enum.udecl-the-using-enum-declaration"><span>9.8.2
+<li><a href="#enum.udecl-the-using-enum-declaration" id="toc-enum.udecl-the-using-enum-declaration"><span>9.7.2
 <span>[enum.udecl]</span></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
 declaration<span></span></a></li>
-<li><a href="#namespace.alias-namespace-alias" id="toc-namespace.alias-namespace-alias"><span>9.9.3
+<li><a href="#namespace.alias-namespace-alias" id="toc-namespace.alias-namespace-alias"><span>9.8.3
 <span>[namespace.alias]</span></span> Namespace
 alias<span></span></a></li>
-<li><a href="#namespace.udir-using-namespace-directive" id="toc-namespace.udir-using-namespace-directive"><span>9.9.4
+<li><a href="#namespace.udir-using-namespace-directive" id="toc-namespace.udir-using-namespace-directive"><span>9.8.4
 <span>[namespace.udir]</span></span> Using namespace
 directive<span></span></a></li>
-<li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.13.1
+<li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1
 <span>[dcl.attr.grammar]</span></span> Attribute syntax and
 semantics<span></span></a></li>
-<li><a href="#dcl.attr.deprecated-deprecated-attribute" id="toc-dcl.attr.deprecated-deprecated-attribute"><span>9.13.4
+<li><a href="#dcl.attr.deprecated-deprecated-attribute" id="toc-dcl.attr.deprecated-deprecated-attribute"><span>9.12.5
 <span>[dcl.attr.deprecated]</span></span> Deprecated
 attribute<span></span></a></li>
-<li><a href="#dcl.attr.unused-maybe-unused-attribute" id="toc-dcl.attr.unused-maybe-unused-attribute"><span>9.13.8
+<li><a href="#dcl.attr.unused-maybe-unused-attribute" id="toc-dcl.attr.unused-maybe-unused-attribute"><span>9.12.9
 <span>[dcl.attr.unused]</span></span> Maybe unused
 attribute<span></span></a></li>
 <li><a href="#module.global.frag-global-module-fragment" id="toc-module.global.frag-global-module-fragment"><span>10.4
@@ -1060,7 +1060,7 @@ Other transformations<span></span></a></li>
 <li><a href="#meta.reflection.misc-miscellaneous-reflection-queries" id="toc-meta.reflection.misc-miscellaneous-reflection-queries">[meta.reflection.misc],
 Miscellaneous Reflection Queries<span></span></a></li>
 </ul></li>
-<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.11.3
+<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.15.3
 <span>[bit.cast]</span></span> Function template
 <code class="sourceCode cpp">bit_cast</code><span></span></a></li>
 <li><a href="#diff.cpp23-annex-c-informative-compatibility" id="toc-diff.cpp23-annex-c-informative-compatibility"><span>C.1
@@ -1077,12 +1077,12 @@ Hagenberg<span></span></a></li>
 </div>
 <h1 data-number="1" style="border-bottom:1px solid #cccccc" id="revision-history"><span class="header-section-number">1</span>
 Revision History<a href="#revision-history" class="self-link"></a></h1>
-<p>Since <span class="citation" data-cites="P2996R11"><a href="https://wg21.link/p2996r11" role="doc-biblioref">[P2996R11]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R11">[<a href="https://wg21.link/p2996r11" role="doc-biblioref">P2996R11</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
 <li>better specify interaction between spliced function calls and
-overload resolution; integrate fix to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span></li>
+overload resolution; integrate fix to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span></li>
 <li>disallow reflection of local parameters introduced by
 <code class="sourceCode cpp"><em>requires-expression</em></code>s</li>
 </ul></li>
@@ -1092,7 +1092,7 @@ overload resolution; integrate fix to <span class="citation" data-cites="CWG2701
 (including examples)</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R10"><a href="https://wg21.link/p2996r10" role="doc-biblioref">[P2996R10]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R10">[<a href="https://wg21.link/p2996r10" role="doc-biblioref">P2996R10</a>]</span>:</p>
 <ul>
 <li>replaced <code class="sourceCode cpp">has_complete_definition</code>
 function with more narrow
@@ -1126,8 +1126,7 @@ immediate functions</li>
 enumerators called from within the containing
 <code class="sourceCode cpp"><em>enum-specifier</em></code></li>
 <li>minor editing and phrasing updates to address CWG feedback</li>
-<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13"><a href="https://wg21.link/p2786r13" role="doc-biblioref">[P2786R13] (Trivial Relocatability For
-C++26)</a></span></span></li>
+<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13">[<a href="https://wg21.link/p2786r13" role="doc-biblioref">P2786R13</a>]</span></span></li>
 <li>in response to CWG feedback: added
 <code class="sourceCode cpp">has_c_language_linkage</code>,
 <code class="sourceCode cpp">has_parent</code>,
@@ -1141,13 +1140,13 @@ members to <code class="sourceCode cpp">access_context</code></li>
 <code class="sourceCode cpp">members_of</code></li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R9"><a href="https://wg21.link/p2996r9" role="doc-biblioref">[P2996R9]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R9">[<a href="https://wg21.link/p2996r9" role="doc-biblioref">P2996R9</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
-<li>merge <span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1] (Consteval blocks)</a></span></span> into
-P2996. Replace the category of “plainly constant-evaluated expressions”
-with consteval blocks.</li>
+<li>merge <span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span> into P2996. Replace the
+category of “plainly constant-evaluated expressions” with consteval
+blocks.</li>
 <li>make the [expr.const] “scope rule” for injected declarations more
 rigorous; disallow escape from function parameter scopes</li>
 <li>revise [expr.reflect] grammar according to CWG feedback</li>
@@ -1155,7 +1154,7 @@ rigorous; disallow escape from function parameter scopes</li>
 arguments</li>
 <li>bring notes and examples into line with current definitions</li>
 <li>rebase [expr.const] onto latest from working draft (in particular,
-integrate changes from <span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+integrate changes from <span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>prefer “core constant expressions” to “manifestly constant-evaluated
 expression” in several places</li>
 <li>producing an injected declaration from a non-plainly
@@ -1173,14 +1172,14 @@ lieu of “core constant expression”)</li>
 <li>avoid referring to “permitted results of constant expressions” in
 wording for <code class="sourceCode cpp">reflect_value</code> and
 <code class="sourceCode cpp">reflect_object</code> (term was retired by
-<span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+<span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>template specializations and non-static data members of closure
 types are not <em>members-of-representable</em></li>
-<li>integrated <span class="title"><span class="citation" data-cites="P3547R1"><a href="https://wg21.link/p3547r1" role="doc-biblioref">[P3547R1] (Modeling Access Control With
-Reflection)</a></span></span> following its approval in (L)EWG.</li>
+<li>integrated <span class="title"><span class="citation" data-cites="P3547R1">[<a href="https://wg21.link/p3547r1" role="doc-biblioref">P3547R1</a>]</span></span> following its approval
+in (L)EWG.</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R8"><a href="https://wg21.link/p2996r8" role="doc-biblioref">[P2996R8]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R8">[<a href="https://wg21.link/p2996r8" role="doc-biblioref">P2996R8</a>]</span>:</p>
 <ul>
 <li>ensure <code class="sourceCode cpp">value_of</code> and
 <code class="sourceCode cpp">extract</code> are usable with reflections
@@ -1233,12 +1232,12 @@ complete-class contexts; rename to “<em>members-of-precedes</em>”</li>
 </ul></li>
 <li>fleshed out revision history for R8</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R7"><a href="https://wg21.link/p2996r7" role="doc-biblioref">[P2996R7]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R7">[<a href="https://wg21.link/p2996r7" role="doc-biblioref">P2996R7</a>]</span>:</p>
 <ul>
 <li>changed reflection operator from
 <code class="sourceCode cpp"><span class="op">^</span></code> to
 <code class="sourceCode cpp"><span class="op">^^</span></code> following
-adoption of <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span></li>
+adoption of <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span></li>
 <li>renamed <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>operator_symbol_of</code>
 to <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>symbol_of</code></li>
 <li>renamed some <code class="sourceCode cpp">operators</code>
@@ -1327,7 +1326,7 @@ base class relationship</em> to assist with specification of
 in [temp.arg.general]</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R6"><a href="https://wg21.link/p2996r6" role="doc-biblioref">[P2996R6]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R6">[<a href="https://wg21.link/p2996r6" role="doc-biblioref">P2996R6</a>]</span>:</p>
 <ul>
 <li>removed the <code class="sourceCode cpp">accessible_members</code>
 family of functions</li>
@@ -1346,7 +1345,7 @@ functions, tweaked enumerator names in <code class="sourceCode cpp">std<span cla
 completeness with
 <code class="sourceCode cpp">is_user_provided</code></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R5"><a href="https://wg21.link/p2996r5" role="doc-biblioref">[P2996R5]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R5">[<a href="https://wg21.link/p2996r5" role="doc-biblioref">P2996R5</a>]</span>:</p>
 <ul>
 <li>fixed broken “Emulating typeful reflection” example.</li>
 <li>removed linkage restrictions on objects of consteval-only type that
@@ -1367,7 +1366,7 @@ Aliases”</a> section.</li>
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
 <li>removed <code class="sourceCode cpp">subobjects_of</code> and
 <code class="sourceCode cpp">accessible_subobjects_of</code> (will be
-reintroduced by <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>).</li>
+reintroduced by <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>).</li>
 <li>specified constraints for
 <code class="sourceCode cpp">enumerators_of</code> in terms of
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
@@ -1389,7 +1388,7 @@ with core language terminology.</li>
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” over “alias
 of a type” in formal wording.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span>:</p>
 <ul>
 <li>removed filters from query functions</li>
 <li>cleaned up accessibility interface, removed
@@ -1431,7 +1430,7 @@ comparison among reflections returned by it.</li>
 <code class="sourceCode cpp">is_complete_type</code></li>
 <li>Many wording updates in response to feedback from CWG.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R3"><a href="https://wg21.link/p2996r3" role="doc-biblioref">[P2996R3]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R3">[<a href="https://wg21.link/p2996r3" role="doc-biblioref">P2996R3</a>]</span>:</p>
 <ul>
 <li>changes to name functions to improve Unicode-friendliness; added
 <code class="sourceCode cpp">u8name_of</code>,
@@ -1457,7 +1456,7 @@ object; added <code class="sourceCode cpp">object_of</code>
 metafunction</li>
 <li>more wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R2"><a href="https://wg21.link/p2996r2" role="doc-biblioref">[P2996R2]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R2">[<a href="https://wg21.link/p2996r2" role="doc-biblioref">P2996R2</a>]</span>:</p>
 <ul>
 <li>many wording changes, additions, and improvements</li>
 <li>elaborated on equivalence among reflections and linkage of templated
@@ -1498,8 +1497,8 @@ functions, not member function templates</li>
 text</a></li>
 <li>added a section discussing ODR concerns</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R1"><a href="https://wg21.link/p2996r1" role="doc-biblioref">[P2996R1]</a></span>, several changes to the
-overall library API:</p>
+<p>Since <span class="citation" data-cites="P2996R1">[<a href="https://wg21.link/p2996r1" role="doc-biblioref">P2996R1</a>]</span>, several changes to the overall
+library API:</p>
 <ul>
 <li>added <code class="sourceCode cpp">qualified_name_of</code> (to
 partner with <code class="sourceCode cpp">name_of</code>)</li>
@@ -1523,7 +1522,7 @@ reflection</a>.</li>
 freestanding.</li>
 <li>adding lots of wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R0"><a href="https://wg21.link/p2996r0" role="doc-biblioref">[P2996R0]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R0">[<a href="https://wg21.link/p2996r0" role="doc-biblioref">P2996R0</a>]</span>:</p>
 <ul>
 <li>added links to Compiler Explorer demonstrating just about all of the
 examples</li>
@@ -1542,7 +1541,7 @@ for exceptions (removing invalid reflections)</li>
 Introduction<a href="#introduction" class="self-link"></a></h1>
 <p>This is a proposal for a reduced initial set of features to support
 static reflection in C++. Specifically, we are mostly proposing a subset
-of features suggested in <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>:</p>
+of features suggested in <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>:</p>
 <ul>
 <li>the representation of program elements via constant-expressions
 producing <em>reflection values</em> — <em>reflections</em> for short —
@@ -1568,7 +1567,7 @@ and compile-time metaprogramming are concerned. Instead, we expect it
 will be a useful core around which more powerful features will be added
 incrementally over time. In particular, we believe that most or all the
 remaining features explored in P1240R2 and that code injection (along
-the lines described in <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>) are desirable directions to
+the lines described in <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>) are desirable directions to
 pursue.</p>
 <p>Our choice to start with something smaller is primarily motivated by
 the belief that that improves the chances of these facilities making it
@@ -1582,7 +1581,7 @@ predicates (such as <code class="sourceCode cpp">is_class_v</code>) in
 reflection computations.</p>
 <p>One addition does stand out, however: We have added metafunctions
 that permit the synthesis of simple struct and union types. While it is
-not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>), it can be remarkably
+not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>), it can be remarkably
 effective in practice.</p>
 <h2 data-number="2.2" id="why-a-single-opaque-reflection-type"><span class="header-section-number">2.2</span> Why a single opaque reflection
 type?<a href="#why-a-single-opaque-reflection-type" class="self-link"></a></h2>
@@ -1728,17 +1727,9 @@ rely on these features, and it is possible to do without them - but it
 would greatly help the usability experience if those could be adopted as
 well:</p>
 <ul>
-<li><span class="title"><span class="citation" data-cites="P1306R2"><a href="https://wg21.link/p1306r2" role="doc-biblioref">[P1306R2]
-(Expansion statements)</a></span></span></li>
-<li><span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]
-(Consteval blocks)</a></span></span></li>
-<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7"><a href="https://wg21.link/p0784r7" role="doc-biblioref">[P0784R7] (More
-constexpr containers)</a></span></span>, <span class="title"><span class="citation" data-cites="P1974R0"><a href="https://wg21.link/p1974r0" role="doc-biblioref">[P1974R0]
-(Non-transient constexpr allocation using propconst)</a></span></span>,
-<span class="title"><span class="citation" data-cites="P2670R1"><a href="https://wg21.link/p2670r1" role="doc-biblioref">[P2670R1]
-(Non-transient constexpr allocation)</a></span></span>, <span class="title"><span class="citation" data-cites="P3554R0"><a href="https://wg21.link/p3554r0" role="doc-biblioref">[P3554R0]
-(Non-transient allocation with vector and
-basic_string)</a></span></span></li>
+<li><span class="title"><span class="citation" data-cites="P1306R2">[<a href="https://wg21.link/p1306r2" role="doc-biblioref">P1306R2</a>]</span></span></li>
+<li><span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span></li>
+<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7">[<a href="https://wg21.link/p0784r7" role="doc-biblioref">P0784R7</a>]</span></span>, <span class="title"><span class="citation" data-cites="P1974R0">[<a href="https://wg21.link/p1974r0" role="doc-biblioref">P1974R0</a>]</span></span>, <span class="title"><span class="citation" data-cites="P2670R1">[<a href="https://wg21.link/p2670r1" role="doc-biblioref">P2670R1</a>]</span></span>, <span class="title"><span class="citation" data-cites="P3554R0">[<a href="https://wg21.link/p3554r0" role="doc-biblioref">P3554R0</a>]</span></span></li>
 </ul>
 <h2 data-number="3.1" id="back-and-forth"><span class="header-section-number">3.1</span> Back-And-Forth<a href="#back-and-forth" class="self-link"></a></h2>
 <p>Our first example is not meant to be compelling but to show how to go
@@ -2316,7 +2307,7 @@ initialize members of a defined union using a splicer, as in:</p>
 </blockquote>
 </div>
 <p>Arguably, the answer should be yes - this would be consistent with
-how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>.</p>
+how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>.</p>
 <p>On Compiler Explorer: <a href="https://godbolt.org/z/W74qxqnhf">EDG</a>, <a href="https://godbolt.org/z/eqj6e3Tjr">Clang</a>.</p>
 <h2 data-number="3.10" id="struct-to-struct-of-arrays"><span class="header-section-number">3.10</span> Struct to Struct of Arrays<a href="#struct-to-struct-of-arrays" class="self-link"></a></h2>
 <div class="std">
@@ -2608,7 +2599,7 @@ requires writing
 since this isn’t a type-only context.</p>
 <h2 data-number="3.13" id="implementing-member-wise-hash_append"><span class="header-section-number">3.13</span> Implementing member-wise
 <code class="sourceCode cpp">hash_append</code><a href="#implementing-member-wise-hash_append" class="self-link"></a></h2>
-<p>Based on the <span class="citation" data-cites="N3980"><a href="https://wg21.link/n3980" role="doc-biblioref">[N3980]</a></span>
+<p>Based on the <span class="citation" data-cites="N3980">[<a href="https://wg21.link/n3980" role="doc-biblioref">N3980</a>]</span>
 API:</p>
 <div class="std">
 <blockquote>
@@ -2624,12 +2615,12 @@ API:</p>
 <p>Of course, any production-ready
 <code class="sourceCode cpp">hash_append</code> would include a facility
 for classes to opt members in and out of participation in hashing.
-Annotations as proposed by <span class="title"><span class="citation" data-cites="P3394R2"><a href="https://wg21.link/p3394r2" role="doc-biblioref">[P3394R2] (Annotations for
-Reflection)</a></span></span> provides just such a mechanism.</p>
+Annotations as proposed by <span class="title"><span class="citation" data-cites="P3394R2">[<a href="https://wg21.link/p3394r2" role="doc-biblioref">P3394R2</a>]</span></span> provides just such a
+mechanism.</p>
 <h2 data-number="3.14" id="converting-a-struct-to-a-tuple"><span class="header-section-number">3.14</span> Converting a Struct to a
 Tuple<a href="#converting-a-struct-to-a-tuple" class="self-link"></a></h2>
-<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R10"><a href="https://wg21.link/p1061r10" role="doc-biblioref">[P1061R10]</a></span>, but can also be written
-using <code class="sourceCode cpp">std<span class="op">::</span>make_index_sequence</code>:</p>
+<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R10">[<a href="https://wg21.link/p1061r10" role="doc-biblioref">P1061R10</a>]</span>, but can also be written using
+<code class="sourceCode cpp">std<span class="op">::</span>make_index_sequence</code>:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb31"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
@@ -2983,10 +2974,10 @@ metafunction can also be used to map a reflection of an object to a
 reflection of its value.</p>
 <h3 data-number="4.1.1" id="syntax-discussion"><span class="header-section-number">4.1.1</span> Syntax discussion<a href="#syntax-discussion" class="self-link"></a></h3>
 <p>The original TS landed on <code class="sourceCode cpp"><span class="cf">reflexpr</span><span class="op">(...)</span></code>
-as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that syntax as well.
-As more examples were discussed, it became clear that that syntax was
-both (a) too “heavy” and (b) insufficiently distinct from a function
-call. SG7 eventually agreed upon the prefix
+as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that syntax as well. As
+more examples were discussed, it became clear that that syntax was both
+(a) too “heavy” and (b) insufficiently distinct from a function call.
+SG7 eventually agreed upon the prefix
 <code class="sourceCode cpp"><span class="op">^</span></code> operator.
 The “upward arrow” interpretation of the caret matches the “lift” or
 “raise” verbs that are sometimes used to describe the reflection
@@ -3017,8 +3008,8 @@ lifting, <code class="sourceCode cpp">\</code> and
 syntax.</p>
 <p>In Wrocław 2024, SG7 and EWG voted to adopt
 <code class="sourceCode cpp"><span class="op">^^</span></code> as the
-new reflection operator (as proposed by <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span>). The R8 revision of this
-paper integrates that change.</p>
+new reflection operator (as proposed by <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span>). The R8 revision of this paper
+integrates that change.</p>
 <h2 data-number="4.2" id="splicers"><span class="header-section-number">4.2</span> Splicers
 (<code class="sourceCode cpp"><span class="op">[:</span></code>…<code class="sourceCode cpp"><span class="op">:]</span></code>)<a href="#splicers" class="self-link"></a></h2>
 <p>A reflection can be “spliced” into source code using one of several
@@ -3269,8 +3260,8 @@ extension in a future paper.</p>
 (described in more detail below). However, there are many cases where we
 don’t have a single reflection, we have a range of reflections - and we
 want to splice them all in one go. For that, the predecessor to this
-paper, <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span>, proposed an additional form
-of splicer: a range splicer.</p>
+paper, <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span>, proposed an additional form of
+splicer: a range splicer.</p>
 <p>Construct the <a href="#converting-a-struct-to-a-tuple">struct-to-tuple</a> example from
 above. It was demonstrated using a single splice, but it would be
 simpler if we had a range splice:</p>
@@ -3356,7 +3347,7 @@ Which is enough for a tolerable implementation:</p>
 <h3 data-number="4.2.4" id="syntax-discussion-1"><span class="header-section-number">4.2.4</span> Syntax discussion<a href="#syntax-discussion-1" class="self-link"></a></h3>
 <p>Early discussions of splice-like constructs (related to the TS
 design) considered using <code class="sourceCode cpp"><span class="cf">unreflexpr</span><span class="op">(...)</span></code>
-for that purpose. <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that option for
+for that purpose. <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that option for
 <em>expression</em> splicing, observing that a single splicing syntax
 could not viably be parsed (some disambiguation is needed to distinguish
 types and templates). SG-7 eventually agreed to adopt the <code class="sourceCode cpp"><span class="op">[:</span> <span class="op">...</span> <span class="op">:]</span></code>
@@ -3437,7 +3428,7 @@ document templates:</p>
 need syntax for in the future:</p>
 <ul>
 <li>code injection (of whatever form), and</li>
-<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1"><a href="https://wg21.link/p1887r1" role="doc-biblioref">[P1887R1]</a></span> suggested
+<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1">[<a href="https://wg21.link/p1887r1" role="doc-biblioref">P1887R1</a>]</span> suggested
 <code class="sourceCode cpp"><span class="op">+</span></code> as an
 annotation introducer, but
 <code class="sourceCode cpp"><span class="op">+</span></code> can begin
@@ -3704,9 +3695,8 @@ because these are <code class="sourceCode cpp">std<span class="op">::</span>meta
 must be a constant. Because it’s not here
 (<code class="sourceCode cpp">__first</code> and
 <code class="sourceCode cpp">__last</code> are just function
-parameters), that triggers the immediate-escalation machinery from <span class="title"><span class="citation" data-cites="P2564R3"><a href="https://wg21.link/p2564r3" role="doc-biblioref">[P2564R3]
-(consteval needs to propagate up)</a></span></span> (before that paper,
-it would have been ill-formed on the spot). But because
+parameters), that triggers the immediate-escalation machinery from <span class="title"><span class="citation" data-cites="P2564R3">[<a href="https://wg21.link/p2564r3" role="doc-biblioref">P2564R3</a>]</span></span> (before that paper, it
+would have been ill-formed on the spot). But because
 <code class="sourceCode cpp">__introsort</code> is not
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>,
 propagation fails at that point, and the program is ill-formed.</p>
@@ -3809,7 +3799,7 @@ example:</p>
 </div>
 <p>Hence this proposal also introduces constraints on constant
 evaluation as follows…</p>
-<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]</a></span>) have the property that their
+<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span>) have the property that their
 evaluation must occur and must succeed in a valid C++ program. We
 require that a programmer can count on those evaluations occurring
 exactly once and completing at translation time.</p>
@@ -3820,9 +3810,8 @@ source constructs lexically following them.</p>
 <p>Those constraints are mostly intuitive, but they are a significant
 change to the underlying principles of the current standard in this
 respect.</p>
-<p><span class="title"><span class="citation" data-cites="P2758R4"><a href="https://wg21.link/p2758r4" role="doc-biblioref">[P2758R4]
-(Emitting messages at compile time)</a></span></span> also has to deal
-with side effects during constant evaluation. However, those effects
+<p><span class="title"><span class="citation" data-cites="P2758R4">[<a href="https://wg21.link/p2758r4" role="doc-biblioref">P2758R4</a>]</span></span> also has to deal with
+side effects during constant evaluation. However, those effects
 (“output”) are of a slightly different nature in the sense that they can
 be buffered until a manifestly constant-evaluated expression/conversion
 has completed. “Buffering” a class type completion is not practical
@@ -3901,7 +3890,7 @@ constant expressions (we would of course still keep the requirement that
 the constraint is a
 <code class="sourceCode cpp"><span class="dt">bool</span></code>).</p></li>
 </ul>
-<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1"><a href="https://wg21.link/p3068r1" role="doc-biblioref">[P3068R1]</a></span> has proposed the introduction
+<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1">[<a href="https://wg21.link/p3068r1" role="doc-biblioref">P3068R1</a>]</span> has proposed the introduction
 of constexpr exceptions. The proposal addresses hurdles like compiler
 modes that disable exception support, and a Clang-based implementation
 is underway. We believe this to be the most desirable error-handling
@@ -4261,14 +4250,14 @@ translated to a different presentation (as in (2)).</p></li>
 to evaluate if the identifier cannot be represented in the ordinary
 literal encoding.</p>
 <h3 data-number="4.4.6" id="reflecting-names"><span class="header-section-number">4.4.6</span> Reflecting names<a href="#reflecting-names" class="self-link"></a></h3>
-<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>) included a metafunction
-called <code class="sourceCode cpp">name_of</code>, which we defined to
-return a <code class="sourceCode cpp">string_view</code> containing the
-“name” of the reflected entity. As the paper evolved, it became
-necessary to sharpen the specification of what this “name” contains.
-Subsequent revisions (beginning with P2996R2, presented in Tokyo)
-specified that <code class="sourceCode cpp">name_of</code> returns the
-unqualified name, whereas a new
+<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>) included a metafunction called
+<code class="sourceCode cpp">name_of</code>, which we defined to return
+a <code class="sourceCode cpp">string_view</code> containing the “name”
+of the reflected entity. As the paper evolved, it became necessary to
+sharpen the specification of what this “name” contains. Subsequent
+revisions (beginning with P2996R2, presented in Tokyo) specified that
+<code class="sourceCode cpp">name_of</code> returns the unqualified
+name, whereas a new
 <code class="sourceCode cpp">qualified_name_of</code> would give the
 fully qualified name.</p>
 <p>Most would agree that <code class="sourceCode cpp">qualified_name_of<span class="op">(^^</span><span class="dt">size_t</span><span class="op">)</span></code>
@@ -4656,9 +4645,9 @@ side-effect.</p>
 <code class="sourceCode cpp">define_aggregate</code> can be used, we are
 not aware of any motivating use cases for P2996 that are harmed. Worth
 mentioning, however: the rule has more dire implications for other code
-injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2"><a href="https://wg21.link/p3294r2" role="doc-biblioref">[P3294R2]</a></span> (“<em>Code Injection With
-Token Sequences</em>”). With this rule as it is, it becomes impossible
-for e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
+injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2">[<a href="https://wg21.link/p3294r2" role="doc-biblioref">P3294R2</a>]</span> (“<em>Code Injection With Token
+Sequences</em>”). With this rule as it is, it becomes impossible for
+e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
 to produce an injected declaration of <code class="sourceCode cpp">std<span class="op">::</span>formatter<span class="op">&lt;</span>TCls<span class="op">&lt;</span>Foo<span class="op">&gt;&gt;</span></code>
 (since the target scope would be the global namespace).</p>
 <p>In this context, we do believe that relaxations of the rule can be
@@ -4680,8 +4669,7 @@ implementations<a href="#freestanding-implementations" class="self-link"></a></h
 return a
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>
 value. Unfortunately, that means that they are currently not usable in a
-freestanding environment, but <span class="title"><span class="citation" data-cites="P3295R0"><a href="https://wg21.link/p3295r0" role="doc-biblioref">[P3295R0] (Freestanding constexpr containers and
-constexpr exception types)</a></span></span> currently proposes
+freestanding environment, but <span class="title"><span class="citation" data-cites="P3295R0">[<a href="https://wg21.link/p3295r0" role="doc-biblioref">P3295R0</a>]</span></span> currently proposes
 freestanding
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>,
 <code class="sourceCode cpp">std<span class="op">::</span>string</code>,
@@ -5566,7 +5554,7 @@ complete definition of <code class="sourceCode cpp">T</code>, and they
 both afterwards <code class="sourceCode cpp"><span class="pp">#include </span><span class="im">&quot;cls.h&quot;</span></code>,
 the result will be an ODR violation.</p>
 <p>Additional papers are already in flight proposing additional
-metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2"><a href="https://wg21.link/p3096r2" role="doc-biblioref">[P3096R2]</a></span> proposes the
+metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2">[<a href="https://wg21.link/p3096r2" role="doc-biblioref">P3096R2</a>]</span> proposes the
 <code class="sourceCode cpp">parameters_of</code> metafunction. This
 feature is important for generating language bindings (e.g., Python,
 JavaScript), but since parameter names can differ between declarations,
@@ -5630,7 +5618,7 @@ follows:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_6" id="pnum_6">7-8</a></span>
-Each preprocessing token is converted into a token (<span>5.10 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). Whitespace
+Each preprocessing token is converted into a token (<span>5.6 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). Whitespace
 characters separating tokens are no longer significant. The resulting
 tokens constitute a <em>translation unit</em> and are syntactically and
 semantically analyzed as a
@@ -5753,7 +5741,7 @@ image which contains information needed for execution in its execution
 environment.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.5
+<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.4
 <a href="https://wg21.link/lex.pptoken">[lex.pptoken]</a></span>
 Preprocessing tokens<a href="#lex.pptoken-preprocessing-tokens" class="self-link"></a></h3>
 <p>Add a bullet after bullet (4.2):</p>
@@ -5799,11 +5787,11 @@ note</em> ]</span></span></span></p></li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
+<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
 Operators and punctuators<a href="#lex.operators-operators-and-punctuators" class="self-link"></a></h3>
 <p>Change the grammar for
 <code class="sourceCode cpp"><em>operator-or-punctuator</em></code> in
-paragraph 1 of <span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
+paragraph 1 of <span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
 include the reflection operator and the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>
 delimiters:</p>
@@ -5981,7 +5969,7 @@ follows:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an
-<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.5
+<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.4
 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>)
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code>
@@ -6164,7 +6152,7 @@ In each such definition, corresponding
 General<a href="#basic.scope.scope-general" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 introduction of a “host scope” in paragraph 2 is part of the resolution
-to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Define the “host scope” of a declaration in paragraph 2:</p>
 <div class="std">
 <blockquote>
@@ -6759,7 +6747,7 @@ the grammar for
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
 <p>Modify paragraph 2 to avoid transforming non-static members into
@@ -6771,7 +6759,7 @@ implicit member accesses when named as operands to
 If an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><em>E</em></code> denotes a non-static
 non-type member of some class <code class="sourceCode cpp">C</code> at a
-point where the current class (<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
+point where the current class (<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
 <code class="sourceCode cpp">X</code> and</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(2.1)</a></span>
@@ -6836,7 +6824,7 @@ member and it appears in an unevaluated operand.</li>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.4.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
 Unqualified names<a href="#expr.prim.id.unqual-unqualified-names" class="self-link"></a></h3>
 <p>Modify paragraph 15 to allow
 <code class="sourceCode cpp"><em>splice-expression</em></code>s to be
@@ -6872,7 +6860,7 @@ the block scope of a
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -7067,7 +7055,7 @@ not declarative, the entity shall not be a template.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.6.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
+<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
 Closure types<a href="#expr.prim.lambda.closure-closure-types" class="self-link"></a></h3>
 <p>We have to say that a closure type is not complete until the
 <code class="sourceCode cpp"><span class="op">}</span></code>:</p>
@@ -7120,7 +7108,7 @@ conversion function template has the same invented template parameter
 list, […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.req.type-type-requirements"><span>7.5.8.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
+<h3 class="unnumbered" id="expr.prim.req.type-type-requirements"><span>7.5.7.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
 Type requirements<a href="#expr.prim.req.type-type-requirements" class="self-link"></a></h3>
 <p>Allow splices in type requirements:</p>
 <div class="std">
@@ -7162,7 +7150,7 @@ of its
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -7244,7 +7232,7 @@ expression has the same type as
 <code class="sourceCode cpp"><em>S</em></code>, and is a bit-field if
 and only if <code class="sourceCode cpp"><em>S</em></code> is a
 bit-field. <span class="note"><span>[ <em>Note 1:</em> </span>The
-implicit transformation (<span>7.5.5 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
+implicit transformation (<span>7.5.4 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
 an <code class="sourceCode cpp"><em>id-expression</em></code> denoting a
 non-static member becomes a class member access does not apply to a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.<span>
@@ -7269,7 +7257,7 @@ adjusted to a non-reference type (<span>7.2.2 <a href="https://wg21.link/expr.ty
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a value
 or an enumerator, the expression is a prvalue that computes
 <code class="sourceCode cpp"><em>S</em></code> and whose type is the
-same as <code class="sourceCode cpp"><em>S</em></code>.</p></li>
+same as that of <code class="sourceCode cpp"><em>S</em></code>.</p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(2.6)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
@@ -7816,7 +7804,7 @@ note</em> ]</span></span></p></li>
 </ul>
 <p>The <code class="sourceCode cpp"><em>id-expression</em></code> of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code> is an
-unevaluated operand (<span>7.2.3 <a href="https://wg21.link/expr.context">[expr.context]</a></span>).</p>
+unevaluated operand ([expr.context]).</p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
 <div class="sourceCode" id="cb132"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="kw">requires</span> <span class="op">(^^</span>T <span class="op">!=</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>;</span>
@@ -8000,7 +7988,7 @@ each constituent reference refers to an object or a non-immediate
 function,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(22.4)</a></span>
 no constituent value of scalar type is an indeterminate value or
-erroneous value (<span>6.7.5 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
+erroneous value (<span>6.7.4 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(22.5)</a></span>
 no constituent value of pointer type is a pointer to an immediate
 function or an invalid pointer value ([basic.compound]), <span class="rm" style="color: #bf0303"><del>and</del></span></li>
@@ -8185,7 +8173,7 @@ of</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(30.1)</a></span>
 the instantiation context of
-<code class="sourceCode cpp"><em>C</em></code> (<span>10.6 <a href="https://wg21.link/module.context">[module.context]</a></span>),
+<code class="sourceCode cpp"><em>C</em></code> ([module.context]),
 and</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(30.2)</a></span>
 the synthesized points corresponding to any injected declarations
@@ -8319,7 +8307,7 @@ and it shall not be used in the
 nor in the
 <code class="sourceCode cpp"><em>decl-specifier-seq</em></code> of a
 <code class="sourceCode cpp"><em>function-definition</em></code>
-(<span>9.6 <a href="https://wg21.link/dcl.fct.def">[dcl.fct.def]</a></span>). If a
+(<span>9.5 <a href="https://wg21.link/dcl.fct.def">[dcl.fct.def]</a></span>). If a
 <code class="sourceCode cpp"><em>typedef-specifier</em></code> appears
 in a declaration without a
 <code class="sourceCode cpp"><em>declarator</em></code>, the program is
@@ -8340,7 +8328,7 @@ alias is</span> the type associated with the
 a <code class="sourceCode cpp"><em>typedef-name</em></code> <span class="rm" style="color: #bf0303"><del>is</del></span> thus <span class="rm" style="color: #bf0303"><del>a synonym for</del></span> <span class="addu">denotes</span> another type. A
 <code class="sourceCode cpp"><em>typedef-name</em></code> does not
 introduce a new type the way a class declaration (<span>11.3 <a href="https://wg21.link/class.name">[class.name]</a></span>) or enum
-declaration (<span>9.8.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
+declaration (<span>9.7.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">2</a></span>
 A <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span> can also be <span class="rm" style="color: #bf0303"><del>introduced</del></span> <span class="addu">declared</span> by an
@@ -8645,7 +8633,7 @@ any) of the
 </div>
 <h3 class="unnumbered" id="dcl.array-arrays"><span>9.3.4.5 <a href="https://wg21.link/dcl.array">[dcl.array]</a></span> Arrays<a href="#dcl.array-arrays" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: This
-change is part of the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+change is part of the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Use “host scope” in lieu of “inhabits” in paragraph 8:</p>
 <div class="std">
 <blockquote>
@@ -8722,7 +8710,7 @@ of an abominable function type:</p>
 Default arguments<a href="#dcl.fct.default-default-arguments" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes related to “host scopes” in paragraphs 4 and 9 are part of the
-resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Use “host scope” in lieu of “inhabits” in paragraph 4:</p>
 <div class="std">
 <blockquote>
@@ -8781,9 +8769,9 @@ example</em> ]</span></p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.5.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 Initializers (General)<a href="#dcl.init.general-initializers-general" class="self-link"></a></h3>
-<p>Change paragraphs 6-8 of <span>9.5.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<p>Change paragraphs 6-8 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 <span class="ednote" style="color: #0000ff">[ Editor&#39;s note: No changes
 are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
@@ -8840,7 +8828,7 @@ thereof.</p>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.fct.def.general-function-definitions"><span>9.6.1 <a href="https://wg21.link/dcl.fct.def.general">[dcl.fct.def.general]</a></span>
+<h3 class="unnumbered" id="dcl.fct.def.general-function-definitions"><span>9.5.1 <a href="https://wg21.link/dcl.fct.def.general">[dcl.fct.def.general]</a></span>
 Function definitions<a href="#dcl.fct.def.general-function-definitions" class="self-link"></a></h3>
 <p>Disallow using
 <code class="sourceCode cpp"><span class="ot">__func__</span></code> in
@@ -8860,9 +8848,9 @@ The function-local predefined variable
 defined as if a definition of the form […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.fct.def.delete-deleted-definitions"><span>9.6.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
+<h3 class="unnumbered" id="dcl.fct.def.delete-deleted-definitions"><span>9.5.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
 Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self-link"></a></h3>
-<p>Change paragraph 2 of <span>9.6.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
+<p>Change paragraph 2 of <span>9.5.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
@@ -8873,7 +8861,7 @@ a <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect])</span>, is ill-formed.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.8.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
+<h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.7.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
 declaration<a href="#enum.udecl-the-using-enum-declaration" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> as
@@ -8914,7 +8902,7 @@ shall designate a non-dependent type with a reachable
 <code class="sourceCode cpp"><em>enum-specifier</em></code>.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="namespace.alias-namespace-alias"><span>9.9.3
+<h3 class="unnumbered" id="namespace.alias-namespace-alias"><span>9.8.3
 <a href="https://wg21.link/namespace.alias">[namespace.alias]</a></span>
 Namespace alias<a href="#namespace.alias-namespace-alias" class="self-link"></a></h3>
 <p>Modify the grammar for
@@ -8974,7 +8962,7 @@ or designated by the
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.9.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
+<h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
 Using namespace directive<a href="#namespace.udir-using-namespace-directive" class="self-link"></a></h3>
 <p>Add <code class="sourceCode cpp"><em>splice-specifier</em></code> to
 the grammar for
@@ -8988,7 +8976,7 @@ the grammar for
 </div>
 </blockquote>
 </div>
-<p>Add the following prior to the first paragraph of <span>9.9.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>, and
+<p>Add the following prior to the first paragraph of <span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>, and
 renumber accordingly:</p>
 <div class="std">
 <blockquote>
@@ -9032,7 +9020,7 @@ namespaces <span class="rm" style="color: #bf0303"><del>nominated</del></span> <
 eligible to be considered.<span> — <em>end note</em> ]</span></span></p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.13.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
+<h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
 Attribute syntax and semantics<a href="#dcl.attr.grammar-attribute-syntax-and-semantics" class="self-link"></a></h3>
 <p>Add a production to the grammar for
 <code class="sourceCode cpp"><em>attribute-specifier</em></code> as
@@ -9061,7 +9049,7 @@ follows:</p>
 </div>
 </blockquote>
 </div>
-<p>Change a sentence in paragraph 4 of <span>9.13.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
+<p>Change a sentence in paragraph 4 of <span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
 as follows:</p>
 <div class="std">
 <blockquote>
@@ -9082,7 +9070,7 @@ the two-token sequence
 — <em>end note</em> ]</span></span></span> …</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.deprecated-deprecated-attribute"><span>9.13.4 <a href="https://wg21.link/dcl.attr.deprecated">[dcl.attr.deprecated]</a></span>
+<h3 class="unnumbered" id="dcl.attr.deprecated-deprecated-attribute"><span>9.12.5 <a href="https://wg21.link/dcl.attr.deprecated">[dcl.attr.deprecated]</a></span>
 Deprecated attribute<a href="#dcl.attr.deprecated-deprecated-attribute" class="self-link"></a></h3>
 <p>Prefer “type alias” to
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” in paragraph
@@ -9096,7 +9084,7 @@ member, a function, a namespace, an enumeration, an enumerator, a
 concept, or a template specialization.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.unused-maybe-unused-attribute"><span>9.13.8 <a href="https://wg21.link/dcl.attr.unused">[dcl.attr.unused]</a></span>
+<h3 class="unnumbered" id="dcl.attr.unused-maybe-unused-attribute"><span>9.12.9 <a href="https://wg21.link/dcl.attr.unused">[dcl.attr.unused]</a></span>
 Maybe unused attribute<a href="#dcl.attr.unused-maybe-unused-attribute" class="self-link"></a></h3>
 <p>Prefer “type alias” to
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” in paragraph
@@ -9340,7 +9328,7 @@ otherwise unnamed,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(30+.8)</a></span>
 it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>
-(<span>9.13.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
+(<span>9.12.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
 <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><em>A</em><span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>A</em></code> does not equal ⊥ and
 is otherwise declared without an
@@ -9352,7 +9340,7 @@ width given by <code class="sourceCode cpp"><em>W</em></code> if
 otherwise not a bit-field,</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(30+.10)</a></span>
 it is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
-(<span>9.13.11 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
+(<span>9.12.12 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
 if <code class="sourceCode cpp"><em>NUA</em></code> is
 <code class="sourceCode cpp"><span class="kw">true</span></code> and is
 otherwise declared without that attribute.</li>
@@ -9583,7 +9571,7 @@ augmented by the addition of an implied function argument as in a
 qualified function call. If the current class is, or is derived from,
 <code class="sourceCode cpp">T</code>, and the keyword
 <code class="sourceCode cpp"><span class="kw">this</span></code>
-(<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
+(<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
 refers to it, then the implied object argument is <code class="sourceCode cpp"><span class="op">(*</span><span class="kw">this</span><span class="op">)</span></code>.
 Otherwise, a contrived object of type
 <code class="sourceCode cpp">T</code> becomes the implied object
@@ -9637,7 +9625,7 @@ Viable functions<a href="#over.match.viable-viable-functions" class="self-link">
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes to paragraph 2.3 (except for the wording related to
 <code class="sourceCode default"><em>splice-expression</em>s</code>) are
-a part of the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. These changes render
+a part of the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. These changes render
 [over.match.best.general]/4 redundant, hence the relocation of its
 associated example to this section. ]</span></p>
 <p>Specify rules for overload sets denoted by
@@ -9673,12 +9661,12 @@ if <span class="addu">there is a declaration
 overload resolution such that for each</span> <span class="rm" style="color: #bf0303"><del>all</del></span> parameter<span class="rm" style="color: #bf0303"><del>s</del></span> following the
 <code class="sourceCode cpp"><em>m</em><sup>th</sup></code> <span class="rm" style="color: #bf0303"><del>have default
 arguments</del></span><span class="addu">, a reachable declaration whose
-host scope is the same as <code class="sourceCode cpp"><em>D</em></code>
-specifies a default argument for that parameter</span>
-([dcl.fct.default]). <span class="addu">If the candidate function is
-selected as the best viable function, no other host scope of a
-declaration considered by overload resolution shall be the host scope of
-a declaration that specifies a default argument for the
+host scope is the same as that of
+<code class="sourceCode cpp"><em>D</em></code> specifies a default
+argument for that parameter</span> ([dcl.fct.default]). <span class="addu">If the candidate function is selected as the best viable
+function, no other host scope of a declaration considered by overload
+resolution shall be the host scope of a declaration that specifies a
+default argument for the
 (<code class="sourceCode cpp"><em>m</em></code>+1)<sup><em>st</em></sup>
 parameter; the host scope of
 <code class="sourceCode cpp"><em>D</em></code> shall not be a block
@@ -9722,7 +9710,7 @@ right, so that there are exactly
 General<a href="#over.match.best.general-general" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes to [over.match.viable]/2.3 included in this proposal (part of
-the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>) render paragraph 4 redundant;
+the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>) render paragraph 4 redundant;
 the contents of example 9 now follow [over.match.viable]/2. ]</span></p>
 <p>Delete paragraph 4 and example 9.</p>
 <div class="std">
@@ -11347,91 +11335,91 @@ synopsis</strong></p>
 <span id="cb178-24"><a href="#cb178-24" aria-hidden="true" tabindex="-1"></a>  consteval source_location source_location_of(info r);</span>
 <span id="cb178-25"><a href="#cb178-25" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb178-26"><a href="#cb178-26" aria-hidden="true" tabindex="-1"></a>  // [meta.reflection.queries], reflection queries</span>
-<span id="cb178-27"><a href="#cb178-27" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
-<span id="cb178-28"><a href="#cb178-28" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
-<span id="cb178-29"><a href="#cb178-29" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
+<span id="cb178-27"><a href="#cb178-27" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
+<span id="cb178-28"><a href="#cb178-28" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
+<span id="cb178-29"><a href="#cb178-29" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
 <span id="cb178-30"><a href="#cb178-30" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-31"><a href="#cb178-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
-<span id="cb178-32"><a href="#cb178-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
-<span id="cb178-33"><a href="#cb178-33" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
-<span id="cb178-34"><a href="#cb178-34" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
-<span id="cb178-35"><a href="#cb178-35" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-36"><a href="#cb178-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
-<span id="cb178-37"><a href="#cb178-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
-<span id="cb178-38"><a href="#cb178-38" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
-<span id="cb178-39"><a href="#cb178-39" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
-<span id="cb178-40"><a href="#cb178-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
-<span id="cb178-41"><a href="#cb178-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
-<span id="cb178-42"><a href="#cb178-42" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-43"><a href="#cb178-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
-<span id="cb178-44"><a href="#cb178-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
-<span id="cb178-45"><a href="#cb178-45" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-46"><a href="#cb178-46" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
-<span id="cb178-47"><a href="#cb178-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
-<span id="cb178-48"><a href="#cb178-48" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
-<span id="cb178-49"><a href="#cb178-49" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
-<span id="cb178-50"><a href="#cb178-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
-<span id="cb178-51"><a href="#cb178-51" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-52"><a href="#cb178-52" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
-<span id="cb178-53"><a href="#cb178-53" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
-<span id="cb178-54"><a href="#cb178-54" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
+<span id="cb178-31"><a href="#cb178-31" aria-hidden="true" tabindex="-1"></a>  consteval bool is_public(info r);</span>
+<span id="cb178-32"><a href="#cb178-32" aria-hidden="true" tabindex="-1"></a>  consteval bool is_protected(info r);</span>
+<span id="cb178-33"><a href="#cb178-33" aria-hidden="true" tabindex="-1"></a>  consteval bool is_private(info r);</span>
+<span id="cb178-34"><a href="#cb178-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-35"><a href="#cb178-35" aria-hidden="true" tabindex="-1"></a>  consteval bool is_virtual(info r);</span>
+<span id="cb178-36"><a href="#cb178-36" aria-hidden="true" tabindex="-1"></a>  consteval bool is_pure_virtual(info r);</span>
+<span id="cb178-37"><a href="#cb178-37" aria-hidden="true" tabindex="-1"></a>  consteval bool is_override(info r);</span>
+<span id="cb178-38"><a href="#cb178-38" aria-hidden="true" tabindex="-1"></a>  consteval bool is_final(info r);</span>
+<span id="cb178-39"><a href="#cb178-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-40"><a href="#cb178-40" aria-hidden="true" tabindex="-1"></a>  consteval bool is_deleted(info r);</span>
+<span id="cb178-41"><a href="#cb178-41" aria-hidden="true" tabindex="-1"></a>  consteval bool is_defaulted(info r);</span>
+<span id="cb178-42"><a href="#cb178-42" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_provided(info r);</span>
+<span id="cb178-43"><a href="#cb178-43" aria-hidden="true" tabindex="-1"></a>  consteval bool is_user_declared(info r);</span>
+<span id="cb178-44"><a href="#cb178-44" aria-hidden="true" tabindex="-1"></a>  consteval bool is_explicit(info r);</span>
+<span id="cb178-45"><a href="#cb178-45" aria-hidden="true" tabindex="-1"></a>  consteval bool is_noexcept(info r);</span>
+<span id="cb178-46"><a href="#cb178-46" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-47"><a href="#cb178-47" aria-hidden="true" tabindex="-1"></a>  consteval bool is_bit_field(info r);</span>
+<span id="cb178-48"><a href="#cb178-48" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerator(info r);</span>
+<span id="cb178-49"><a href="#cb178-49" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-50"><a href="#cb178-50" aria-hidden="true" tabindex="-1"></a>  consteval bool is_const(info r);</span>
+<span id="cb178-51"><a href="#cb178-51" aria-hidden="true" tabindex="-1"></a>  consteval bool is_volatile(info r);</span>
+<span id="cb178-52"><a href="#cb178-52" aria-hidden="true" tabindex="-1"></a>  consteval bool is_mutable_member(info r);</span>
+<span id="cb178-53"><a href="#cb178-53" aria-hidden="true" tabindex="-1"></a>  consteval bool is_lvalue_reference_qualified(info r);</span>
+<span id="cb178-54"><a href="#cb178-54" aria-hidden="true" tabindex="-1"></a>  consteval bool is_rvalue_reference_qualified(info r);</span>
 <span id="cb178-55"><a href="#cb178-55" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-56"><a href="#cb178-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
-<span id="cb178-57"><a href="#cb178-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
-<span id="cb178-58"><a href="#cb178-58" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
-<span id="cb178-59"><a href="#cb178-59" aria-hidden="true" tabindex="-1"></a>  consteval bool has_c_language_linkage(info r);</span>
-<span id="cb178-60"><a href="#cb178-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
-<span id="cb178-61"><a href="#cb178-61" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-62"><a href="#cb178-62" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
-<span id="cb178-63"><a href="#cb178-63" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerable_type(info r);</span>
-<span id="cb178-64"><a href="#cb178-64" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-65"><a href="#cb178-65" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
-<span id="cb178-66"><a href="#cb178-66" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
-<span id="cb178-67"><a href="#cb178-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
-<span id="cb178-68"><a href="#cb178-68" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
-<span id="cb178-69"><a href="#cb178-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
-<span id="cb178-70"><a href="#cb178-70" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-71"><a href="#cb178-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
-<span id="cb178-72"><a href="#cb178-72" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
-<span id="cb178-73"><a href="#cb178-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
-<span id="cb178-74"><a href="#cb178-74" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
-<span id="cb178-75"><a href="#cb178-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
-<span id="cb178-76"><a href="#cb178-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
-<span id="cb178-77"><a href="#cb178-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
-<span id="cb178-78"><a href="#cb178-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
-<span id="cb178-79"><a href="#cb178-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
-<span id="cb178-80"><a href="#cb178-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
-<span id="cb178-81"><a href="#cb178-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
-<span id="cb178-82"><a href="#cb178-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
-<span id="cb178-83"><a href="#cb178-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
-<span id="cb178-84"><a href="#cb178-84" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-85"><a href="#cb178-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
-<span id="cb178-86"><a href="#cb178-86" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
-<span id="cb178-87"><a href="#cb178-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
-<span id="cb178-88"><a href="#cb178-88" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
-<span id="cb178-89"><a href="#cb178-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
-<span id="cb178-90"><a href="#cb178-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
-<span id="cb178-91"><a href="#cb178-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
-<span id="cb178-92"><a href="#cb178-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
-<span id="cb178-93"><a href="#cb178-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
-<span id="cb178-94"><a href="#cb178-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
-<span id="cb178-95"><a href="#cb178-95" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-96"><a href="#cb178-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
-<span id="cb178-97"><a href="#cb178-97" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
-<span id="cb178-98"><a href="#cb178-98" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-99"><a href="#cb178-99" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
-<span id="cb178-100"><a href="#cb178-100" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-101"><a href="#cb178-101" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
-<span id="cb178-102"><a href="#cb178-102" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
-<span id="cb178-103"><a href="#cb178-103" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
-<span id="cb178-104"><a href="#cb178-104" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
-<span id="cb178-105"><a href="#cb178-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
-<span id="cb178-106"><a href="#cb178-106" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-107"><a href="#cb178-107" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
-<span id="cb178-108"><a href="#cb178-108" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb178-109"><a href="#cb178-109" aria-hidden="true" tabindex="-1"></a>  consteval info type_of(info r);</span>
-<span id="cb178-110"><a href="#cb178-110" aria-hidden="true" tabindex="-1"></a>  consteval info object_of(info r);</span>
-<span id="cb178-111"><a href="#cb178-111" aria-hidden="true" tabindex="-1"></a>  consteval info value_of(info r);</span>
+<span id="cb178-56"><a href="#cb178-56" aria-hidden="true" tabindex="-1"></a>  consteval bool has_static_storage_duration(info r);</span>
+<span id="cb178-57"><a href="#cb178-57" aria-hidden="true" tabindex="-1"></a>  consteval bool has_thread_storage_duration(info r);</span>
+<span id="cb178-58"><a href="#cb178-58" aria-hidden="true" tabindex="-1"></a>  consteval bool has_automatic_storage_duration(info r);</span>
+<span id="cb178-59"><a href="#cb178-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-60"><a href="#cb178-60" aria-hidden="true" tabindex="-1"></a>  consteval bool has_internal_linkage(info r);</span>
+<span id="cb178-61"><a href="#cb178-61" aria-hidden="true" tabindex="-1"></a>  consteval bool has_module_linkage(info r);</span>
+<span id="cb178-62"><a href="#cb178-62" aria-hidden="true" tabindex="-1"></a>  consteval bool has_external_linkage(info r);</span>
+<span id="cb178-63"><a href="#cb178-63" aria-hidden="true" tabindex="-1"></a>  consteval bool has_c_language_linkage(info r);</span>
+<span id="cb178-64"><a href="#cb178-64" aria-hidden="true" tabindex="-1"></a>  consteval bool has_linkage(info r);</span>
+<span id="cb178-65"><a href="#cb178-65" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-66"><a href="#cb178-66" aria-hidden="true" tabindex="-1"></a>  consteval bool is_complete_type(info r);</span>
+<span id="cb178-67"><a href="#cb178-67" aria-hidden="true" tabindex="-1"></a>  consteval bool is_enumerable_type(info r);</span>
+<span id="cb178-68"><a href="#cb178-68" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-69"><a href="#cb178-69" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable(info r);</span>
+<span id="cb178-70"><a href="#cb178-70" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type(info r);</span>
+<span id="cb178-71"><a href="#cb178-71" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace(info r);</span>
+<span id="cb178-72"><a href="#cb178-72" aria-hidden="true" tabindex="-1"></a>  consteval bool is_type_alias(info r);</span>
+<span id="cb178-73"><a href="#cb178-73" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_alias(info r);</span>
+<span id="cb178-74"><a href="#cb178-74" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-75"><a href="#cb178-75" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function(info r);</span>
+<span id="cb178-76"><a href="#cb178-76" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function(info r);</span>
+<span id="cb178-77"><a href="#cb178-77" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function(info r);</span>
+<span id="cb178-78"><a href="#cb178-78" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator(info r);</span>
+<span id="cb178-79"><a href="#cb178-79" aria-hidden="true" tabindex="-1"></a>  consteval bool is_special_member_function(info r);</span>
+<span id="cb178-80"><a href="#cb178-80" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor(info r);</span>
+<span id="cb178-81"><a href="#cb178-81" aria-hidden="true" tabindex="-1"></a>  consteval bool is_default_constructor(info r);</span>
+<span id="cb178-82"><a href="#cb178-82" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_constructor(info r);</span>
+<span id="cb178-83"><a href="#cb178-83" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_constructor(info r);</span>
+<span id="cb178-84"><a href="#cb178-84" aria-hidden="true" tabindex="-1"></a>  consteval bool is_assignment(info r);</span>
+<span id="cb178-85"><a href="#cb178-85" aria-hidden="true" tabindex="-1"></a>  consteval bool is_copy_assignment(info r);</span>
+<span id="cb178-86"><a href="#cb178-86" aria-hidden="true" tabindex="-1"></a>  consteval bool is_move_assignment(info r);</span>
+<span id="cb178-87"><a href="#cb178-87" aria-hidden="true" tabindex="-1"></a>  consteval bool is_destructor(info r);</span>
+<span id="cb178-88"><a href="#cb178-88" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-89"><a href="#cb178-89" aria-hidden="true" tabindex="-1"></a>  consteval bool is_template(info r);</span>
+<span id="cb178-90"><a href="#cb178-90" aria-hidden="true" tabindex="-1"></a>  consteval bool is_function_template(info r);</span>
+<span id="cb178-91"><a href="#cb178-91" aria-hidden="true" tabindex="-1"></a>  consteval bool is_variable_template(info r);</span>
+<span id="cb178-92"><a href="#cb178-92" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_template(info r);</span>
+<span id="cb178-93"><a href="#cb178-93" aria-hidden="true" tabindex="-1"></a>  consteval bool is_alias_template(info r);</span>
+<span id="cb178-94"><a href="#cb178-94" aria-hidden="true" tabindex="-1"></a>  consteval bool is_conversion_function_template(info r);</span>
+<span id="cb178-95"><a href="#cb178-95" aria-hidden="true" tabindex="-1"></a>  consteval bool is_operator_function_template(info r);</span>
+<span id="cb178-96"><a href="#cb178-96" aria-hidden="true" tabindex="-1"></a>  consteval bool is_literal_operator_template(info r);</span>
+<span id="cb178-97"><a href="#cb178-97" aria-hidden="true" tabindex="-1"></a>  consteval bool is_constructor_template(info r);</span>
+<span id="cb178-98"><a href="#cb178-98" aria-hidden="true" tabindex="-1"></a>  consteval bool is_concept(info r);</span>
+<span id="cb178-99"><a href="#cb178-99" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-100"><a href="#cb178-100" aria-hidden="true" tabindex="-1"></a>  consteval bool is_value(info r);</span>
+<span id="cb178-101"><a href="#cb178-101" aria-hidden="true" tabindex="-1"></a>  consteval bool is_object(info r);</span>
+<span id="cb178-102"><a href="#cb178-102" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-103"><a href="#cb178-103" aria-hidden="true" tabindex="-1"></a>  consteval bool is_structured_binding(info r);</span>
+<span id="cb178-104"><a href="#cb178-104" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-105"><a href="#cb178-105" aria-hidden="true" tabindex="-1"></a>  consteval bool is_class_member(info r);</span>
+<span id="cb178-106"><a href="#cb178-106" aria-hidden="true" tabindex="-1"></a>  consteval bool is_namespace_member(info r);</span>
+<span id="cb178-107"><a href="#cb178-107" aria-hidden="true" tabindex="-1"></a>  consteval bool is_nonstatic_data_member(info r);</span>
+<span id="cb178-108"><a href="#cb178-108" aria-hidden="true" tabindex="-1"></a>  consteval bool is_static_member(info r);</span>
+<span id="cb178-109"><a href="#cb178-109" aria-hidden="true" tabindex="-1"></a>  consteval bool is_base(info r);</span>
+<span id="cb178-110"><a href="#cb178-110" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb178-111"><a href="#cb178-111" aria-hidden="true" tabindex="-1"></a>  consteval bool has_default_member_initializer(info r);</span>
 <span id="cb178-112"><a href="#cb178-112" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb178-113"><a href="#cb178-113" aria-hidden="true" tabindex="-1"></a>  consteval bool has_parent(info r);</span>
 <span id="cb178-114"><a href="#cb178-114" aria-hidden="true" tabindex="-1"></a>  consteval info parent_of(info r);</span>
@@ -12153,59 +12141,232 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb188-2"><a href="#cb188-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb188-3"><a href="#cb188-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> <em>has-type</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
+<em>Returns</em>:
+<code class="sourceCode cpp"><span class="kw">true</span></code> if
+<code class="sourceCode cpp">r</code> represents a value, object,
+variable, function that is not a constructor or destructor, enumerator,
+non-static data member, bit-field, direct base class relationship, or
+data member description. Otherwise,
+<code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
+<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
+is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">3</a></span>
+<em>Returns</em>:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(3.1)</a></span>
+If <code class="sourceCode cpp">r</code> represents a value, object,
+variable, function, non-static data member, or bit-field, then the type
+of what is represented by <code class="sourceCode cpp">r</code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(3.2)</a></span>
+Otherwise, if <code class="sourceCode cpp">r</code> represents an
+enumerator <code class="sourceCode cpp"><em>N</em></code> of an
+enumeration <code class="sourceCode cpp"><em>E</em></code>, then:
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">(3.2.1)</a></span>
+If <code class="sourceCode cpp"><em>E</em></code> is defined by a
+declaration <code class="sourceCode cpp"><em>D</em></code> that is
+reachable from a point <code class="sourceCode cpp"><em>P</em></code> in
+the evaluation context and
+<code class="sourceCode cpp"><em>P</em></code> does not occur within an
+<code class="sourceCode cpp"><em>enum-specifier</em></code> of
+<code class="sourceCode cpp"><em>D</em></code>, then a reflection of
+<code class="sourceCode cpp"><em>E</em></code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">(3.2.2)</a></span>
+Otherwise, a reflection of the type of
+<code class="sourceCode cpp"><em>N</em></code> prior to the closing
+brace of the <code class="sourceCode cpp"><em>enum-specifier</em></code>
+as specified in [dcl.enum].</li>
+</ul></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">(3.3)</a></span>
+Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
+base class relationship, then a reflection of the type of the direct
+base class.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">(3.4)</a></span>
+Otherwise, for a data member description
+(<code class="sourceCode cpp"><em>T</em></code>,
+<code class="sourceCode cpp"><em>N</em></code>,
+<code class="sourceCode cpp"><em>A</em></code>,
+<code class="sourceCode cpp"><em>W</em></code>,
+<code class="sourceCode cpp"><em>NUA</em></code>) ([class.mem.general]),
+a reflection of the type
+<code class="sourceCode cpp"><em>T</em></code>.</li>
+</ul>
+<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">4</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
+reflection representing either</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">(4.1)</a></span>
+an object with static storage duration ([basic.stc.general]), or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">(4.2)</a></span>
+a variable that either declares or refers to such an object, and if that
+variable is a reference <code class="sourceCode cpp"><em>R</em></code>
+then either
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">(4.2.1)</a></span>
+<code class="sourceCode cpp"><em>R</em></code> is usable in constant
+expressions ([expr.const]), or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">(4.2.2)</a></span>
+the lifetime of <code class="sourceCode cpp"><em>R</em></code> began
+within the core constant expression currently under evaluation.</li>
+</ul></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">5</a></span>
+<em>Returns</em>:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">(5.1)</a></span>
+If <code class="sourceCode cpp">r</code> represents an object, then
+<code class="sourceCode cpp">r</code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">(5.2)</a></span>
+Otherwise, if <code class="sourceCode cpp">r</code> represents a
+reference, then a reflection of the object referred to by that
+reference.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(5.3)</a></span>
+Otherwise (if <code class="sourceCode cpp">r</code> represents any other
+variable), a reflection of the object declared by that variable.</li>
+</ul>
+<div class="example">
+<span>[ <em>Example 1:</em> </span>
+<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
+<span id="cb191-2"><a href="#cb191-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
+<span id="cb191-3"><a href="#cb191-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb191-4"><a href="#cb191-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^^</span>x <span class="op">!=</span> <span class="op">^^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb191-5"><a href="#cb191-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
+<span id="cb191-6"><a href="#cb191-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
+<span id="cb191-7"><a href="#cb191-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
+<span> — <em>end example</em> ]</span>
+</div>
+<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">6</a></span>
+Let <code class="sourceCode cpp"><em>Q</em></code> be</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(6.1)</a></span>
+If <code class="sourceCode cpp">r</code> represents a reference, then
+the object referred to by that reference.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">(6.2)</a></span>
+Otherwise, if <code class="sourceCode cpp">r</code> represents any other
+variable, then the object declared by that variable.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">(6.3)</a></span>
+Otherwise, the construct represented by
+<code class="sourceCode cpp">r</code>.</li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">7</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp"><em>Q</em></code>
+is</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">(7.1)</a></span>
+a value,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">(7.2)</a></span>
+an enumerator, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(7.3)</a></span>
+an object such that
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(7.3.1)</a></span>
+the lifetime of <code class="sourceCode cpp"><em>Q</em></code> has not
+ended,</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(7.3.2)</a></span>
+the type of <code class="sourceCode cpp"><em>Q</em></code> is a
+structural type ([temp.param]) that is copyable, and</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(7.3.3)</a></span>
+either <code class="sourceCode cpp"><em>Q</em></code> is usable in
+constant expressions from some point in the evaluation context or the
+lifetime of <code class="sourceCode cpp"><em>Q</em></code> began within
+the core constant expression currently under evaluation
+([expr.const]).</li>
+</ul></li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">8</a></span>
+<em>Returns</em>:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(8.1)</a></span>
+If <code class="sourceCode cpp"><em>Q</em></code> is an object
+<code class="sourceCode cpp">o</code>, then a reflection of the value
+held by <code class="sourceCode cpp">o</code>. The reflected value has
+the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
+with the cv-qualifiers removed if this is a scalar type.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(8.2)</a></span>
+Otherwise, if <code class="sourceCode cpp"><em>Q</em></code> is an
+enumerator, then a reflection of the value of the enumerator. The
+reflected value has the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
+with the cv-qualifiers removed.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(8.3)</a></span>
+Otherwise, <code class="sourceCode cpp">r</code>.</li>
+</ul>
+<div class="example">
+<span>[ <em>Example 2:</em> </span>
+<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb193-3"><a href="#cb193-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb193-4"><a href="#cb193-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^^</span>x <span class="op">!=</span> <span class="op">^^</span>y<span class="op">)</span>;                        <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb193-5"><a href="#cb193-5" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// reflections compare different</span></span>
+<span id="cb193-6"><a href="#cb193-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^^</span>y<span class="op">))</span>;    <span class="co">// OK, both value_of(^^x) and value_of(^^y) represent</span></span>
+<span id="cb193-7"><a href="#cb193-7" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// the value 0</span></span>
+<span id="cb193-8"><a href="#cb193-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span>
+<span id="cb193-9"><a href="#cb193-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb193-10"><a href="#cb193-10" aria-hidden="true" tabindex="-1"></a>info fn<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb193-11"><a href="#cb193-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">42</span>;</span>
+<span id="cb193-12"><a href="#cb193-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">^^</span>x;</span>
+<span id="cb193-13"><a href="#cb193-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb193-14"><a href="#cb193-14" aria-hidden="true" tabindex="-1"></a>info r <span class="op">=</span> value_of<span class="op">(</span>fn<span class="op">())</span>;  <span class="co">// error: x is outside its lifetime</span></span></code></pre></div>
+<span> — <em>end example</em> ]</span>
+</div>
+<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb194-3"><a href="#cb194-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or
 direct base class relationship that is public, protected, or private,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">2</a></span>
+<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
 function or a direct base class relationship that is virtual. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb190-2"><a href="#cb190-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">3</a></span>
+<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
 is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">4</a></span>
+<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb192-2"><a href="#cb192-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">5</a></span>
+<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
 deleted function ([dcl.fct.def.delete]) or defaulted function
 ([dcl.fct.def.default]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">6</a></span>
+<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 user-provided or user-declared ([dcl.fct.def.default]), respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">7</a></span>
+<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -12219,8 +12380,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">8</a></span>
+<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -12236,8 +12397,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">9</a></span>
+<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -12250,52 +12411,52 @@ description (<code class="sourceCode cpp"><em>T</em></code>,
 for which <code class="sourceCode cpp"><em>W</em></code> is not ⊥.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">10</a></span>
+<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">11</a></span>
+<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">19</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a const or
 volatile type, respectively, or a const- or volatile-qualified function
 type, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">13</a></span>
+<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><span class="kw">mutable</span></code>
 non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">14</a></span>
+<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">22</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a lvalue- or
 rvalue-reference qualified function type, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb201-3"><a href="#cb201-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">16</a></span>
+<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb207-3"><a href="#cb207-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -12304,12 +12465,12 @@ that has static, thread, or automatic storage duration, respectively
 <code class="sourceCode cpp"><span class="kw">false</span></code>. <span class="note"><span>[ <em>Note 3:</em> </span>It is not possible to have
 a reflection representing an object or variable having dynamic storage
 duration.<span> — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb202-2"><a href="#cb202-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb202-3"><a href="#cb202-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb202-4"><a href="#cb202-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_c_language_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb202-5"><a href="#cb202-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">17</a></span>
+<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb208-3"><a href="#cb208-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb208-4"><a href="#cb208-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_c_language_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb208-5"><a href="#cb208-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -12317,8 +12478,8 @@ type, template, or namespace whose name has internal linkage, module
 linkage, external linkage, C language linkage, or any linkage,
 respectively ([basic.link]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">18</a></span>
+<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -12327,16 +12488,16 @@ there is some point in the evaluation context from which the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerable_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">19</a></span>
+<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerable_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">27</a></span>
 A type <code class="sourceCode cpp"><em>T</em></code> is
 <em>enumerable</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(19.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">(27.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a class type complete
 at <code class="sourceCode cpp"><em>P</em></code> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">(19.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">(27.2)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is an enumeration type
 defined by a declaration <code class="sourceCode cpp"><em>D</em></code>
 such that <code class="sourceCode cpp"><em>D</em></code> is reachable
@@ -12345,7 +12506,7 @@ from <code class="sourceCode cpp"><em>P</em></code> but
 <code class="sourceCode cpp"><em>enum-specifier</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> ([dcl.enum]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">28</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
@@ -12353,44 +12514,44 @@ represents a type that is enumerable from some point in the evaluation
 context. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="example">
-<span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S;</span>
-<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E;</span>
-<span id="cb205-3"><a href="#cb205-3" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb205-4"><a href="#cb205-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
-<span id="cb205-5"><a href="#cb205-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb205-6"><a href="#cb205-6" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S <span class="op">{</span></span>
-<span id="cb205-7"><a href="#cb205-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> mfn<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb205-8"><a href="#cb205-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb205-9"><a href="#cb205-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb205-10"><a href="#cb205-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb205-11"><a href="#cb205-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb205-12"><a href="#cb205-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb205-13"><a href="#cb205-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb205-14"><a href="#cb205-14" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E <span class="op">{</span></span>
-<span id="cb205-15"><a href="#cb205-15" aria-hidden="true" tabindex="-1"></a>  A <span class="op">=</span> is_enumerable_type<span class="op">(^^</span>E<span class="op">)</span> <span class="op">?</span> <span class="dv">1</span> <span class="op">:</span> <span class="dv">2</span></span>
-<span id="cb205-16"><a href="#cb205-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb205-17"><a href="#cb205-17" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
-<span id="cb205-18"><a href="#cb205-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span><span class="kw">static_cast</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;(</span>E<span class="op">::</span>A<span class="op">)</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span>;</span></code></pre></div>
+<span>[ <em>Example 3:</em> </span>
+<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S;</span>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E;</span>
+<span id="cb211-3"><a href="#cb211-3" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb211-4"><a href="#cb211-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
+<span id="cb211-5"><a href="#cb211-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb211-6"><a href="#cb211-6" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S <span class="op">{</span></span>
+<span id="cb211-7"><a href="#cb211-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> mfn<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb211-8"><a href="#cb211-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb211-9"><a href="#cb211-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb211-10"><a href="#cb211-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb211-11"><a href="#cb211-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb211-12"><a href="#cb211-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb211-13"><a href="#cb211-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb211-14"><a href="#cb211-14" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E <span class="op">{</span></span>
+<span id="cb211-15"><a href="#cb211-15" aria-hidden="true" tabindex="-1"></a>  A <span class="op">=</span> is_enumerable_type<span class="op">(^^</span>E<span class="op">)</span> <span class="op">?</span> <span class="dv">1</span> <span class="op">:</span> <span class="dv">2</span></span>
+<span id="cb211-16"><a href="#cb211-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb211-17"><a href="#cb211-17" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
+<span id="cb211-18"><a href="#cb211-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span><span class="kw">static_cast</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;(</span>E<span class="op">::</span>A<span class="op">)</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">21</a></span>
+<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">22</a></span>
+<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity whose
 underlying entity is a type or namespace, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">23</a></span>
+<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias or
@@ -12398,32 +12559,32 @@ namespace alias, respectively <span class="note"><span>[ <em>Note
 4:</em> </span>A specialization of an alias template is a type
 alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">24</a></span>
+<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">25</a></span>
+<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb216-3"><a href="#cb216-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
 conversion function ([class.conv.fct]), operator function ([over.oper]),
 or literal operator ([over.literal]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-3"><a href="#cb211-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-4"><a href="#cb211-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-5"><a href="#cb211-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-6"><a href="#cb211-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-7"><a href="#cb211-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-8"><a href="#cb211-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb211-9"><a href="#cb211-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">26</a></span>
+<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-3"><a href="#cb217-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-4"><a href="#cb217-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-5"><a href="#cb217-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-6"><a href="#cb217-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-7"><a href="#cb217-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-8"><a href="#cb217-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-9"><a href="#cb217-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12432,15 +12593,15 @@ constructor, a copy constructor, a move constructor, an assignment
 operator, a copy assignment operator, a move assignment operator, or a
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">27</a></span>
+<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">35</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">36</a></span>
 <span class="note"><span>[ <em>Note 5:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -12448,16 +12609,16 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code> but
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-3"><a href="#cb213-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-4"><a href="#cb213-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-5"><a href="#cb213-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-6"><a href="#cb213-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-7"><a href="#cb213-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-8"><a href="#cb213-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-9"><a href="#cb213-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">29</a></span>
+<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">37</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -12465,213 +12626,40 @@ variable template, class template, alias template, conversion function
 template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">30</a></span>
+<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">38</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">31</a></span>
+<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">39</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb216-3"><a href="#cb216-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb216-4"><a href="#cb216-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb216-5"><a href="#cb216-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">32</a></span>
+<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb222-3"><a href="#cb222-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb222-4"><a href="#cb222-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb222-5"><a href="#cb222-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">40</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
 namespace member, non-static data member, static member, or direct base
 class relationship, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">33</a></span>
+<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">41</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> <em>has-type</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">34</a></span>
-<em>Returns</em>:
-<code class="sourceCode cpp"><span class="kw">true</span></code> if
-<code class="sourceCode cpp">r</code> represents a value, object,
-variable, function that is not a constructor or destructor, enumerator,
-non-static data member, bit-field, direct base class relationship, or
-data member description. Otherwise,
-<code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">35</a></span>
-<em>Constant When</em>: <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
-is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">36</a></span>
-<em>Returns</em>:</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">(36.1)</a></span>
-If <code class="sourceCode cpp">r</code> represents a value, object,
-variable, function, non-static data member, or bit-field, then the type
-of what is represented by <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">(36.2)</a></span>
-Otherwise, if <code class="sourceCode cpp">r</code> represents an
-enumerator <code class="sourceCode cpp"><em>N</em></code> of an
-enumeration <code class="sourceCode cpp"><em>E</em></code>, then:
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(36.2.1)</a></span>
-If <code class="sourceCode cpp"><em>E</em></code> is defined by a
-declaration <code class="sourceCode cpp"><em>D</em></code> that is
-reachable from a point <code class="sourceCode cpp"><em>P</em></code> in
-the evaluation context and
-<code class="sourceCode cpp"><em>P</em></code> does not occur within an
-<code class="sourceCode cpp"><em>enum-specifier</em></code> of
-<code class="sourceCode cpp"><em>D</em></code>, then a reflection of
-<code class="sourceCode cpp"><em>E</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(36.2.2)</a></span>
-Otherwise, a reflection of the type of
-<code class="sourceCode cpp"><em>N</em></code> prior to the closing
-brace of the <code class="sourceCode cpp"><em>enum-specifier</em></code>
-as specified in [dcl.enum].</li>
-</ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">(36.3)</a></span>
-Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
-base class relationship, then a reflection of the type of the direct
-base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">(36.4)</a></span>
-Otherwise, for a data member description
-(<code class="sourceCode cpp"><em>T</em></code>,
-<code class="sourceCode cpp"><em>N</em></code>,
-<code class="sourceCode cpp"><em>A</em></code>,
-<code class="sourceCode cpp"><em>W</em></code>,
-<code class="sourceCode cpp"><em>NUA</em></code>) ([class.mem.general]),
-a reflection of the type
-<code class="sourceCode cpp"><em>T</em></code>.</li>
-</ul>
-<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">37</a></span>
-<em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
-reflection representing either</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(37.1)</a></span>
-an object with static storage duration ([basic.stc.general]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(37.2)</a></span>
-a variable that either declares or refers to such an object, and if that
-variable is a reference <code class="sourceCode cpp"><em>R</em></code>
-then either
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">(37.2.1)</a></span>
-<code class="sourceCode cpp"><em>R</em></code> is usable in constant
-expressions ([expr.const]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">(37.2.2)</a></span>
-the lifetime of <code class="sourceCode cpp"><em>R</em></code> began
-within the core constant expression currently under evaluation.</li>
-</ul></li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">38</a></span>
-<em>Returns</em>:</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">(38.1)</a></span>
-If <code class="sourceCode cpp">r</code> represents an object, then
-<code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">(38.2)</a></span>
-Otherwise, if <code class="sourceCode cpp">r</code> represents a
-reference, then a reflection of the object referred to by that
-reference.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">(38.3)</a></span>
-Otherwise (if <code class="sourceCode cpp">r</code> represents any other
-variable), a reflection of the object declared by that variable.</li>
-</ul>
-<div class="example">
-<span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> x;</span>
-<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span><span class="op">&amp;</span> y <span class="op">=</span> x;</span>
-<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb221-4"><a href="#cb221-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^^</span>x <span class="op">!=</span> <span class="op">^^</span>y<span class="op">)</span>;                       <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb221-5"><a href="#cb221-5" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// reflections compare different</span></span>
-<span id="cb221-6"><a href="#cb221-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>object_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> object_of<span class="op">(^^</span>y<span class="op">))</span>; <span class="co">// OK, because y is a reference</span></span>
-<span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a>                                                 <span class="co">// to x, their underlying objects are the same</span></span></code></pre></div>
-<span> — <em>end example</em> ]</span>
-</div>
-<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">39</a></span>
-Let <code class="sourceCode cpp"><em>Q</em></code> be</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">(39.1)</a></span>
-If <code class="sourceCode cpp">r</code> represents a reference, then
-the object referred to by that reference.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">(39.2)</a></span>
-Otherwise, if <code class="sourceCode cpp">r</code> represents any other
-variable, then the object declared by that variable.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">(39.3)</a></span>
-Otherwise, the construct represented by
-<code class="sourceCode cpp">r</code>.</li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">40</a></span>
-<em>Constant When</em>: <code class="sourceCode cpp"><em>Q</em></code>
-is</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">(40.1)</a></span>
-a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">(40.2)</a></span>
-an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">(40.3)</a></span>
-an object such that
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">(40.3.1)</a></span>
-the lifetime of <code class="sourceCode cpp"><em>Q</em></code> has not
-ended,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">(40.3.2)</a></span>
-the type of <code class="sourceCode cpp"><em>Q</em></code> is a
-structural type ([temp.param]) that is copyable, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">(40.3.3)</a></span>
-either <code class="sourceCode cpp"><em>Q</em></code> is usable in
-constant expressions from some point in the evaluation context or the
-lifetime of <code class="sourceCode cpp"><em>Q</em></code> began within
-the core constant expression currently under evaluation
-([expr.const]).</li>
-</ul></li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">41</a></span>
-<em>Returns</em>:</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(41.1)</a></span>
-If <code class="sourceCode cpp"><em>Q</em></code> is an object
-<code class="sourceCode cpp">o</code>, then a reflection of the value
-held by <code class="sourceCode cpp">o</code>. The reflected value has
-the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
-with the cv-qualifiers removed if this is a scalar type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">(41.2)</a></span>
-Otherwise, if <code class="sourceCode cpp"><em>Q</em></code> is an
-enumerator, then a reflection of the value of the enumerator. The
-reflected value has the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
-with the cv-qualifiers removed.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">(41.3)</a></span>
-Otherwise, <code class="sourceCode cpp">r</code>.</li>
-</ul>
-<div class="example">
-<span>[ <em>Example 3:</em> </span>
-<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb223-3"><a href="#cb223-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb223-4"><a href="#cb223-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^^</span>x <span class="op">!=</span> <span class="op">^^</span>y<span class="op">)</span>;                        <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb223-5"><a href="#cb223-5" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// reflections compare different</span></span>
-<span id="cb223-6"><a href="#cb223-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^^</span>y<span class="op">))</span>;    <span class="co">// OK, both value_of(^^x) and value_of(^^y) represent</span></span>
-<span id="cb223-7"><a href="#cb223-7" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// the value 0</span></span>
-<span id="cb223-8"><a href="#cb223-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span>
-<span id="cb223-9"><a href="#cb223-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb223-10"><a href="#cb223-10" aria-hidden="true" tabindex="-1"></a>info fn<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb223-11"><a href="#cb223-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">42</span>;</span>
-<span id="cb223-12"><a href="#cb223-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">^^</span>x;</span>
-<span id="cb223-13"><a href="#cb223-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb223-14"><a href="#cb223-14" aria-hidden="true" tabindex="-1"></a>info r <span class="op">=</span> value_of<span class="op">(</span>fn<span class="op">())</span>;  <span class="co">// error: x is outside its lifetime</span></span></code></pre></div>
-<span> — <em>end example</em> ]</span>
-</div>
 <div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_parent<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">42</a></span>
 <em>Returns</em>:</p>
@@ -12935,43 +12923,49 @@ appears at <code class="sourceCode cpp"><em>P</em></code>, then a point
 determined as follows:
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(6.1.1)</a></span>
-If <code class="sourceCode cpp"><em>I</em></code> is used by an
+If <code class="sourceCode cpp"><em>I</em></code> is being used by an
 aggregate initialization that appears at point
 <code class="sourceCode cpp"><em>Q</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(6.1.2)</a></span>
-Otherwise, if initialization by an inherited constructor
-([class.inhctor.init]) uses
-<code class="sourceCode cpp"><em>I</em></code>, a point whose immediate
-scope is the class scope corresponding to
-<code class="sourceCode cpp"><em>C</em></code>.</li>
+Otherwise, if <code class="sourceCode cpp"><em>I</em></code> is being
+used for an initialization by an inherited constructor
+([class.inhctor.init]), a point whose immediate scope is the class scope
+corresponding to <code class="sourceCode cpp"><em>C</em></code>.</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(6.1.3)</a></span>
 Otherwise, a point whose immediate scope is the function parameter scope
-corresponding to the constructor definition that uses
+corresponding to the constructor definition that is using
 <code class="sourceCode cpp"><em>I</em></code>.</li>
 </ul></li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">(6.2)</a></span>
 Otherwise, if a potentially-evaluated subexpression of a default
 argument ([dcl.fct.default]) appears at
 <code class="sourceCode cpp"><em>P</em></code>, and that default
-argument is used by an invocation of a function ([expr.call]) that
+argument is being used by an invocation of a function ([expr.call]) that
 appears at point <code class="sourceCode cpp"><em>Q</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(6.3)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a function parameter
 scope introduced by a declaration
-<code class="sourceCode cpp"><em>D</em></code> that is not reachable, a
-point with the same immediate scope as the locus of
-<code class="sourceCode cpp"><em>D</em></code>.</li>
+<code class="sourceCode cpp"><em>D</em></code>, and
+<code class="sourceCode cpp"><em>P</em></code> appears either before the
+locus of <code class="sourceCode cpp"><em>D</em></code> or within the
+trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
+<code class="sourceCode cpp"><em>D</em></code>, a point whose immediate
+scope is the innermost scope enclosing the locus of
+<code class="sourceCode cpp"><em>D</em></code> that is not a template
+parameter scope.</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(6.4)</a></span>
-Otherwise, if a potentially-evaluated subexpression of a
-<code class="sourceCode cpp"><em>constraint-expression</em></code>
-appears at <code class="sourceCode cpp"><em>P</em></code>, and that
-<code class="sourceCode cpp"><em>constraint-expression</em></code> is
-introduced by the trailing
-<code class="sourceCode cpp"><em>requires-clause</em></code> of a
-function declaration <code class="sourceCode cpp"><em>D</em></code>
-([dcl.decl.general]), a point with the same immediate scope as the locus
-of <code class="sourceCode cpp"><em>D</em></code>.</li>
+Otherwise, if the immediate scope of
+<code class="sourceCode cpp"><em>P</em></code> is a function parameter
+scope introduced by a
+<code class="sourceCode cpp"><em>lambda-expression</em></code>
+<code class="sourceCode cpp"><em>L</em></code> whose
+<code class="sourceCode cpp"><em>lambda-introducer</em></code> appears
+at point <code class="sourceCode cpp"><em>Q</em></code>, and
+<code class="sourceCode cpp"><em>P</em></code> appears either within the
+<code class="sourceCode cpp"><em>trailing-return-type</em></code> or the
+trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
+<code class="sourceCode cpp"><em>L</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">(6.5)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a block scope and the
@@ -12985,22 +12979,46 @@ whose immediate scope is the scope inhabited by
 Otherwise, <code class="sourceCode cpp"><em>P</em></code>.</li>
 </ul>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">7</a></span>
+Given a scope <code class="sourceCode cpp"><em>S</em></code>, let <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="op">)</span></code>
+be the following scope:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(7.1)</a></span>
+If <code class="sourceCode cpp"><em>S</em></code> is a class scope or a
+namespace scope, <code class="sourceCode cpp"><em>S</em></code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(7.2)</a></span>
+Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a lambda
+scope introduced by a
+<code class="sourceCode cpp"><em>lambda-expression</em></code>
+<code class="sourceCode cpp"><em>L</em></code>, the function parameter
+scope corresponding to the call operator of the closure type for
+<code class="sourceCode cpp"><em>L</em></code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(7.3)</a></span>
+Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
+function parameter scope introduced by the declaration of a function,
+<code class="sourceCode cpp"><em>S</em></code>.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(7.4)</a></span>
+Otherwise, <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="ch">&#39;)</span></code>
+where
+<code class="sourceCode cpp"><em>S</em><span class="ch">&#39;</span></code>
+is the parent scope of
+<code class="sourceCode cpp"><em>S</em></code>.</li>
+</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">8</a></span>
 An invocation of <code class="sourceCode cpp">current</code> that
 appears at a program point
 <code class="sourceCode cpp"><em>P</em></code> is value-dependent
 ([temp.dep.contexpr]) if <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
-is enclosed by a template parameter scope.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">8</a></span>
-<em>Returns</em>: Let <code class="sourceCode cpp"><em>P</em></code> be
-the point at which the invocation of
-<code class="sourceCode cpp">current</code> appears, and let
-<code class="sourceCode cpp"><em>S</em></code> be the innermost scope
-enclosing <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
-that is either a class scope, a namespace scope, or a function parameter
-scope that corresponds to a function. An
-<code class="sourceCode cpp">access_context</code> whose naming class is
-the null reflection and whose scope is the class, namespace, or function
-to which <code class="sourceCode cpp"><em>S</em></code> corresponds.</p>
+is enclosed by a scope corresponding to a templated entity.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">9</a></span>
+<em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
+whose naming class is the null reflection and whose scope represents the
+function, class, or namespace whose corresponding function parameter
+scope, class scope, or namespace scope is <code class="sourceCode cpp"><em>eval-ctx</em><span class="op">(</span><em>S</em><span class="op">)</span></code>,
+where <code class="sourceCode cpp"><em>S</em></code> is the immediate
+scope of <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
+and <code class="sourceCode cpp"><em>P</em></code> is the point at which
+the invocation of <code class="sourceCode cpp">current</code> lexically
+appears.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb236"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb236-1"><a href="#cb236-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> A <span class="op">{</span></span>
@@ -13042,19 +13060,19 @@ to which <code class="sourceCode cpp"><em>S</em></code> corresponds.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb237"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb237-1"><a href="#cb237-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unprivileged<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">10</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class is the null reflection and whose scope is the global
 namespace.</p>
 <div class="sourceCode" id="cb238"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb238-1"><a href="#cb238-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">11</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class and scope are both the null reflection.</p>
 <div class="sourceCode" id="cb239"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb239-1"><a href="#cb239-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">cls</code> is
 either the null reflection or a reflection of a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">13</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose scope is <code class="sourceCode cpp"><span class="kw">this</span><span class="op">-&gt;</span>scope<span class="op">()</span></code>
 and whose naming class is <code class="sourceCode cpp">cls</code>.</p>
@@ -13067,44 +13085,44 @@ Member accessibility queries<a href="#meta.reflection.access.queries-member-acce
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb240"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb240-1"><a href="#cb240-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">1</a></span>
 Let <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">(1.1)</a></span>
 If <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 the class <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(1.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>parent_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">2</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">(2.1)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a class member
 for which <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 is an incomplete class and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">(2.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a direct base
 class relationship between a base class and an incomplete derived
 class.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">3</a></span>
 Let <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">(3.1)</a></span>
 If <code class="sourceCode cpp">ctx<span class="op">.</span>naming_class<span class="op">()</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">(4.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed bit-field
 <code class="sourceCode cpp"><em>F</em></code>, then <code class="sourceCode cpp">is_accessible<span class="op">(</span>r<sub><span class="math inline"><em>H</em></span></sub>, ctx<span class="op">)</span></code>
 where
@@ -13115,37 +13133,36 @@ with the same access as <code class="sourceCode cpp"><em>F</em></code>.
 <span class="note"><span>[ <em>Note 1:</em> </span>Unnamed bit-fields
 are treated as class members for the purpose of
 <code class="sourceCode cpp">is_accessible</code>.<span> — <em>end
-note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">(4.2)</a></span>
+note</em> ]</span></span></p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> does not represent a
 class member or a direct base class relationship, then
-<code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">(4.3)</a></span>
-Otherwise, if <code class="sourceCode cpp">r</code> represents
+<code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">(4.3)</a></span>
+Otherwise, if <code class="sourceCode cpp">r</code> represents</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">(4.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">(4.3.1)</a></span>
 a class member that is not a (possibly indirect or variant) member of
 <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">(4.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">(4.3.2)</a></span>
 a direct base class relationship such that <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 does not represent <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or a (direct or indirect) base class thereof,</li>
 </ul>
-then
-<code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">(4.4)</a></span>
+<p>then
+<code class="sourceCode cpp"><span class="kw">false</span></code>.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>
 is the null reflection, then
-<code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">(4.5)</a></span>
+<code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">(4.5)</a></span>
 Otherwise, letting <code class="sourceCode cpp"><em>P</em></code> be a
-program point such that <code class="sourceCode cpp">access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">()</span> <span class="op">==</span> ctx<span class="op">.</span>scope<span class="op">()</span></code>
-would be
-<code class="sourceCode cpp"><span class="kw">true</span></code> if it
-appeared at that point:
+program point whose immediate scope is the function parameter scope,
+class scope, or namespace scope corresponding to the function, class, or
+namespace represented by <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">(4.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">(4.5.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a direct base class
 relationship with base class
 <code class="sourceCode cpp"><em>B</em></code>, then
@@ -13154,7 +13171,7 @@ class <code class="sourceCode cpp"><em>B</em></code> of <code class="sourceCode 
 is accessible at <code class="sourceCode cpp"><em>P</em></code>
 ([class.access.base]); otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">(4.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">(4.5.2)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a class
 member <code class="sourceCode cpp"><em>M</em></code>;
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -13193,17 +13210,17 @@ note</em> ]</span></p>
 <div class="sourceCode" id="cb242"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_nonstatic_data_members<span class="op">(</span></span>
 <span id="cb242-2"><a href="#cb242-2" aria-hidden="true" tabindex="-1"></a>      info r,</span>
 <span id="cb242-3"><a href="#cb242-3" aria-hidden="true" tabindex="-1"></a>      access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">5</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">(5.1)</a></span>
 <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">(5.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a closure
 type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13212,10 +13229,10 @@ any <code class="sourceCode cpp"><em>R</em></code> in <code class="sourceCode cp
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb243"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb243-1"><a href="#cb243-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_bases<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">bases_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13232,11 +13249,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb244"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb244-1"><a href="#cb244-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing either a class type that is complete from
 some point in the evaluation context or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">2</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>members-of-precedes</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if
@@ -13246,31 +13263,31 @@ following the
 <code class="sourceCode cpp"><em>class-specifier</em></code> of the
 outermost class for which <code class="sourceCode cpp"><em>P</em></code>
 is in a complete-class context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> of a member
 <code class="sourceCode cpp"><em>M</em></code> of a class or namespace
 <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible</em>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(3.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a closure type
 ([expr.prim.lambda.closure]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(3.2)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a specialization
 of a template ([temp.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(3.3)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a class that is not
 a closure type, then <code class="sourceCode cpp"><em>M</em></code> is a
 direct member of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.mem.general]) that is not a variant member of a nested anonymous
 union of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.union.anon]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">(3.4)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a namespace, then
 <code class="sourceCode cpp"><em>D</em></code> inhabits the namespace
 scope of <code class="sourceCode cpp"><em>Q</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(3.5)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a closure type,
 then <code class="sourceCode cpp"><em>M</em></code> is a function call
 operator or function call operator template.</li>
@@ -13278,7 +13295,7 @@ operator or function call operator template.</li>
 <p>It is implementation-defined whether declarations of other members of
 a closure type <code class="sourceCode cpp"><em>Q</em></code> are
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">4</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-representable</em>
@@ -13288,34 +13305,34 @@ declaration of <code class="sourceCode cpp"><em>M</em></code>
 members-of-precedes <code class="sourceCode cpp"><em>P</em></code> and
 <code class="sourceCode cpp"><em>M</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">(4.1)</a></span>
 a class or enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">(4.2)</a></span>
 a type alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">(4.3)</a></span>
 a primary class template, function template, primary variable template,
 alias template, or concept,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">(4.4)</a></span>
 a variable or reference,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">(4.5)</a></span>
 a function <code class="sourceCode cpp"><em>F</em></code> for which
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">(4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">(4.6)</a></span>
 the type of <code class="sourceCode cpp"><em>F</em></code> does not
 contain an undeduced placeholder type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">(4.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">(4.7)</a></span>
 the constraints (if any) of
 <code class="sourceCode cpp"><em>F</em></code> are satisfied, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">(4.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">(4.8)</a></span>
 if <code class="sourceCode cpp"><em>F</em></code> is a prospective
 destructor, <code class="sourceCode cpp"><em>F</em></code> is the
 selected destructor ([class.dtor]),</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">(4.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">(4.9)</a></span>
 a non-static data member,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">(4.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">(4.10)</a></span>
 a namespace, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">(4.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">(4.11)</a></span>
 a namespace alias.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Examples of direct
@@ -13326,18 +13343,18 @@ unscoped enumerators ([enum]), partial specializations of templates
 ([temp.spec.partial]), and closure types
 ([expr.prim.lambda.closure]).<span> — <em>end
 note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members
 <code class="sourceCode cpp"><em>M</em></code> of the entity
 <code class="sourceCode cpp"><em>Q</em></code> represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 for which</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">(5.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-representable
 from some point in the evaluation context and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">(5.2)</a></span>
 <code class="sourceCode cpp">is_accessible<span class="op">(^^</span><em>M</em>, ctx<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
@@ -13371,10 +13388,10 @@ note</em> ]</span></span></p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb246"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb246-1"><a href="#cb246-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">7</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp"><em>C</em></code> be
 the class represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -13387,31 +13404,31 @@ corresponding base classes appear in the
 <code class="sourceCode cpp"><em>base-specifier-list</em></code> of
 <code class="sourceCode cpp"><em>C</em></code>.</p>
 <div class="sourceCode" id="cb247"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb247-1"><a href="#cb247-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">8</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">9</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_variable<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
 <div class="sourceCode" id="cb248"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb248-1"><a href="#cb248-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_nonstatic_data_member<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
 <div class="sourceCode" id="cb249"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb249-1"><a href="#cb249-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">is_enumerable_type<span class="op">(</span>type_enum<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">13</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
@@ -13432,29 +13449,29 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <span id="cb250-6"><a href="#cb250-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb250-7"><a href="#cb250-7" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb250-8"><a href="#cb250-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb251"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb251-1"><a href="#cb251-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or direct base class
 relationship other than a virtual base class of an abstract class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the offset in bits
 from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb252"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb252-1"><a href="#cb252-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, direct base class relationship, or data
 member description. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>, a data member
@@ -13477,34 +13494,34 @@ If <code class="sourceCode cpp">b</code> represents a direct base class
 relationship of an empty base class, then <code class="sourceCode cpp">size_of<span class="op">(</span>b<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb253"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb253-1"><a href="#cb253-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing a type, object, variable, non-static data
 member that is not a bit-field, direct base class relationship, or data
 member description. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">(8.1)</a></span>
 If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp"><em>T</em></code>, then
 the alignment requirement for the type of the layout-associated
 subobject ([class.mem.general]) for a non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a variable or object, then the alignment requirement of the
 variable or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">(8.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">(8.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">(8.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>TR</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13518,7 +13535,7 @@ where the corresponding subobject of
 <code class="sourceCode cpp"><em>T</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb254"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb254-1"><a href="#cb254-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, unnamed bit-field, direct base class
@@ -13526,15 +13543,15 @@ relationship, or data member description. If <code class="sourceCode cpp">dealia
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">10</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">(10.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member that is a bit-field or an unnamed bit-field with width
 <code class="sourceCode cpp"><em>W</em></code>, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">(10.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13543,7 +13560,7 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>NUA</em></code>) ([class.mem.general])
 and <code class="sourceCode cpp"><em>W</em></code> is not ⊥, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">(10.3)</a></span>
 Otherwise, <code class="sourceCode cpp">CHAR_BIT <span class="op">*</span> size_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
 </div>
@@ -13554,35 +13571,35 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when its type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb255"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb255-2"><a href="#cb255-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(4.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a variable or object of
 type <code class="sourceCode cpp">U</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">(4.2)</a></span>
 <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">(4.3)</a></span>
 if <code class="sourceCode cpp">r</code> represents a variable, then
 either that variable is usable in constant expressions or its lifetime
 began within the core constant expression currently under
 evaluation.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">5</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 object <code class="sourceCode cpp"><em>O</em></code>, then a reference
 to <code class="sourceCode cpp"><em>O</em></code>. Otherwise, a
@@ -13590,17 +13607,17 @@ reference to the object declared, or referred to, by the variable or
 reference represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb256"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb256-1"><a href="#cb256-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb256-2"><a href="#cb256-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(6.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-static data
 member with type <code class="sourceCode cpp">X</code>, that is not a
 bit-field, that is a direct member of a class
 <code class="sourceCode cpp">C</code> and
 <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">X C<span class="op">::*</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">(6.2)</a></span>
 <code class="sourceCode cpp">r</code> represents an implicit object
 member function with type <code class="sourceCode cpp">F</code> or
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>
@@ -13608,7 +13625,7 @@ that is a direct member of a class <code class="sourceCode cpp">C</code>
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>;
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">(6.3)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-member function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -13616,49 +13633,49 @@ type <code class="sourceCode cpp">F</code> or
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">7</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a pointer type, then a
 pointer value pointing to the function represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">(7.2)</a></span>
 Otherwise, a pointer-to-member value designating the non-static data
 member or function represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb257"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb257-1"><a href="#cb257-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb257-2"><a href="#cb257-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-value</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value that
 <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value that <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">10</a></span>
 <em>Returns</em>: The value that <code class="sourceCode cpp">r</code>
 represents, converted to <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb258"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb258-1"><a href="#cb258-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb258-2"><a href="#cb258-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">11</a></span>
 <em>Effects</em>: Equivalent to:</p>
 <div class="sourceCode" id="cb259"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb259-1"><a href="#cb259-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_reference_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
 <span id="cb259-2"><a href="#cb259-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</span>
@@ -13680,44 +13697,44 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb260-3"><a href="#cb260-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
 <span id="cb260-4"><a href="#cb260-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
 <span id="cb260-5"><a href="#cb260-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">1</a></span>
 <em>Constant When</em>: Let</p>
 <div class="sourceCode" id="cb261"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb261-1"><a href="#cb261-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb261-2"><a href="#cb261-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the values held by
 the elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">4</a></span>
 <em>Remarks</em>: If attempting to substitute leads to a failure outside
 of the immediate context, the program is ill-formed.</p>
 <div class="sourceCode" id="cb262"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb262-1"><a href="#cb262-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb262-2"><a href="#cb262-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the values held by
 the elements of <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">7</a></span>
 <em>Returns</em>: A reflection representing <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">8</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>The specialization
 <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]..&gt;</span></code>
 is only instantiated if the deduction of a placeholder type necessarily
@@ -13731,7 +13748,7 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">1</a></span>
 An object <code class="sourceCode cpp"><em>O</em></code> of type
 <code class="sourceCode cpp"><em>T</em></code> is
 <em>meta-reflectable</em> if an lvalue expression denoting
@@ -13741,52 +13758,52 @@ constant template argument for a constant template parameter of type
 ([temp.arg.nontype]).</p>
 <div class="sourceCode" id="cb263"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb263-1"><a href="#cb263-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb263-2"><a href="#cb263-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">2</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a copy
 constructible, structural type that is neither a reference type nor an
 array type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the value computed
 by an lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">(4.1)</a></span>
 <code class="sourceCode cpp"><em>V</em></code> satisfies the constraints
 for a value computed by a prvalue constant expression
 ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">(4.2)</a></span>
 no constituent reference of
 <code class="sourceCode cpp"><em>V</em></code> refers to an object that
 is not meta-reflectable, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">(4.3)</a></span>
 no constituent value of <code class="sourceCode cpp"><em>V</em></code>
 of pointer type is a pointer to an object that is not
 meta-reflectable.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">5</a></span>
 <em>Returns</em>: A reflection of
 <code class="sourceCode cpp"><em>V</em></code>. The type of the
 represented value is the cv-unqualified version of
 <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb264"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb264-2"><a href="#cb264-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">6</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates a meta-reflectable object.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">8</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb265"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb265-2"><a href="#cb265-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> fn<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">9</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">10</a></span>
 <em>Returns</em>: A reflection of the function designated by
 <code class="sourceCode cpp">fn</code>.</p>
 </div>
@@ -13814,19 +13831,19 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <span id="cb266-15"><a href="#cb266-15" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> bit_width;</span>
 <span id="cb266-16"><a href="#cb266-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
 <span id="cb266-17"><a href="#cb266-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">data_member_options<span class="op">::</span><em>name-type</em></code>
 are consteval-only types ([basic.types.general]), and are not structural
 types ([temp.param]).</p>
 <div class="sourceCode" id="cb267"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb267-1"><a href="#cb267-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb267-2"><a href="#cb267-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="sourceCode" id="cb268"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb268-1"><a href="#cb268-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb268-2"><a href="#cb268-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="note">
@@ -13848,63 +13865,63 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb270"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb270-1"><a href="#cb270-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb270-2"><a href="#cb270-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp">cv <em>T</em></code>
 where <code class="sourceCode cpp"><em>T</em></code> is either an object
 type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">(4.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">(4.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">(4.4.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(4.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">(4.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">(4.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">(4.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">(4.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">(4.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em></code> equals
 <code class="sourceCode cpp"><span class="dv">0</span></code> then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value; and</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13913,31 +13930,31 @@ contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type represented
 by <code class="sourceCode cpp">delias<span class="op">(</span>type<span class="op">)</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 or ⊥ if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 does not contain a value, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">6</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>; it can also be
@@ -13947,7 +13964,7 @@ queried by certain other functions in
 <code class="sourceCode cpp">identifier_of</code>).<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb271"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb271-1"><a href="#cb271-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
@@ -13955,7 +13972,7 @@ description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb272"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb272-1"><a href="#cb272-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb272-2"><a href="#cb272-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">8</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -13963,24 +13980,24 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">(8.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">(8.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context; <span class="note"><span>[ <em>Note
 3:</em> </span><code class="sourceCode cpp"><em>C</em></code> can be a
 class template specialization for which there is a reachable definition
 of the primary class template. In this case, an explicit specialization
 is injected.<span> — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">(8.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">(8.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>;</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">(8.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">(8.3)</a></span>
 <code class="sourceCode cpp">is_complete_type<span class="op">(</span>type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>; and</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">(8.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">(8.4)</a></span>
 for every pair
 (<code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>) where
@@ -13989,11 +14006,11 @@ for every pair
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 then either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">(8.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">(8.4.1)</a></span>
 <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">(8.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">(8.4.2)</a></span>
 <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">==</span> <span class="st">u8&quot;_&quot;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 <span class="note"><span>[ <em>Note 4:</em> </span>Every provided
@@ -14001,7 +14018,7 @@ identifier is unique or <code class="sourceCode cpp"><span class="st">&quot;_&qu
 — <em>end note</em> ]</span></span></li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">9</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -14012,28 +14029,28 @@ values such that <code class="sourceCode cpp">data_member_spec<span class="op">(
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">(10.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">(10.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the core constant expression currently under
 evaluation.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization,
 that is not a local class, of a templated class
 <code class="sourceCode cpp"><em>T</em></code>; then
 <code class="sourceCode cpp"><em>D</em></code> is an explicit
 specialization of
 <code class="sourceCode cpp"><em>T</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">(10.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(10.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>. For every
@@ -14044,27 +14061,27 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">(10.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">(10.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">(10.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">(10.5.1)</a></span>
 It has the type represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">(10.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">(10.5.2)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, it
 is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">(10.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">(10.5.3)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value, it is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(10.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">(10.5.4)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value, it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(*</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">(10.5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">(10.5.5)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>name</code>
 does not contain a value, it is an unnamed bit-field. Otherwise, it is a
 non-static data member with an identifier determined by the character
@@ -14072,7 +14089,7 @@ sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op"
 in UTF-8.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -14082,14 +14099,14 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
-the function is a non-constant library call (<span>3.35 <a href="https://wg21.link/defns.nonconst.libcall">[defns.nonconst.libcall]</a></span>)
+the function is a non-constant library call (<span>3.34 <a href="https://wg21.link/defns.nonconst.libcall">[defns.nonconst.libcall]</a></span>)
 if that argument is not a reflection of a type or type alias. For each
 function taking an argument named
 <code class="sourceCode cpp">type_args</code>, a call to the function is
@@ -14104,7 +14121,7 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -14125,7 +14142,7 @@ as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.
 <span id="cb273-13"><a href="#cb273-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb273-14"><a href="#cb273-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb273-15"><a href="#cb273-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb274"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb274-1"><a href="#cb274-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
@@ -14151,7 +14168,7 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
@@ -14172,7 +14189,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -14181,7 +14198,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TYPE</em></code>
@@ -14190,7 +14207,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14277,12 +14294,12 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb277"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb277-1"><a href="#cb277-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb278"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb278-1"><a href="#cb278-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
@@ -14296,17 +14313,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">1</a></span>
 The consteval functions specified in this subclause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type</code>
 defined in this subclause with type <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>meta<span class="op">::</span>info, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14316,7 +14333,7 @@ each binary function template <code class="sourceCode cpp">meta<span class="op">
 <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14343,7 +14360,7 @@ as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a>
 <span id="cb279-15"><a href="#cb279-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb279-16"><a href="#cb279-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb279-17"><a href="#cb279-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -14365,7 +14382,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -14377,7 +14394,7 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14398,7 +14415,7 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14416,7 +14433,7 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14433,7 +14450,7 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14450,7 +14467,7 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14477,7 +14494,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14485,7 +14502,7 @@ defined in this subclause with type <code class="sourceCode cpp">meta<span class
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>equal<span class="op">(</span>r, vector<span class="op">{^^</span>T<span class="op">...})</span></code>
@@ -14494,7 +14511,7 @@ each unary function template <code class="sourceCode cpp">meta<span class="op">:
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14514,7 +14531,7 @@ returns the reflection of the corresponding type denoted by <code class="sourceC
 <span id="cb285-9"><a href="#cb285-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb285-10"><a href="#cb285-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb285-11"><a href="#cb285-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">4</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb286"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb286-1"><a href="#cb286-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
@@ -14536,29 +14553,29 @@ Miscellaneous Reflection Queries<a href="#meta.reflection.misc-miscellaneous-ref
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 below inclusion of
 <code class="sourceCode default">meta::type_order</code> assumes the
-acceptance of <span class="citation" data-cites="P2830R10"><a href="https://wg21.link/p2830r10" role="doc-biblioref">[P2830R10]</a></span>. ]</span></p>
+acceptance of <span class="citation" data-cites="P2830R10">[<a href="https://wg21.link/p2830r10" role="doc-biblioref">P2830R10</a>]</span>. ]</span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 value <code class="sourceCode cpp">I</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp">info<span class="op">(</span><span class="dt">size_t</span>, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^^</span>T<span class="op">)</span></code>
 returns a reflection representing the type denoted by <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">3</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, <code class="sourceCode cpp">meta<span class="op">::</span>type_order<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of <code class="sourceCode cpp">type_order_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
-as defined in <span>17.12 <a href="https://wg21.link/cmp">[cmp]</a></span>.</p>
+as defined in <span>17.11 <a href="https://wg21.link/cmp">[cmp]</a></span>.</p>
 <div class="sourceCode" id="cb287"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb287-1"><a href="#cb287-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb287-2"><a href="#cb287-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
 <span id="cb287-3"><a href="#cb287-3" aria-hidden="true" tabindex="-1"></a></span>
@@ -14569,43 +14586,43 @@ as defined in <span>17.12 <a href="https://wg21.link/cmp">[cmp]</a></span>.</p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
+<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
 template <code class="sourceCode cpp">bit_cast</code><a href="#bit.cast-function-template-bit_cast" class="self-link"></a></h3>
 <p>And we have adjust the requirements of
 <code class="sourceCode cpp">bit_cast</code> to not allow casting to or
 from
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>,
-in <span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
+in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
 as a mandates:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb288"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb288-1"><a href="#cb288-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> To, <span class="kw">class</span> From<span class="op">&gt;</span></span>
 <span id="cb288-2"><a href="#cb288-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> To bit_cast<span class="op">(</span><span class="kw">const</span> From<span class="op">&amp;</span> from<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">1</a></span>
 <em>Constraints</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">(1.1)</a></span>
 <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>To<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span>From<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">(1.2)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>To<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">(1.3)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>From<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
 </ul>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">*</a></span>
 <em>Mandates</em>: Neither <code class="sourceCode cpp">To</code> nor
 <code class="sourceCode cpp">From</code> are consteval-only types
 ([expr.const]).</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">2</a></span>
 <em>Returns</em>: […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">3</a></span>
 <span class="rm" style="color: #bf0303"><del><em>Remarks</em></del></span> <span class="addu"><em>Constant When</em></span>: <span class="rm" style="color: #bf0303"><del>This function is constexpr if and only
 if</del></span> <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -14613,23 +14630,23 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -14685,7 +14702,7 @@ usual practice is to provide something like
 since the two pieces are so closely tied together, maybe it really only
 makes sense to provide one?</p>
 <p>For now, we’ll add both.</p>
-<p>To <span>15.12 <a href="https://wg21.link/cpp.predefined">[cpp.predefined]</a></span>:</p>
+<p>To <span>15.11 <a href="https://wg21.link/cpp.predefined">[cpp.predefined]</a></span>:</p>
 <div class="std">
 <blockquote>
 <div>
@@ -14706,13 +14723,13 @@ makes sense to provide one?</p>
 </div>
 <h1 data-number="6" style="border-bottom:1px solid #cccccc" id="appendix-design-changes-approved-in-hagenberg"><span class="header-section-number">6</span> Appendix: Design changes approved
 in Hagenberg<a href="#appendix-design-changes-approved-in-hagenberg" class="self-link"></a></h1>
-<p><span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span> was forwarded to CWG in
+<p><span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span> was forwarded to CWG in
 St. Louis (June 2024). In the time after, some minor design changes were
 shown to be necessary. The following changes were confirmed by EWG
 during the Hagenberg 2025 meeting.</p>
 <p>One small change was needed to the reflection operator.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">1</a></span>
 Application of the
 <code class="sourceCode cpp"><span class="op">^^</span></code> operator
 to a non-type template parameter
@@ -14741,7 +14758,7 @@ as appropriate.</li>
 <p>A few changes were needed to “consteval-only types” to ensure that
 objects of such types cannot reach runtime.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">2</a></span>
 Relaxed linkage restrictions on objects of consteval-only types
 <ul>
 <li><strong>P2996R4</strong>: Rigid rules prevented objects of
@@ -14759,7 +14776,7 @@ imported across TUs and modules without issue.
 <li>Try it with <a href="https://godbolt.org/z/Y8cdd9sGo">Clang</a>.</li>
 </ul></li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">3</a></span>
 Immediate-escalation of expressions of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Every expression of consteval-only type
@@ -14769,7 +14786,7 @@ to persist to runtime (e.g., passing a reference to a <code class="sourceCode cp
 to a runtime function).</li>
 <li>Fully implemented; try it with Clang <a href="https://godbolt.org/z/5sfe7vdzE">here</a> and <a href="https://godbolt.org/z/T3MY1Yqo4">here</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">4</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">4</a></span>
 Immediate-escalation of non-constexpr variables of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Immediate-escalating functions containing
@@ -14780,7 +14797,7 @@ of consteval-only type (for which an expression does not necessarily
 appear) from reaching runtime.</li>
 <li>Fully implemented; try it with <a href="https://godbolt.org/z/3asrnK13G">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">5</a></span>
 No “erasure” of consteval-only-ness from results of constant
 expressions.
 <ul>
@@ -14799,7 +14816,7 @@ seen <a href="https://godbolt.org/z/E4faezfr3">here</a>).</li>
 </ul>
 <p>Two changes were needed for splicers.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_777" id="pnum_777">6</a></span>
 A slight syntactic change is needed for template splicers.
 <ul>
 <li><strong>P2994R4</strong>:
@@ -14820,14 +14837,14 @@ were supposed to work.</li>
 </ul></li>
 <li>Try it on godbolt with <a href="https://godbolt.org/z/GKj5of839">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">7</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_778" id="pnum_778">7</a></span>
 Reflections of concepts cannot be spliced.
 <ul>
 <li><strong>P2996R4</strong>: Concepts could be spliced within both
 <code class="sourceCode cpp"><em>type-constraint</em></code>s and
 <code class="sourceCode cpp"><em>concept-id</em></code>s.</li>
 <li><strong>D2996R10</strong>: Splicing a concept is ill-formed.</li>
-<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5"><a href="https://wg21.link/p2841r5" role="doc-biblioref">[P2841R5]</a></span> has already done the work to
+<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5">[<a href="https://wg21.link/p2841r5" role="doc-biblioref">P2841R5</a>]</span> has already done the work to
 figure out dependent concepts. CWG requested that we wait for that to
 land first, and revisit concept splicers in a future paper.</li>
 <li><strong>Instead</strong>: For the case of a
@@ -14843,7 +14860,7 @@ after P2996R4. When the evaluation of an expression calls
 evaluation produces an <em>injected declaration</em> of the completed
 type (try it on <a href="https://godbolt.org/z/PTeb9qqcW">godbolt</a>).</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_779" id="pnum_779">1</a></span>
 Recent revisions lock down the context from which
 <code class="sourceCode cpp">define_aggregate</code> can be called.
 <ul>
@@ -14862,7 +14879,7 @@ for code injection due to e.g., template instantiation behavior,
 immediate-escalating expression behavior, etc.</li>
 <li>Fully implemented with Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_780" id="pnum_780">2</a></span>
 The scope that a given expression can inject a declaration <em>into</em>
 has been constrained.
 <ul>
@@ -14877,7 +14894,7 @@ use <code class="sourceCode cpp">define_aggregate</code> to observe
 failed substitutions, overload resolution order, etc.</li>
 <li>Fully implemented in Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_781" id="pnum_781">3</a></span>
 Strengthening order of evaluation for core constant expressions removes
 the need for more IFNDR.
 <ul>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -6771,7 +6771,7 @@ consteval source_location source_location_of(info r);
 consteval bool $has-type$(info r); // exposition only
 ```
 
-[#]{.pnum} *Returns*: `true` if  `r` represents a value, object, variable, function that is not a constructor or destructor, enumerator, non-static data member, bit-field, direct base class relationship, or data member description. Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if  `r` represents a value, object, variable, function that is not a constructor or destructor, enumerator, non-static data member, unnamed bit-field, direct base class relationship, or data member description. Otherwise, `false`.
 
 ```cpp
 consteval info type_of(info r);
@@ -6781,7 +6781,7 @@ consteval info type_of(info r);
 
 [#]{.pnum} *Returns*:
 
-- [#.#]{.pnum} If `r` represents a value, object, variable, function, non-static data member, or bit-field, then the type of what is represented by `r`.
+- [#.#]{.pnum} If `r` represents a value, object, variable, function, non-static data member, or unnamed bit-field, then the type of what is represented by `r`.
 - [#.#]{.pnum} Otherwise, if `r` represents an enumerator `$N$` of an enumeration `$E$`, then:
   - [#.#.#]{.pnum} If `$E$` is defined by a declaration `$D$` that is reachable from a point `$P$` in the evaluation context and `$P$` does not occur within an `$enum-specifier$` of `$D$`, then a reflection of `$E$`.
   - [#.#.#]{.pnum} Otherwise, a reflection of the type of `$N$` prior to the closing brace of the `$enum-specifier$` as specified in [dcl.enum].


### PR DESCRIPTION
Further edits to `access_context::current()` and `is_accessible`.

Other minor edits:
- Move `type_of` and friends earlier in `[meta.reflection]` such that the definition of _has-type_ precedes its usage in e.g., `is_const`.
- "same as that of _S_" instead of "same as _S_" (which makes it sound like _S_ is a type).
- Remove some more `{.sref}`s.