### PR TITLE
Updates before 2025-05-09 telecon.

### DIFF
--- a/2996_reflection/d2996r12.html
+++ b/2996_reflection/d2996r12.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-05-08" />
+  <meta name="dcterms.date" content="2025-05-09" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -575,7 +575,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-05-08</td>
+    <td>2025-05-09</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -761,10 +761,10 @@ definitions<span></span></a></li>
 <li><a href="#lex.phases-phases-of-translation" id="toc-lex.phases-phases-of-translation"><span>5.2
 <span>[lex.phases]</span></span> Phases of
 translation<span></span></a></li>
-<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.5
+<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.4
 <span>[lex.pptoken]</span></span> Preprocessing
 tokens<span></span></a></li>
-<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.8
+<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.12
 <span>[lex.operators]</span></span> Operators and
 punctuators<span></span></a></li>
 <li><a href="#basic.pre-preamble" id="toc-basic.pre-preamble"><span>6.1
@@ -806,18 +806,18 @@ dependence<span></span></a></li>
 <li><a href="#expr.prim-primary-expressions" id="toc-expr.prim-primary-expressions"><span>7.5
 <span>[expr.prim]</span></span> Primary
 expressions<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.5.2
+<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.4.2
 <span>[expr.prim.id.unqual]</span></span> Unqualified
 names<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
-<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.6.2
+<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.5.2
 <span>[expr.prim.lambda.closure]</span></span> Closure
 types<span></span></a></li>
-<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span>7.5.8.3
+<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span>7.5.7.3
 <span>[expr.prim.req.type]</span></span> Type
 requirements<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
@@ -862,31 +862,31 @@ Functions<span></span></a></li>
 <li><a href="#dcl.fct.default-default-arguments" id="toc-dcl.fct.default-default-arguments"><span>9.3.4.7
 <span>[dcl.fct.default]</span></span> Default
 arguments<span></span></a></li>
-<li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.5.1
+<li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.4.1
 <span>[dcl.init.general]</span></span> Initializers
 (General)<span></span></a></li>
-<li><a href="#dcl.fct.def.general-function-definitions" id="toc-dcl.fct.def.general-function-definitions"><span>9.6.1
+<li><a href="#dcl.fct.def.general-function-definitions" id="toc-dcl.fct.def.general-function-definitions"><span>9.5.1
 <span>[dcl.fct.def.general]</span></span> Function
 definitions<span></span></a></li>
-<li><a href="#dcl.fct.def.delete-deleted-definitions" id="toc-dcl.fct.def.delete-deleted-definitions"><span>9.6.3
+<li><a href="#dcl.fct.def.delete-deleted-definitions" id="toc-dcl.fct.def.delete-deleted-definitions"><span>9.5.3
 <span>[dcl.fct.def.delete]</span></span> Deleted
 definitions<span></span></a></li>
-<li><a href="#enum.udecl-the-using-enum-declaration" id="toc-enum.udecl-the-using-enum-declaration"><span>9.8.2
+<li><a href="#enum.udecl-the-using-enum-declaration" id="toc-enum.udecl-the-using-enum-declaration"><span>9.7.2
 <span>[enum.udecl]</span></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
 declaration<span></span></a></li>
-<li><a href="#namespace.alias-namespace-alias" id="toc-namespace.alias-namespace-alias"><span>9.9.3
+<li><a href="#namespace.alias-namespace-alias" id="toc-namespace.alias-namespace-alias"><span>9.8.3
 <span>[namespace.alias]</span></span> Namespace
 alias<span></span></a></li>
-<li><a href="#namespace.udir-using-namespace-directive" id="toc-namespace.udir-using-namespace-directive"><span>9.9.4
+<li><a href="#namespace.udir-using-namespace-directive" id="toc-namespace.udir-using-namespace-directive"><span>9.8.4
 <span>[namespace.udir]</span></span> Using namespace
 directive<span></span></a></li>
-<li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.13.1
+<li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1
 <span>[dcl.attr.grammar]</span></span> Attribute syntax and
 semantics<span></span></a></li>
-<li><a href="#dcl.attr.deprecated-deprecated-attribute" id="toc-dcl.attr.deprecated-deprecated-attribute"><span>9.13.4
+<li><a href="#dcl.attr.deprecated-deprecated-attribute" id="toc-dcl.attr.deprecated-deprecated-attribute"><span>9.12.5
 <span>[dcl.attr.deprecated]</span></span> Deprecated
 attribute<span></span></a></li>
-<li><a href="#dcl.attr.unused-maybe-unused-attribute" id="toc-dcl.attr.unused-maybe-unused-attribute"><span>9.13.8
+<li><a href="#dcl.attr.unused-maybe-unused-attribute" id="toc-dcl.attr.unused-maybe-unused-attribute"><span>9.12.9
 <span>[dcl.attr.unused]</span></span> Maybe unused
 attribute<span></span></a></li>
 <li><a href="#module.global.frag-global-module-fragment" id="toc-module.global.frag-global-module-fragment"><span>10.4
@@ -904,10 +904,11 @@ unions<span></span></a></li>
 General<span></span></a></li>
 <li><a href="#class.access.general-general" id="toc-class.access.general-general"><span>11.8.1
 <span>[class.access.general]</span></span> General<span></span></a></li>
+<li><a href="#class.access.base-accessibility-of-base-classes-and-base-class-members" id="toc-class.access.base-accessibility-of-base-classes-and-base-class-members"><span>11.8.3
+<span>[class.access.base]</span></span> Accessibility of base classes
+and base class members<span></span></a></li>
 <li><a href="#over.pre-preamble" id="toc-over.pre-preamble"><span>12.1
 <span>[over.pre]</span></span> Preamble<span></span></a></li>
-<li><a href="#over.match.general-general" id="toc-over.match.general-general"><span>12.2.1
-<span>[over.match.general]</span></span> General<span></span></a></li>
 <li><a href="#over.call.func-call-to-named-function" id="toc-over.call.func-call-to-named-function"><span>12.2.2.2.2
 <span>[over.call.func]</span></span> Call to named
 function<span></span></a></li>
@@ -1060,7 +1061,7 @@ Other transformations<span></span></a></li>
 <li><a href="#meta.reflection.misc-miscellaneous-reflection-queries" id="toc-meta.reflection.misc-miscellaneous-reflection-queries">[meta.reflection.misc],
 Miscellaneous Reflection Queries<span></span></a></li>
 </ul></li>
-<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.11.3
+<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.15.3
 <span>[bit.cast]</span></span> Function template
 <code class="sourceCode cpp">bit_cast</code><span></span></a></li>
 <li><a href="#diff.cpp23-annex-c-informative-compatibility" id="toc-diff.cpp23-annex-c-informative-compatibility"><span>C.1
@@ -1077,14 +1078,19 @@ Hagenberg<span></span></a></li>
 </div>
 <h1 data-number="1" style="border-bottom:1px solid #cccccc" id="revision-history"><span class="header-section-number">1</span>
 Revision History<a href="#revision-history" class="self-link"></a></h1>
-<p>Since <span class="citation" data-cites="P2996R11"><a href="https://wg21.link/p2996r11" role="doc-biblioref">[P2996R11]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R11">[<a href="https://wg21.link/p2996r11" role="doc-biblioref">P2996R11</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
 <li>better specify interaction between spliced function calls and
-overload resolution; integrate fix to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span></li>
+overload resolution; integrate fix to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span></li>
 <li>disallow reflection of local parameters introduced by
 <code class="sourceCode cpp"><em>requires-expression</em></code>s</li>
+<li>change “naming class” to “designating class” and define for
+<code class="sourceCode cpp"><em>splice-expression</em></code>s</li>
+<li>clarified value reflection model and the interaction between
+<code class="sourceCode cpp">reflect_value</code>,
+<code class="sourceCode cpp">value_of</code>, and splicing.</li>
 </ul></li>
 <li>library wording updates
 <ul>
@@ -1095,7 +1101,7 @@ is no longer constant if <code class="sourceCode cpp">r</code> is a
 bit-field</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R10"><a href="https://wg21.link/p2996r10" role="doc-biblioref">[P2996R10]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R10">[<a href="https://wg21.link/p2996r10" role="doc-biblioref">P2996R10</a>]</span>:</p>
 <ul>
 <li>replaced <code class="sourceCode cpp">has_complete_definition</code>
 function with more narrow
@@ -1129,8 +1135,7 @@ immediate functions</li>
 enumerators called from within the containing
 <code class="sourceCode cpp"><em>enum-specifier</em></code></li>
 <li>minor editing and phrasing updates to address CWG feedback</li>
-<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13"><a href="https://wg21.link/p2786r13" role="doc-biblioref">[P2786R13] (Trivial Relocatability For
-C++26)</a></span></span></li>
+<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13">[<a href="https://wg21.link/p2786r13" role="doc-biblioref">P2786R13</a>]</span></span></li>
 <li>in response to CWG feedback: added
 <code class="sourceCode cpp">has_c_language_linkage</code>,
 <code class="sourceCode cpp">has_parent</code>,
@@ -1144,13 +1149,13 @@ members to <code class="sourceCode cpp">access_context</code></li>
 <code class="sourceCode cpp">members_of</code></li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R9"><a href="https://wg21.link/p2996r9" role="doc-biblioref">[P2996R9]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R9">[<a href="https://wg21.link/p2996r9" role="doc-biblioref">P2996R9</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
-<li>merge <span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1] (Consteval blocks)</a></span></span> into
-P2996. Replace the category of “plainly constant-evaluated expressions”
-with consteval blocks.</li>
+<li>merge <span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span> into P2996. Replace the
+category of “plainly constant-evaluated expressions” with consteval
+blocks.</li>
 <li>make the [expr.const] “scope rule” for injected declarations more
 rigorous; disallow escape from function parameter scopes</li>
 <li>revise [expr.reflect] grammar according to CWG feedback</li>
@@ -1158,7 +1163,7 @@ rigorous; disallow escape from function parameter scopes</li>
 arguments</li>
 <li>bring notes and examples into line with current definitions</li>
 <li>rebase [expr.const] onto latest from working draft (in particular,
-integrate changes from <span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+integrate changes from <span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>prefer “core constant expressions” to “manifestly constant-evaluated
 expression” in several places</li>
 <li>producing an injected declaration from a non-plainly
@@ -1176,14 +1181,14 @@ lieu of “core constant expression”)</li>
 <li>avoid referring to “permitted results of constant expressions” in
 wording for <code class="sourceCode cpp">reflect_value</code> and
 <code class="sourceCode cpp">reflect_object</code> (term was retired by
-<span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+<span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>template specializations and non-static data members of closure
 types are not <em>members-of-representable</em></li>
-<li>integrated <span class="title"><span class="citation" data-cites="P3547R1"><a href="https://wg21.link/p3547r1" role="doc-biblioref">[P3547R1] (Modeling Access Control With
-Reflection)</a></span></span> following its approval in (L)EWG.</li>
+<li>integrated <span class="title"><span class="citation" data-cites="P3547R1">[<a href="https://wg21.link/p3547r1" role="doc-biblioref">P3547R1</a>]</span></span> following its approval
+in (L)EWG.</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R8"><a href="https://wg21.link/p2996r8" role="doc-biblioref">[P2996R8]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R8">[<a href="https://wg21.link/p2996r8" role="doc-biblioref">P2996R8</a>]</span>:</p>
 <ul>
 <li>ensure <code class="sourceCode cpp">value_of</code> and
 <code class="sourceCode cpp">extract</code> are usable with reflections
@@ -1236,12 +1241,12 @@ complete-class contexts; rename to “<em>members-of-precedes</em>”</li>
 </ul></li>
 <li>fleshed out revision history for R8</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R7"><a href="https://wg21.link/p2996r7" role="doc-biblioref">[P2996R7]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R7">[<a href="https://wg21.link/p2996r7" role="doc-biblioref">P2996R7</a>]</span>:</p>
 <ul>
 <li>changed reflection operator from
 <code class="sourceCode cpp"><span class="op">^</span></code> to
 <code class="sourceCode cpp"><span class="op">^^</span></code> following
-adoption of <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span></li>
+adoption of <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span></li>
 <li>renamed <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>operator_symbol_of</code>
 to <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>symbol_of</code></li>
 <li>renamed some <code class="sourceCode cpp">operators</code>
@@ -1330,7 +1335,7 @@ base class relationship</em> to assist with specification of
 in [temp.arg.general]</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R6"><a href="https://wg21.link/p2996r6" role="doc-biblioref">[P2996R6]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R6">[<a href="https://wg21.link/p2996r6" role="doc-biblioref">P2996R6</a>]</span>:</p>
 <ul>
 <li>removed the <code class="sourceCode cpp">accessible_members</code>
 family of functions</li>
@@ -1349,7 +1354,7 @@ functions, tweaked enumerator names in <code class="sourceCode cpp">std<span cla
 completeness with
 <code class="sourceCode cpp">is_user_provided</code></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R5"><a href="https://wg21.link/p2996r5" role="doc-biblioref">[P2996R5]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R5">[<a href="https://wg21.link/p2996r5" role="doc-biblioref">P2996R5</a>]</span>:</p>
 <ul>
 <li>fixed broken “Emulating typeful reflection” example.</li>
 <li>removed linkage restrictions on objects of consteval-only type that
@@ -1370,7 +1375,7 @@ Aliases”</a> section.</li>
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
 <li>removed <code class="sourceCode cpp">subobjects_of</code> and
 <code class="sourceCode cpp">accessible_subobjects_of</code> (will be
-reintroduced by <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>).</li>
+reintroduced by <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>).</li>
 <li>specified constraints for
 <code class="sourceCode cpp">enumerators_of</code> in terms of
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
@@ -1392,7 +1397,7 @@ with core language terminology.</li>
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” over “alias
 of a type” in formal wording.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span>:</p>
 <ul>
 <li>removed filters from query functions</li>
 <li>cleaned up accessibility interface, removed
@@ -1434,7 +1439,7 @@ comparison among reflections returned by it.</li>
 <code class="sourceCode cpp">is_complete_type</code></li>
 <li>Many wording updates in response to feedback from CWG.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R3"><a href="https://wg21.link/p2996r3" role="doc-biblioref">[P2996R3]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R3">[<a href="https://wg21.link/p2996r3" role="doc-biblioref">P2996R3</a>]</span>:</p>
 <ul>
 <li>changes to name functions to improve Unicode-friendliness; added
 <code class="sourceCode cpp">u8name_of</code>,
@@ -1460,7 +1465,7 @@ object; added <code class="sourceCode cpp">object_of</code>
 metafunction</li>
 <li>more wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R2"><a href="https://wg21.link/p2996r2" role="doc-biblioref">[P2996R2]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R2">[<a href="https://wg21.link/p2996r2" role="doc-biblioref">P2996R2</a>]</span>:</p>
 <ul>
 <li>many wording changes, additions, and improvements</li>
 <li>elaborated on equivalence among reflections and linkage of templated
@@ -1501,8 +1506,8 @@ functions, not member function templates</li>
 text</a></li>
 <li>added a section discussing ODR concerns</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R1"><a href="https://wg21.link/p2996r1" role="doc-biblioref">[P2996R1]</a></span>, several changes to the
-overall library API:</p>
+<p>Since <span class="citation" data-cites="P2996R1">[<a href="https://wg21.link/p2996r1" role="doc-biblioref">P2996R1</a>]</span>, several changes to the overall
+library API:</p>
 <ul>
 <li>added <code class="sourceCode cpp">qualified_name_of</code> (to
 partner with <code class="sourceCode cpp">name_of</code>)</li>
@@ -1526,7 +1531,7 @@ reflection</a>.</li>
 freestanding.</li>
 <li>adding lots of wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R0"><a href="https://wg21.link/p2996r0" role="doc-biblioref">[P2996R0]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R0">[<a href="https://wg21.link/p2996r0" role="doc-biblioref">P2996R0</a>]</span>:</p>
 <ul>
 <li>added links to Compiler Explorer demonstrating just about all of the
 examples</li>
@@ -1545,7 +1550,7 @@ for exceptions (removing invalid reflections)</li>
 Introduction<a href="#introduction" class="self-link"></a></h1>
 <p>This is a proposal for a reduced initial set of features to support
 static reflection in C++. Specifically, we are mostly proposing a subset
-of features suggested in <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>:</p>
+of features suggested in <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>:</p>
 <ul>
 <li>the representation of program elements via constant-expressions
 producing <em>reflection values</em> — <em>reflections</em> for short —
@@ -1571,7 +1576,7 @@ and compile-time metaprogramming are concerned. Instead, we expect it
 will be a useful core around which more powerful features will be added
 incrementally over time. In particular, we believe that most or all the
 remaining features explored in P1240R2 and that code injection (along
-the lines described in <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>) are desirable directions to
+the lines described in <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>) are desirable directions to
 pursue.</p>
 <p>Our choice to start with something smaller is primarily motivated by
 the belief that that improves the chances of these facilities making it
@@ -1585,7 +1590,7 @@ predicates (such as <code class="sourceCode cpp">is_class_v</code>) in
 reflection computations.</p>
 <p>One addition does stand out, however: We have added metafunctions
 that permit the synthesis of simple struct and union types. While it is
-not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>), it can be remarkably
+not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>), it can be remarkably
 effective in practice.</p>
 <h2 data-number="2.2" id="why-a-single-opaque-reflection-type"><span class="header-section-number">2.2</span> Why a single opaque reflection
 type?<a href="#why-a-single-opaque-reflection-type" class="self-link"></a></h2>
@@ -1731,17 +1736,9 @@ rely on these features, and it is possible to do without them - but it
 would greatly help the usability experience if those could be adopted as
 well:</p>
 <ul>
-<li><span class="title"><span class="citation" data-cites="P1306R2"><a href="https://wg21.link/p1306r2" role="doc-biblioref">[P1306R2]
-(Expansion statements)</a></span></span></li>
-<li><span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]
-(Consteval blocks)</a></span></span></li>
-<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7"><a href="https://wg21.link/p0784r7" role="doc-biblioref">[P0784R7] (More
-constexpr containers)</a></span></span>, <span class="title"><span class="citation" data-cites="P1974R0"><a href="https://wg21.link/p1974r0" role="doc-biblioref">[P1974R0]
-(Non-transient constexpr allocation using propconst)</a></span></span>,
-<span class="title"><span class="citation" data-cites="P2670R1"><a href="https://wg21.link/p2670r1" role="doc-biblioref">[P2670R1]
-(Non-transient constexpr allocation)</a></span></span>, <span class="title"><span class="citation" data-cites="P3554R0"><a href="https://wg21.link/p3554r0" role="doc-biblioref">[P3554R0]
-(Non-transient allocation with vector and
-basic_string)</a></span></span></li>
+<li><span class="title"><span class="citation" data-cites="P1306R2">[<a href="https://wg21.link/p1306r2" role="doc-biblioref">P1306R2</a>]</span></span></li>
+<li><span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span></li>
+<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7">[<a href="https://wg21.link/p0784r7" role="doc-biblioref">P0784R7</a>]</span></span>, <span class="title"><span class="citation" data-cites="P1974R0">[<a href="https://wg21.link/p1974r0" role="doc-biblioref">P1974R0</a>]</span></span>, <span class="title"><span class="citation" data-cites="P2670R1">[<a href="https://wg21.link/p2670r1" role="doc-biblioref">P2670R1</a>]</span></span>, <span class="title"><span class="citation" data-cites="P3554R0">[<a href="https://wg21.link/p3554r0" role="doc-biblioref">P3554R0</a>]</span></span></li>
 </ul>
 <h2 data-number="3.1" id="back-and-forth"><span class="header-section-number">3.1</span> Back-And-Forth<a href="#back-and-forth" class="self-link"></a></h2>
 <p>Our first example is not meant to be compelling but to show how to go
@@ -2319,7 +2316,7 @@ initialize members of a defined union using a splicer, as in:</p>
 </blockquote>
 </div>
 <p>Arguably, the answer should be yes - this would be consistent with
-how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>.</p>
+how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>.</p>
 <p>On Compiler Explorer: <a href="https://godbolt.org/z/W74qxqnhf">EDG</a>, <a href="https://godbolt.org/z/eqj6e3Tjr">Clang</a>.</p>
 <h2 data-number="3.10" id="struct-to-struct-of-arrays"><span class="header-section-number">3.10</span> Struct to Struct of Arrays<a href="#struct-to-struct-of-arrays" class="self-link"></a></h2>
 <div class="std">
@@ -2611,7 +2608,7 @@ requires writing
 since this isn’t a type-only context.</p>
 <h2 data-number="3.13" id="implementing-member-wise-hash_append"><span class="header-section-number">3.13</span> Implementing member-wise
 <code class="sourceCode cpp">hash_append</code><a href="#implementing-member-wise-hash_append" class="self-link"></a></h2>
-<p>Based on the <span class="citation" data-cites="N3980"><a href="https://wg21.link/n3980" role="doc-biblioref">[N3980]</a></span>
+<p>Based on the <span class="citation" data-cites="N3980">[<a href="https://wg21.link/n3980" role="doc-biblioref">N3980</a>]</span>
 API:</p>
 <div class="std">
 <blockquote>
@@ -2627,12 +2624,12 @@ API:</p>
 <p>Of course, any production-ready
 <code class="sourceCode cpp">hash_append</code> would include a facility
 for classes to opt members in and out of participation in hashing.
-Annotations as proposed by <span class="title"><span class="citation" data-cites="P3394R2"><a href="https://wg21.link/p3394r2" role="doc-biblioref">[P3394R2] (Annotations for
-Reflection)</a></span></span> provides just such a mechanism.</p>
+Annotations as proposed by <span class="title"><span class="citation" data-cites="P3394R2">[<a href="https://wg21.link/p3394r2" role="doc-biblioref">P3394R2</a>]</span></span> provides just such a
+mechanism.</p>
 <h2 data-number="3.14" id="converting-a-struct-to-a-tuple"><span class="header-section-number">3.14</span> Converting a Struct to a
 Tuple<a href="#converting-a-struct-to-a-tuple" class="self-link"></a></h2>
-<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R10"><a href="https://wg21.link/p1061r10" role="doc-biblioref">[P1061R10]</a></span>, but can also be written
-using <code class="sourceCode cpp">std<span class="op">::</span>make_index_sequence</code>:</p>
+<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R10">[<a href="https://wg21.link/p1061r10" role="doc-biblioref">P1061R10</a>]</span>, but can also be written using
+<code class="sourceCode cpp">std<span class="op">::</span>make_index_sequence</code>:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb31"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
@@ -2986,10 +2983,10 @@ metafunction can also be used to map a reflection of an object to a
 reflection of its value.</p>
 <h3 data-number="4.1.1" id="syntax-discussion"><span class="header-section-number">4.1.1</span> Syntax discussion<a href="#syntax-discussion" class="self-link"></a></h3>
 <p>The original TS landed on <code class="sourceCode cpp"><span class="cf">reflexpr</span><span class="op">(...)</span></code>
-as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that syntax as well.
-As more examples were discussed, it became clear that that syntax was
-both (a) too “heavy” and (b) insufficiently distinct from a function
-call. SG7 eventually agreed upon the prefix
+as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that syntax as well. As
+more examples were discussed, it became clear that that syntax was both
+(a) too “heavy” and (b) insufficiently distinct from a function call.
+SG7 eventually agreed upon the prefix
 <code class="sourceCode cpp"><span class="op">^</span></code> operator.
 The “upward arrow” interpretation of the caret matches the “lift” or
 “raise” verbs that are sometimes used to describe the reflection
@@ -3020,8 +3017,8 @@ lifting, <code class="sourceCode cpp">\</code> and
 syntax.</p>
 <p>In Wrocław 2024, SG7 and EWG voted to adopt
 <code class="sourceCode cpp"><span class="op">^^</span></code> as the
-new reflection operator (as proposed by <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span>). The R8 revision of this
-paper integrates that change.</p>
+new reflection operator (as proposed by <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span>). The R8 revision of this paper
+integrates that change.</p>
 <h2 data-number="4.2" id="splicers"><span class="header-section-number">4.2</span> Splicers
 (<code class="sourceCode cpp"><span class="op">[:</span></code>…<code class="sourceCode cpp"><span class="op">:]</span></code>)<a href="#splicers" class="self-link"></a></h2>
 <p>A reflection can be “spliced” into source code using one of several
@@ -3272,8 +3269,8 @@ extension in a future paper.</p>
 (described in more detail below). However, there are many cases where we
 don’t have a single reflection, we have a range of reflections - and we
 want to splice them all in one go. For that, the predecessor to this
-paper, <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span>, proposed an additional form
-of splicer: a range splicer.</p>
+paper, <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span>, proposed an additional form of
+splicer: a range splicer.</p>
 <p>Construct the <a href="#converting-a-struct-to-a-tuple">struct-to-tuple</a> example from
 above. It was demonstrated using a single splice, but it would be
 simpler if we had a range splice:</p>
@@ -3359,7 +3356,7 @@ Which is enough for a tolerable implementation:</p>
 <h3 data-number="4.2.4" id="syntax-discussion-1"><span class="header-section-number">4.2.4</span> Syntax discussion<a href="#syntax-discussion-1" class="self-link"></a></h3>
 <p>Early discussions of splice-like constructs (related to the TS
 design) considered using <code class="sourceCode cpp"><span class="cf">unreflexpr</span><span class="op">(...)</span></code>
-for that purpose. <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that option for
+for that purpose. <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that option for
 <em>expression</em> splicing, observing that a single splicing syntax
 could not viably be parsed (some disambiguation is needed to distinguish
 types and templates). SG-7 eventually agreed to adopt the <code class="sourceCode cpp"><span class="op">[:</span> <span class="op">...</span> <span class="op">:]</span></code>
@@ -3440,7 +3437,7 @@ document templates:</p>
 need syntax for in the future:</p>
 <ul>
 <li>code injection (of whatever form), and</li>
-<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1"><a href="https://wg21.link/p1887r1" role="doc-biblioref">[P1887R1]</a></span> suggested
+<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1">[<a href="https://wg21.link/p1887r1" role="doc-biblioref">P1887R1</a>]</span> suggested
 <code class="sourceCode cpp"><span class="op">+</span></code> as an
 annotation introducer, but
 <code class="sourceCode cpp"><span class="op">+</span></code> can begin
@@ -3707,9 +3704,8 @@ because these are <code class="sourceCode cpp">std<span class="op">::</span>meta
 must be a constant. Because it’s not here
 (<code class="sourceCode cpp">__first</code> and
 <code class="sourceCode cpp">__last</code> are just function
-parameters), that triggers the immediate-escalation machinery from <span class="title"><span class="citation" data-cites="P2564R3"><a href="https://wg21.link/p2564r3" role="doc-biblioref">[P2564R3]
-(consteval needs to propagate up)</a></span></span> (before that paper,
-it would have been ill-formed on the spot). But because
+parameters), that triggers the immediate-escalation machinery from <span class="title"><span class="citation" data-cites="P2564R3">[<a href="https://wg21.link/p2564r3" role="doc-biblioref">P2564R3</a>]</span></span> (before that paper, it
+would have been ill-formed on the spot). But because
 <code class="sourceCode cpp">__introsort</code> is not
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>,
 propagation fails at that point, and the program is ill-formed.</p>
@@ -3812,7 +3808,7 @@ example:</p>
 </div>
 <p>Hence this proposal also introduces constraints on constant
 evaluation as follows…</p>
-<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]</a></span>) have the property that their
+<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span>) have the property that their
 evaluation must occur and must succeed in a valid C++ program. We
 require that a programmer can count on those evaluations occurring
 exactly once and completing at translation time.</p>
@@ -3823,9 +3819,8 @@ source constructs lexically following them.</p>
 <p>Those constraints are mostly intuitive, but they are a significant
 change to the underlying principles of the current standard in this
 respect.</p>
-<p><span class="title"><span class="citation" data-cites="P2758R4"><a href="https://wg21.link/p2758r4" role="doc-biblioref">[P2758R4]
-(Emitting messages at compile time)</a></span></span> also has to deal
-with side effects during constant evaluation. However, those effects
+<p><span class="title"><span class="citation" data-cites="P2758R4">[<a href="https://wg21.link/p2758r4" role="doc-biblioref">P2758R4</a>]</span></span> also has to deal with
+side effects during constant evaluation. However, those effects
 (“output”) are of a slightly different nature in the sense that they can
 be buffered until a manifestly constant-evaluated expression/conversion
 has completed. “Buffering” a class type completion is not practical
@@ -3904,7 +3899,7 @@ constant expressions (we would of course still keep the requirement that
 the constraint is a
 <code class="sourceCode cpp"><span class="dt">bool</span></code>).</p></li>
 </ul>
-<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1"><a href="https://wg21.link/p3068r1" role="doc-biblioref">[P3068R1]</a></span> has proposed the introduction
+<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1">[<a href="https://wg21.link/p3068r1" role="doc-biblioref">P3068R1</a>]</span> has proposed the introduction
 of constexpr exceptions. The proposal addresses hurdles like compiler
 modes that disable exception support, and a Clang-based implementation
 is underway. We believe this to be the most desirable error-handling
@@ -4264,14 +4259,14 @@ translated to a different presentation (as in (2)).</p></li>
 to evaluate if the identifier cannot be represented in the ordinary
 literal encoding.</p>
 <h3 data-number="4.4.6" id="reflecting-names"><span class="header-section-number">4.4.6</span> Reflecting names<a href="#reflecting-names" class="self-link"></a></h3>
-<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>) included a metafunction
-called <code class="sourceCode cpp">name_of</code>, which we defined to
-return a <code class="sourceCode cpp">string_view</code> containing the
-“name” of the reflected entity. As the paper evolved, it became
-necessary to sharpen the specification of what this “name” contains.
-Subsequent revisions (beginning with P2996R2, presented in Tokyo)
-specified that <code class="sourceCode cpp">name_of</code> returns the
-unqualified name, whereas a new
+<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>) included a metafunction called
+<code class="sourceCode cpp">name_of</code>, which we defined to return
+a <code class="sourceCode cpp">string_view</code> containing the “name”
+of the reflected entity. As the paper evolved, it became necessary to
+sharpen the specification of what this “name” contains. Subsequent
+revisions (beginning with P2996R2, presented in Tokyo) specified that
+<code class="sourceCode cpp">name_of</code> returns the unqualified
+name, whereas a new
 <code class="sourceCode cpp">qualified_name_of</code> would give the
 fully qualified name.</p>
 <p>Most would agree that <code class="sourceCode cpp">qualified_name_of<span class="op">(^^</span><span class="dt">size_t</span><span class="op">)</span></code>
@@ -4659,9 +4654,9 @@ side-effect.</p>
 <code class="sourceCode cpp">define_aggregate</code> can be used, we are
 not aware of any motivating use cases for P2996 that are harmed. Worth
 mentioning, however: the rule has more dire implications for other code
-injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2"><a href="https://wg21.link/p3294r2" role="doc-biblioref">[P3294R2]</a></span> (“<em>Code Injection With
-Token Sequences</em>”). With this rule as it is, it becomes impossible
-for e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
+injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2">[<a href="https://wg21.link/p3294r2" role="doc-biblioref">P3294R2</a>]</span> (“<em>Code Injection With Token
+Sequences</em>”). With this rule as it is, it becomes impossible for
+e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
 to produce an injected declaration of <code class="sourceCode cpp">std<span class="op">::</span>formatter<span class="op">&lt;</span>TCls<span class="op">&lt;</span>Foo<span class="op">&gt;&gt;</span></code>
 (since the target scope would be the global namespace).</p>
 <p>In this context, we do believe that relaxations of the rule can be
@@ -4683,8 +4678,7 @@ implementations<a href="#freestanding-implementations" class="self-link"></a></h
 return a
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>
 value. Unfortunately, that means that they are currently not usable in a
-freestanding environment, but <span class="title"><span class="citation" data-cites="P3295R0"><a href="https://wg21.link/p3295r0" role="doc-biblioref">[P3295R0] (Freestanding constexpr containers and
-constexpr exception types)</a></span></span> currently proposes
+freestanding environment, but <span class="title"><span class="citation" data-cites="P3295R0">[<a href="https://wg21.link/p3295r0" role="doc-biblioref">P3295R0</a>]</span></span> currently proposes
 freestanding
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>,
 <code class="sourceCode cpp">std<span class="op">::</span>string</code>,
@@ -5569,7 +5563,7 @@ complete definition of <code class="sourceCode cpp">T</code>, and they
 both afterwards <code class="sourceCode cpp"><span class="pp">#include </span><span class="im">&quot;cls.h&quot;</span></code>,
 the result will be an ODR violation.</p>
 <p>Additional papers are already in flight proposing additional
-metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2"><a href="https://wg21.link/p3096r2" role="doc-biblioref">[P3096R2]</a></span> proposes the
+metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2">[<a href="https://wg21.link/p3096r2" role="doc-biblioref">P3096R2</a>]</span> proposes the
 <code class="sourceCode cpp">parameters_of</code> metafunction. This
 feature is important for generating language bindings (e.g., Python,
 JavaScript), but since parameter names can differ between declarations,
@@ -5633,7 +5627,7 @@ follows:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_6" id="pnum_6">7-8</a></span>
-Each preprocessing token is converted into a token (<span>5.10 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). Whitespace
+Each preprocessing token is converted into a token (<span>5.6 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). Whitespace
 characters separating tokens are no longer significant. The resulting
 tokens constitute a <em>translation unit</em> and are syntactically and
 semantically analyzed as a
@@ -5756,7 +5750,7 @@ image which contains information needed for execution in its execution
 environment.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.5
+<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.4
 <a href="https://wg21.link/lex.pptoken">[lex.pptoken]</a></span>
 Preprocessing tokens<a href="#lex.pptoken-preprocessing-tokens" class="self-link"></a></h3>
 <p>Add a bullet after bullet (4.2):</p>
@@ -5802,11 +5796,11 @@ note</em> ]</span></span></span></p></li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
+<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
 Operators and punctuators<a href="#lex.operators-operators-and-punctuators" class="self-link"></a></h3>
 <p>Change the grammar for
 <code class="sourceCode cpp"><em>operator-or-punctuator</em></code> in
-paragraph 1 of <span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
+paragraph 1 of <span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
 include the reflection operator and the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>
 delimiters:</p>
@@ -5984,7 +5978,7 @@ follows:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an
-<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.5
+<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.4
 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>)
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code>
@@ -6167,7 +6161,7 @@ In each such definition, corresponding
 General<a href="#basic.scope.scope-general" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 introduction of a “host scope” in paragraph 2 is part of the resolution
-to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Define the “host scope” of a declaration in paragraph 2:</p>
 <div class="std">
 <blockquote>
@@ -6598,8 +6592,8 @@ construct.</p>
 is associated with</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(x.20)</a></span>
-if <code class="sourceCode cpp">T</code> is a scalar type, then a
-computed value of type <code class="sourceCode cpp">T</code>, or</li>
+if <code class="sourceCode cpp">T</code> is a scalar type, then a value
+of type <code class="sourceCode cpp">T</code>, or</li>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(x.21)</a></span>
 if <code class="sourceCode cpp">T</code> is a class type, then a
 template parameter object ([temp.param]) of type
@@ -6802,7 +6796,7 @@ the grammar for
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
 <p>Modify paragraph 2 to avoid transforming non-static members into
@@ -6814,7 +6808,7 @@ implicit member accesses when named as operands to
 If an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><em>E</em></code> denotes a non-static
 non-type member of some class <code class="sourceCode cpp">C</code> at a
-point where the current class (<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
+point where the current class (<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
 <code class="sourceCode cpp">X</code> and</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(2.1)</a></span>
@@ -6879,7 +6873,7 @@ member and it appears in an unevaluated operand.</li>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.4.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
 Unqualified names<a href="#expr.prim.id.unqual-unqualified-names" class="self-link"></a></h3>
 <p>Modify paragraph 15 to allow
 <code class="sourceCode cpp"><em>splice-expression</em></code>s to be
@@ -6915,7 +6909,7 @@ the block scope of a
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -7110,7 +7104,7 @@ not declarative, the entity shall not be a template.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.6.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
+<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
 Closure types<a href="#expr.prim.lambda.closure-closure-types" class="self-link"></a></h3>
 <p>We have to say that a closure type is not complete until the
 <code class="sourceCode cpp"><span class="op">}</span></code>:</p>
@@ -7163,7 +7157,7 @@ conversion function template has the same invented template parameter
 list, […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.req.type-type-requirements"><span>7.5.8.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
+<h3 class="unnumbered" id="expr.prim.req.type-type-requirements"><span>7.5.7.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
 Type requirements<a href="#expr.prim.req.type-type-requirements" class="self-link"></a></h3>
 <p>Allow splices in type requirements:</p>
 <div class="std">
@@ -7205,7 +7199,7 @@ of its
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -7287,7 +7281,7 @@ expression has the same type as
 <code class="sourceCode cpp"><em>S</em></code>, and is a bit-field if
 and only if <code class="sourceCode cpp"><em>S</em></code> is a
 bit-field. <span class="note"><span>[ <em>Note 1:</em> </span>The
-implicit transformation (<span>7.5.5 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
+implicit transformation (<span>7.5.4 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
 an <code class="sourceCode cpp"><em>id-expression</em></code> denoting a
 non-static member becomes a class member access does not apply to a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.<span>
@@ -7310,9 +7304,9 @@ adjusted to a non-reference type (<span>7.2.2 <a href="https://wg21.link/expr.ty
 — <em>end note</em> ]</span></span></p></li>
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(2.5)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a value
-or an enumerator, the expression is a prvalue whose type is the same of
-<code class="sourceCode cpp"><em>S</em></code> and whose value is
-determined as follows:</p>
+or an enumerator, the expression is a prvalue whose type is the same as
+that of <code class="sourceCode cpp"><em>S</em></code> and whose value
+is determined as follows:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(2.5.1)</a></span>
 if <code class="sourceCode cpp"><em>S</em></code> is an enumerator, then
@@ -7376,14 +7370,15 @@ The expression is an lvalue referring to the same object associated with
 <li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(4.3)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
-<p><span class="note"><span>[ <em>Note 4:</em> </span>Access checking of
-class members occurs during lookup, and therefore does not pertain to
-splicing.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">5</a></span>
-While performing overload resolution to determine the entity referred to
-by a <code class="sourceCode cpp"><em>splice-expression</em></code>, the
-best viable function is <em>designated in a manner exempt from access
-rules</em>.</p>
+<p><span class="note"><span>[ <em>Note 4:</em> </span>Class members
+designated by
+<code class="sourceCode cpp"><em>splice-expression</em></code>s are
+accessible from any point ([class.access.base]). A class member access
+expression whose right operand is a
+<code class="sourceCode cpp"><em>splice-expression</em></code> is
+ill-formed if the left operand (considered as a pointer) cannot be
+implicitly converted to a pointer to the designating class of the right
+operand.<span> — <em>end note</em> ]</span></span></p>
 </div>
 </blockquote>
 </div>
@@ -7412,7 +7407,7 @@ access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -7438,7 +7433,7 @@ and is followed by a
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">2</a></span>
 For <span class="rm" style="color: #bf0303"><del>the first option (dot),
 if the</del></span> <span class="addu">a dot that is followed by
 an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
@@ -7462,7 +7457,7 @@ the remainder of [expr.ref] will address only <span class="rm" style="color: #bf
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">3</a></span>
 The postfix expression before the dot is evaluated;<sup>50</sup> the
 result of that evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -7474,7 +7469,7 @@ determines the result of the entire postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">4</a></span>
 Abbreviating
 <code class="sourceCode cpp"><em>postfix-expression</em></code>.<code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="addu">or <code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span><em>splice-expression</em></code></span>
@@ -7486,21 +7481,22 @@ as <code class="sourceCode cpp">E1<span class="op">.</span>E2</code>,
 <p>Adjust the language in paragraphs 6-9 to account for
 <code class="sourceCode cpp"><em>splice-expression</em></code>s.
 Explicitly add a fallback to paragraph 7 that makes other cases
-ill-formed.</p>
+ill-formed. Update the term “naming class” to “designated class” in
+paragraph 8.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">*</a></span>
 If <code class="sourceCode cpp">E2</code> is a
 <code class="sourceCode cpp"><em>splice-expression</em></code>, then
 <code class="sourceCode cpp">E2</code> shall designate a member of the
 type of <code class="sourceCode cpp">E1</code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">7</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="addu">designates
 an entity that</span> is declared to have type “reference to
 <code class="sourceCode cpp">T</code>”, then
@@ -7515,13 +7511,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(7.2)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
@@ -7540,15 +7536,15 @@ member, then the type of
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 “<em>cq12</em> <em>vq12</em>
 <code class="sourceCode cpp">T</code>”.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(7.3)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> is an overload set, […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(7.4)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(7.5)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
@@ -7556,18 +7552,19 @@ ill-formed.</p></li>
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(7.6)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(7.6)</a></span>
 Otherwise, the program is ill-formed.</span></p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">8</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static member, the program is
 ill-formed if the class of which <code class="sourceCode cpp">E2</code>
 <span class="rm" style="color: #bf0303"><del>is directly</del></span>
-<span class="addu">designates</span> a member is an ambiguous base
-(<span>6.5.2 <a href="https://wg21.link/class.member.lookup">[class.member.lookup]</a></span>)
-of the naming class (<span>11.8.3 <a href="https://wg21.link/class.access.base">[class.access.base]</a></span>)
+<span class="addu">designates</span> a <span class="addu">direct</span>
+member is an ambiguous base (<span>6.5.2 <a href="https://wg21.link/class.member.lookup">[class.member.lookup]</a></span>)
+of the <span class="rm" style="color: #bf0303"><del>naming</del></span>
+<span class="addu">designating</span> class (<span>11.8.3 <a href="https://wg21.link/class.access.base">[class.access.base]</a></span>)
 of <code class="sourceCode cpp">E2</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -7583,7 +7580,7 @@ to the grammar for
 paragraph 1:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -7600,13 +7597,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -7616,7 +7613,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -7627,7 +7624,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -7653,7 +7650,7 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a><em>qualified-reflection-name</em>:</span>
 <span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>   <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
 <span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>   <em>nested-name-specifier</em> template <em>identifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -7663,14 +7660,14 @@ places no restriction on representing, by reflections, constructs not
 described by this document or using such constructs as operands of
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 are those of its
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> (if
 any) and its
 <code class="sourceCode cpp"><em>identifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">3</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 parsed as the longest possible sequence of tokens that could
 syntactically form a
@@ -7698,17 +7695,17 @@ followed by
 <span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">4</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <span class="op">::</span></code>
 represents the global namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">5</a></span>
 If a <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> matches the form <code class="sourceCode cpp"><span class="op">^^</span> <em>qualified-reflection-name</em></code>,
 it is interpreted as such and its representation is determined as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(5.1)</a></span>
 If the <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>namespace-name</em></code> that names a
 namespace alias ([namespace.alias]),
@@ -7717,36 +7714,36 @@ alias. For any other
 <code class="sourceCode cpp"><em>namespace-name</em></code>,
 <code class="sourceCode cpp"><em>R</em></code> represents the denoted
 namespace.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(5.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>concept-name</em></code>
 ([temp.concept]), <code class="sourceCode cpp"><em>R</em></code>
 represents the denoted concept.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(5.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>template-name</em></code>
 ([temp.names]), the representation of
 <code class="sourceCode cpp"><em>R</em></code> is determined as follows:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(5.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(5.3.1)</a></span>
 If the <code class="sourceCode cpp"><em>template-name</em></code> names
 an injected-class-name ([class.pre]), then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(5.3.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(5.3.1.1)</a></span>
 If the
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 is of the form <code class="sourceCode cpp"><em>nested-name-specifier</em> <span class="kw">template</span> <em>identifier</em></code>,
 then <code class="sourceCode cpp"><em>R</em></code> represents the class
 template named by the injected-class-name.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(5.3.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(5.3.1.2)</a></span>
 Otherwise, the injected-class-name shall be unambiguous when considered
 as a <code class="sourceCode cpp"><em>type-name</em></code> and
 <code class="sourceCode cpp"><em>R</em></code> represents the class
 template specialization so named.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(5.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(5.3.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>template-name</em></code> names a
 function template <code class="sourceCode cpp"><em>F</em></code>, then
@@ -7757,14 +7754,14 @@ an overload set containing only
 <code class="sourceCode cpp"><em>F</em></code>.
 <code class="sourceCode cpp"><em>R</em></code> represents
 <code class="sourceCode cpp"><em>F</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(5.3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(5.3.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>template-name</em></code> denotes a
 primary class template, primary variable template, or alias template,
 <code class="sourceCode cpp"><em>R</em></code> represents that
 template.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(5.4)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> names a type
 alias that was introduced by the declaration of a template parameter,
@@ -7773,14 +7770,14 @@ entity of that type alias. For any other
 <code class="sourceCode cpp"><em>identifier</em></code> that names a
 type alias, <code class="sourceCode cpp"><em>R</em></code> represents
 that type alias.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(5.5)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>class-name</em></code> or an
 <code class="sourceCode cpp"><em>enum-name</em></code>,
 <code class="sourceCode cpp"><em>R</em></code> represents the denoted
 type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(5.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(5.6)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 shall be an <code class="sourceCode cpp"><em>id-expression</em></code>
@@ -7789,22 +7786,22 @@ shall be an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><span class="op">^^</span> <em>I</em></code>
 (see below).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">6</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> of the form
 <code class="sourceCode cpp"><span class="op">^^</span> <em>type-id</em></code>
 represents an entity determined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(6.1)</a></span>
 If the <code class="sourceCode cpp"><em>type-id</em></code> designates a
 placeholder type, <code class="sourceCode cpp"><em>R</em></code> is
 ill-formed.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(6.2)</a></span>
 Otherwise, if the <code class="sourceCode cpp"><em>type-id</em></code>
 names a type alias that is a specialization of an alias template,
 <code class="sourceCode cpp"><em>R</em></code> represents that type
 alias.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> represents the
 type denoted by the
 <code class="sourceCode cpp"><em>type-id</em></code>.</li>
@@ -7815,12 +7812,12 @@ other cases for
 by
 <code class="sourceCode default"><em>qualified-reflection-name</em></code>.
 ]</span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">7</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> of the form <code class="sourceCode cpp"><span class="op">^^</span> <em>id-expression</em></code>
 represents an entity determined as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(7.1)</a></span>
 If the <code class="sourceCode cpp"><em>id-expression</em></code>
 denotes an overload set <code class="sourceCode cpp"><em>S</em></code>,
 overload resolution for the expression
@@ -7828,21 +7825,21 @@ overload resolution for the expression
 with no target shall select a unique function ([over.over]);
 <code class="sourceCode cpp"><em>R</em></code> represents that
 function.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(7.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 variable declared by an
 <code class="sourceCode cpp"><em>init-capture</em></code>
 ([expr.prim.lambda.capture]),
 <code class="sourceCode cpp"><em>R</em></code> is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(7.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 local parameter introduced by a
 <code class="sourceCode cpp"><em>requires-expression</em></code>
 ([expr.prim.req]), <code class="sourceCode cpp"><em>R</em></code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(7.4)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 local entity <code class="sourceCode cpp"><em>E</em></code>
@@ -7850,7 +7847,7 @@ local entity <code class="sourceCode cpp"><em>E</em></code>
 <code class="sourceCode cpp"><em>R</em></code> and the point at which
 <code class="sourceCode cpp"><em>E</em></code> was introduced,
 <code class="sourceCode cpp"><em>R</em></code> is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(7.5)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 function-local predefined variable ([dcl.fct.def.general]),
@@ -7858,13 +7855,13 @@ function-local predefined variable ([dcl.fct.def.general]),
 other <code class="sourceCode cpp"><em>id-expression</em></code> that
 denotes a variable, <code class="sourceCode cpp"><em>R</em></code>
 represents that variable.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(7.6)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(7.6)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 structured binding, enumerator, or non-static data member,
 <code class="sourceCode cpp"><em>R</em></code> represents that
 entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(7.7)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(7.7)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> is ill-formed.
 <span class="note"><span>[ <em>Note 2:</em> </span>This includes
 <code class="sourceCode cpp"><em>pack-index-expression</em></code>s and
@@ -7907,33 +7904,33 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <p>Add a new paragraph between paragraphs 5 and 6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">5</a></span>
 Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">5+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">5+</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(5+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(5+.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(5+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(5+.2)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a value that is
 template-argument-equivalent (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(5+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(5+.3)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(5+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(5+.4)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(5+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(5+.5)</a></span>
 Otherwise, if one operand represents a direct base class relationship,
 then they compare equal if and only if the other operand represents the
 same direct base class relationship.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(5+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(5+.6)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -7944,7 +7941,7 @@ data member descriptions represented by
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -7966,7 +7963,7 @@ production of injected declarations from any core constant expression
 that isn’t a consteval block.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">10</a></span>
 An expression <code class="sourceCode cpp"><em>E</em></code> is a
 <em>core constant expression</em> unless the evaluation of
 <code class="sourceCode cpp"><em>E</em></code>, following the rules of
@@ -7974,7 +7971,7 @@ the abstract machine ([intro.execution]), would evaluate one of the
 following:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(10.27)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(10.27)</a></span>
 a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>
 ([expr.dynamic.cast]) expression,
@@ -7983,16 +7980,16 @@ a
 <code class="sourceCode cpp"><em>new-expression</em></code> ([expr.new])
 that would throw an exception where no definition of the exception type
 is reachable;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(10.27+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(10.27+)</a></span>
 an expression that would produce an injected declaration (see below),
 unless <code class="sourceCode cpp"><em>E</em></code> is the
 corresponding expression of a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
 ([dcl.pre]);</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(10.28)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(10.28)</a></span>
 an <code class="sourceCode cpp"><em>asm-declaration</em></code>
 ([dcl.asm]);</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(10.29)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(10.29)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -8001,7 +7998,7 @@ an <code class="sourceCode cpp"><em>asm-declaration</em></code>
 <code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">17</a></span>
 During the evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> as a core constant
 expression, all
@@ -8019,15 +8016,15 @@ includes the entire constant evaluation. […]</p>
 and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">22</a></span>
 A <em>constant expression</em> is either a glvalue core constant
 expression <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> that
 <span class="addu"> </span></p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(22.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(22.1)</a></span>
 refers to an object or a non-immediate function<span class="addu">,
 and</span></p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(22.2)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(22.2)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> designates a function
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>)
 or an object whose complete object is of consteval-only type, then
@@ -8052,22 +8049,22 @@ type,</span></p>
 <p>or a prvalue core constant expression whose result object
 ([basic.lval]) satisfies the following constraints:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(22.3)</a></span>
 each constituent reference refers to an object or a non-immediate
 function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(22.4)</a></span>
 no constituent value of scalar type is an indeterminate value or
-erroneous value (<span>6.7.5 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(22.5)</a></span>
+erroneous value (<span>6.7.4 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(22.5)</a></span>
 no constituent value of pointer type is a pointer to an immediate
 function or an invalid pointer value ([basic.compound]), <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(22.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(22.6)</a></span>
 no constituent value of pointer-to-member type designates an immediate
 function<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(22.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(22.7)</a></span>
 unless the value is of consteval-only type, no constituent value of
 pointer or pointer-to-member type is
 <ul>
@@ -8086,13 +8083,13 @@ expression</em> in paragraph 25 to also apply to expressions of
 consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">25</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it is <span class="rm" style="color: #bf0303"><del>either</del></span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(25.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(25.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -8100,10 +8097,10 @@ potentially-evaluated</del></span> <span class="addu">an</span>
 that <span class="rm" style="color: #bf0303"><del>denotes</del></span>
 <span class="addu">designates</span> an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that
 is not a subexpression of an immediate invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(25.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(25.2)</a></span>
 an immediate invocation that is not a constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(25.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(25.3)</a></span>
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>).</span></li>
 </ul>
 </blockquote>
@@ -8113,21 +8110,21 @@ to include functions containing a declaration of a variable of
 consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">27</a></span>
 An <em>immediate function</em> is a function or constructor that is
 <span class="addu">either</span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(27.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(27.1)</a></span>
 declared with the
 <code class="sourceCode cpp"><span class="kw">consteval</span></code>
 specifier, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(27.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(27.2)</a></span>
 an immediate-escalating function <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>F</em></code></span></del></span>
 whose function <span class="rm" style="color: #bf0303"><del>body
 contains</del></span> <span class="addu">parameter scope is the
 innermost non-block scope enclosing either</span>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(27.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(27.2.1)</a></span>
 an immediate-escalating expression <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>E</em></code></span>
 such that
 <span><code class="sourceCode default"><em>E</em></code></span>’s
@@ -8135,7 +8132,7 @@ innermost enclosing non-block scope is
 <span><code class="sourceCode default"><em>F</em></code></span>’s
 function parameter scope.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(27.2.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(27.2.2)</a></span>
 a definition of a non-constexpr variable with consteval-only
 type.</span></li>
 </ul></li>
@@ -8148,7 +8145,7 @@ injecting declarations and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">28</a></span>
 The evaluation of an expression can introduce one or more <em>injected
 declarations</em>. Each such declaration has an associated
 <em>synthesized point</em> which follows the last non-synthesized
@@ -8157,7 +8154,7 @@ evaluation is said to <em>produce</em> the declaration.</p>
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to synthesized points (<span>10.7 <a href="https://wg21.link/module.reach">[module.reach]</a></span>).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">29</a></span>
 Let <code class="sourceCode cpp"><em>C</em></code> be a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>,
 the evaluation of whose corresponding expression produces an injected
@@ -8170,9 +8167,9 @@ encloses exactly one of <code class="sourceCode cpp"><em>C</em></code>
 or <code class="sourceCode cpp"><em>D</em></code> where
 <code class="sourceCode cpp"><em>S</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(29.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(29.1)</a></span>
 a function parameter scope, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(29.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(29.2)</a></span>
 a class scope.</li>
 </ul>
 <div class="example">
@@ -8231,7 +8228,7 @@ a class scope.</li>
 <span id="cb134-52"><a href="#cb134-52" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">30</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines the behavior of certain functions used for reflection
 ([meta.reflection]). During the evaluation of an expression
@@ -8240,11 +8237,11 @@ expression, the evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(30.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(30.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>C</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(30.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(30.2)</a></span>
 the synthesized points corresponding to any injected declarations
 produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> (<span>6.9.1 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>).</li>
@@ -8293,7 +8290,7 @@ with its associated type from paragraph 8 (type aliases are entities
 now).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">8</a></span>
 If the <code class="sourceCode cpp"><em>decl-specifier-seq</em></code>
 contains the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -8307,12 +8304,12 @@ type</del></span> (<span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.type
 blocks:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">14</a></span>
 <em>Recommended practice</em>: When a
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 fails, […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">*</a></span>
 For a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
 <code class="sourceCode cpp"><em>D</em></code>, the expression
@@ -8342,7 +8339,7 @@ can produce injected declarations as side effects ([expr.const]).<span>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">15</a></span>
 An <code class="sourceCode cpp"><em>empty-declaration</em></code> has no
 effect.</p>
 </blockquote>
@@ -8355,7 +8352,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 specifier now introduces an entity.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">1</a></span>
 Declarations containing the
 <code class="sourceCode cpp"><em>decl-specifier</em></code>
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -8376,7 +8373,7 @@ and it shall not be used in the
 nor in the
 <code class="sourceCode cpp"><em>decl-specifier-seq</em></code> of a
 <code class="sourceCode cpp"><em>function-definition</em></code>
-(<span>9.6 <a href="https://wg21.link/dcl.fct.def">[dcl.fct.def]</a></span>). If a
+(<span>9.5 <a href="https://wg21.link/dcl.fct.def">[dcl.fct.def]</a></span>). If a
 <code class="sourceCode cpp"><em>typedef-specifier</em></code> appears
 in a declaration without a
 <code class="sourceCode cpp"><em>declarator</em></code>, the program is
@@ -8397,8 +8394,8 @@ alias is</span> the type associated with the
 a <code class="sourceCode cpp"><em>typedef-name</em></code> <span class="rm" style="color: #bf0303"><del>is</del></span> thus <span class="rm" style="color: #bf0303"><del>a synonym for</del></span> <span class="addu">denotes</span> another type. A
 <code class="sourceCode cpp"><em>typedef-name</em></code> does not
 introduce a new type the way a class declaration (<span>11.3 <a href="https://wg21.link/class.name">[class.name]</a></span>) or enum
-declaration (<span>9.8.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">2</a></span>
+declaration (<span>9.7.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">2</a></span>
 A <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span> can also be <span class="rm" style="color: #bf0303"><del>introduced</del></span> <span class="addu">declared</span> by an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>. The
@@ -8436,7 +8433,7 @@ to accommodate
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -8444,10 +8441,10 @@ is a placeholder for a type to be deduced ([dcl.spec.auto]). A
 is a placeholder for a deduced class type ([dcl.type.class.deduct])
 <span class="addu">if it either </span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(3.1)</a></span>
 is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(3.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(3.2)</a></span>
 is of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>
 and the <code class="sourceCode cpp"><em>splice-specifier</em></code>
@@ -8548,13 +8545,13 @@ Decltype specifiers<a href="#dcl.type.decltype-decltype-specifiers" class="self-
 extend the example that follows the paragraph:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">1</a></span>
 For an expression <code class="sourceCode cpp"><em>E</em></code>, the
 type denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
 is defined as follows:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">(1.3)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>id-expression</em></code> or an
@@ -8562,7 +8559,7 @@ unparenthesized class member access ([expr.ref]), <code class="sourceCode cpp"><
 is the type of the entity named by
 <code class="sourceCode cpp"><em>E</em></code>. If there is no such
 entity, the program is ill-formed;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">(1.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">(1.3+)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>splice-expression</em></code>, <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
@@ -8603,7 +8600,7 @@ Placeholder type specifiers<a href="#dcl.spec.auto.general-placeholder-type-spec
 to account for splicing:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">13</a></span>
 If a variable or function with an undeduced placeholder type is <span class="addu">either</span> named by an expression ([basic.def.odr])
 <span class="addu">or designated by a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> in an
@@ -8647,7 +8644,7 @@ statements.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
 <span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specifier</em></span>
 <span id="cb144-3"><a href="#cb144-3" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -8676,7 +8673,7 @@ within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.gen
 <span id="cb145-11"><a href="#cb145-11" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> alias <span class="op">=</span> <span class="op">[:^^</span>S<span class="op">::</span>type<span class="op">:]</span>;    <span class="co">// OK, type-only context</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>,
@@ -8685,7 +8682,7 @@ designate a type, a primary class template, or an alias template. The
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -8702,11 +8699,11 @@ any) of the
 </div>
 <h3 class="unnumbered" id="dcl.array-arrays"><span>9.3.4.5 <a href="https://wg21.link/dcl.array">[dcl.array]</a></span> Arrays<a href="#dcl.array-arrays" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: This
-change is part of the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+change is part of the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Use “host scope” in lieu of “inhabits” in paragraph 8:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">8</a></span>
 Furthermore, if there is a reachable declaration of the entity that
 <span class="rm" style="color: #bf0303"><del>inhabits</del></span> <span class="addu">has</span> the same <span class="addu">host</span> scope in
 which the bound was specified, an omitted array bound is taken to be the
@@ -8720,7 +8717,7 @@ clear about the entity being referred to, and add a bullet to allow for
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
@@ -8729,19 +8726,19 @@ type <span class="rm" style="color: #bf0303"><del>named</del></span>
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -8750,7 +8747,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -8779,11 +8776,11 @@ of an abominable function type:</p>
 Default arguments<a href="#dcl.fct.default-default-arguments" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes related to “host scopes” in paragraphs 4 and 9 are part of the
-resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Use “host scope” in lieu of “inhabits” in paragraph 4:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">4</a></span>
 For non-template functions, default arguments can be added in later
 declarations of a function that <span class="rm" style="color: #bf0303"><del>inhabit</del></span> <span class="addu">have</span> the same <span class="addu">host</span> scope.
 Declarations that <span class="rm" style="color: #bf0303"><del>inhabit</del></span> <span class="addu">have</span> different <span class="addu">host</span> scopes
@@ -8795,7 +8792,7 @@ appear in default function arguments, extend example 8 which follows,
 and use “host scope” rather than “inhabits” following example 9.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">9</a></span>
 A default argument is evaluated each time the function is called with no
 argument for the corresponding parameter.</p>
 <p>[…]</p>
@@ -8838,54 +8835,54 @@ example</em> ]</span></p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.5.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 Initializers (General)<a href="#dcl.init.general-initializers-general" class="self-link"></a></h3>
-<p>Change paragraphs 6-8 of <span>9.5.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<p>Change paragraphs 6-8 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 <span class="ednote" style="color: #0000ff">[ Editor&#39;s note: No changes
 are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>),
 the object is initialized to the value obtained by converting the
 integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -8893,11 +8890,11 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible class type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.fct.def.general-function-definitions"><span>9.6.1 <a href="https://wg21.link/dcl.fct.def.general">[dcl.fct.def.general]</a></span>
+<h3 class="unnumbered" id="dcl.fct.def.general-function-definitions"><span>9.5.1 <a href="https://wg21.link/dcl.fct.def.general">[dcl.fct.def.general]</a></span>
 Function definitions<a href="#dcl.fct.def.general-function-definitions" class="self-link"></a></h3>
 <p>Disallow using
 <code class="sourceCode cpp"><span class="ot">__func__</span></code> in
@@ -8905,32 +8902,32 @@ a <code class="sourceCode cpp"><span class="kw">consteval</span></code>
 block:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">7</a></span>
 A <em>function-local predefined variable</em> is a variable with static
 storage duration that is implicitly defined in a function parameter
 scope<span class="addu">, other than the function parameter scope of the
 expression corresponding to a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">8</a></span>
 The function-local predefined variable
 <code class="sourceCode cpp"><span class="ot">__func__</span></code> is
 defined as if a definition of the form […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.fct.def.delete-deleted-definitions"><span>9.6.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
+<h3 class="unnumbered" id="dcl.fct.def.delete-deleted-definitions"><span>9.5.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
 Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self-link"></a></h3>
-<p>Change paragraph 2 of <span>9.6.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
+<p>Change paragraph 2 of <span>9.5.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 a <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect])</span>, is ill-formed.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.8.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
+<h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.7.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
 declaration<a href="#enum.udecl-the-using-enum-declaration" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> as
@@ -8952,7 +8949,7 @@ follows:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">1</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> of
 the form
@@ -8971,7 +8968,7 @@ shall designate a non-dependent type with a reachable
 <code class="sourceCode cpp"><em>enum-specifier</em></code>.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="namespace.alias-namespace-alias"><span>9.9.3
+<h3 class="unnumbered" id="namespace.alias-namespace-alias"><span>9.8.3
 <a href="https://wg21.link/namespace.alias">[namespace.alias]</a></span>
 Namespace alias<a href="#namespace.alias-namespace-alias" class="self-link"></a></h3>
 <p>Modify the grammar for
@@ -8980,7 +8977,7 @@ in paragraph 1, and clarify that such declarations declare a “namespace
 alias” (which is now an entity as per [basic.pre]).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">1</a></span>
 A
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 declares <span class="rm" style="color: #bf0303"><del>an alternative
@@ -9008,7 +9005,7 @@ this will fall out from the “underlying entity” of the namespace alias
 defined below:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -9022,7 +9019,7 @@ note:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">2+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">2+</a></span>
 The underlying entity (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>) of the
 namespace alias is the namespace either denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
@@ -9031,7 +9028,7 @@ or designated by the
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.9.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
+<h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
 Using namespace directive<a href="#namespace.udir-using-namespace-directive" class="self-link"></a></h3>
 <p>Add <code class="sourceCode cpp"><em>splice-specifier</em></code> to
 the grammar for
@@ -9045,12 +9042,12 @@ the grammar for
 </div>
 </blockquote>
 </div>
-<p>Add the following prior to the first paragraph of <span>9.9.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>, and
+<p>Add the following prior to the first paragraph of <span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>, and
 renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> (if
 any) shall designate a namespace other than the global namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
@@ -9058,7 +9055,7 @@ any) shall designate a namespace other than the global namespace. The
 <code class="sourceCode cpp"><em>splice-specifier</em></code> shall not
 be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -9089,7 +9086,7 @@ namespaces <span class="rm" style="color: #bf0303"><del>nominated</del></span> <
 eligible to be considered.<span> — <em>end note</em> ]</span></span></p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.13.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
+<h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
 Attribute syntax and semantics<a href="#dcl.attr.grammar-attribute-syntax-and-semantics" class="self-link"></a></h3>
 <p>Add a production to the grammar for
 <code class="sourceCode cpp"><em>attribute-specifier</em></code> as
@@ -9118,11 +9115,11 @@ follows:</p>
 </div>
 </blockquote>
 </div>
-<p>Change a sentence in paragraph 4 of <span>9.13.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
+<p>Change a sentence in paragraph 4 of <span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -9139,28 +9136,28 @@ the two-token sequence
 — <em>end note</em> ]</span></span></span> …</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.deprecated-deprecated-attribute"><span>9.13.4 <a href="https://wg21.link/dcl.attr.deprecated">[dcl.attr.deprecated]</a></span>
+<h3 class="unnumbered" id="dcl.attr.deprecated-deprecated-attribute"><span>9.12.5 <a href="https://wg21.link/dcl.attr.deprecated">[dcl.attr.deprecated]</a></span>
 Deprecated attribute<a href="#dcl.attr.deprecated-deprecated-attribute" class="self-link"></a></h3>
 <p>Prefer “type alias” to
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” in paragraph
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">2</a></span>
 The attribute may be applied to the declaration of a class, a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, a variable, a non-static data
 member, a function, a namespace, an enumeration, an enumerator, a
 concept, or a template specialization.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.unused-maybe-unused-attribute"><span>9.13.8 <a href="https://wg21.link/dcl.attr.unused">[dcl.attr.unused]</a></span>
+<h3 class="unnumbered" id="dcl.attr.unused-maybe-unused-attribute"><span>9.12.9 <a href="https://wg21.link/dcl.attr.unused">[dcl.attr.unused]</a></span>
 Maybe unused attribute<a href="#dcl.attr.unused-maybe-unused-attribute" class="self-link"></a></h3>
 <p>Prefer “type alias” to
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” in paragraph
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">2</a></span>
 The attribute may be applied to the declaration of a class, <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, variable (including a structured
 binding declaration), structured binding, non-static data member,
@@ -9177,11 +9174,11 @@ additional bullet further clarifying that it is unspecified whether any
 splice specifier is replaced.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">3</a></span>
 […]</p>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -9190,22 +9187,22 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>template-name</em></code> names an
 alias template is replaced by its denoted type prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(3.8)</a></span>
 whether a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 that does not <span class="rm" style="color: #bf0303"><del>denote</del></span> <span class="addu">designate</span> a dependent type is replaced by its <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> type prior to this determination, <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(3.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(3.9)</a></span>
 whether a non-value-dependent constant expression is replaced by the
 result of constant evaluation prior to this determination<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(3.10)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(3.10)</a></span>
 whether a <code class="sourceCode cpp"><em>splice-specifier</em></code>
 or <code class="sourceCode cpp"><em>splice-expression</em></code> that
 is not dependent is replaced by the construct that it designates prior
@@ -9219,23 +9216,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 a synthesized point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 synthesized point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 (<span>10.4 <a href="https://wg21.link/module.global.frag">[module.global.frag]</a></span>),
 appears in a translation unit that is reachable from
@@ -9291,25 +9288,25 @@ follows:</p>
 <p>Update paragraph 4 accordingly:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">4</a></span>
 A <code class="sourceCode cpp"><em>member-declaration</em></code> does
 not declare new members of the class if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">(4.1)</a></span>
 a friend declaration ([class.friend]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">(4.2)</a></span>
 a <code class="sourceCode cpp"><em>deduction-guide</em></code>
 ([temp.deduct.guide]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(4.3)</a></span>
 a <code class="sourceCode cpp"><em>template-declaration</em></code>
 whose declaration is one of the above,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.4)</a></span>
 a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>static_assert-declaration</em></code></span>,</del></span>
 <span class="addu"><code class="sourceCode cpp"><em>vacuous-declaration</em></code></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.5)</a></span>
 a <code class="sourceCode cpp"><em>using-declaration</em></code>
 ([namespace.udecl]) , or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(4.6)</a></span>
 an <code class="sourceCode cpp"><em>empty-declaration</em></code>.</li>
 </ul>
 </blockquote>
@@ -9319,7 +9316,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">6</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <code class="sourceCode cpp"><em>member-declaration</em></code>, in
@@ -9348,7 +9345,7 @@ member description</em>:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">30+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">30+</a></span>
 A <em>data member description</em> is a quintuple
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -9357,19 +9354,19 @@ A <em>data member description</em> is a quintuple
 <code class="sourceCode cpp"><em>NUA</em></code>) describing the
 potential declaration of a nonstatic data member where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(30+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">(30+.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a type or type
 alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(30+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(30+.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is an
 <code class="sourceCode cpp"><em>identifier</em></code> or ⊥,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(30+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(30+.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is an alignment or
 ⊥,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(30+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(30+.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is a bit-field width or
 ⊥, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(30+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(30+.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is a boolean
 value.</li>
 </ul>
@@ -9379,30 +9376,30 @@ components are same types, same identifiers, and equal values.</p>
 <p><span>[ <em>Note 4:</em> </span>The components of a data member
 description describe a data member such that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(30+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(30+.6)</a></span>
 its type is specified using the type or type alias given by
 <code class="sourceCode cpp"><em>T</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(30+.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(30+.7)</a></span>
 it is declared with the name given by
 <code class="sourceCode cpp"><em>N</em></code> if
 <code class="sourceCode cpp"><em>N</em></code> does not equal ⊥ and is
 otherwise unnamed,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(30+.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(30+.8)</a></span>
 it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>
-(<span>9.13.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
+(<span>9.12.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
 <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><em>A</em><span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>A</em></code> does not equal ⊥ and
 is otherwise declared without an
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(30+.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(30+.9)</a></span>
 it is a bit-field (<span>11.4.10 <a href="https://wg21.link/class.bit">[class.bit]</a></span>) with the
 width given by <code class="sourceCode cpp"><em>W</em></code> if
 <code class="sourceCode cpp"><em>W</em></code> does not equal ⊥ and is
 otherwise not a bit-field,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(30+.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(30+.10)</a></span>
 it is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
-(<span>9.13.11 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
+(<span>9.12.12 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
 if <code class="sourceCode cpp"><em>NUA</em></code> is
 <code class="sourceCode cpp"><span class="kw">true</span></code> and is
 otherwise declared without that attribute.</li>
@@ -9426,7 +9423,7 @@ with <code class="sourceCode cpp"><em>vacuous-declaration</em></code> in
 paragraph 1.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">1</a></span>
 […] Each <code class="sourceCode cpp"><em>member-declaration</em></code>
 in the <code class="sourceCode cpp"><em>member-specification</em></code>
 of an anonymous union shall either define one or more public non-static
@@ -9442,7 +9439,7 @@ General<a href="#class.derived.general-general" class="self-link"></a></h3>
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>class-or-decltype</em></code> are those
 of its
@@ -9484,12 +9481,109 @@ the
 — <em>end note</em> ]</span></span></p>
 </blockquote>
 </div>
+<h3 class="unnumbered" id="class.access.base-accessibility-of-base-classes-and-base-class-members"><span>11.8.3
+<a href="https://wg21.link/class.access.base">[class.access.base]</a></span>
+Accessibility of base classes and base class members<a href="#class.access.base-accessibility-of-base-classes-and-base-class-members" class="self-link"></a></h3>
+<p>Update paragraph 5 to handle
+<code class="sourceCode cpp"><em>splice-expression</em></code>s, and to
+make more clear that the “naming class” (renamed “designating class”
+here) is a property of the expression. State explicitly that members
+designated through
+<code class="sourceCode cpp"><em>splice-expression</em></code>s are
+accessible.</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">5</a></span>
+[…]</p>
+<p><span class="rm" style="color: #bf0303"><del>The access to a member
+is affected by the class in which the member is named. This naming class
+is the</del></span> <span class="addu">An expression
+<code class="sourceCode cpp">E</code> that designates a member
+<code class="sourceCode cpp">m</code> has a <em>designating class</em>
+that affects the access to <code class="sourceCode cpp">m</code>. This
+designating class is either</span></p>
+<ul>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(5.1)</a></span>
+the innermost class of which <code class="sourceCode cpp">m</code> is
+directly a member if <code class="sourceCode cpp">E</code> is a
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(5.2)</a></span>
+<span class="addu">the</span> class in whose scope lookup performed a
+search that found <span class="addu"><code class="sourceCode cpp">m</code></span> <span class="rm" style="color: #bf0303"><del>the member</del></span> <span class="addu">otherwise</span>.</li>
+</ul>
+<p><span class="note3"><span>[ <em>Note 3:</em> </span>This class can be
+explicit, e.g., when a
+<code class="sourceCode cpp"><em>qualified-id</em></code> is used, or
+implicit, e.g., when a class member access operator ([expr.ref]) is used
+(including cases where an implicit “<code class="sourceCode cpp"><span class="kw">this</span><span class="op">-&gt;</span></code>”
+was added). If both a class member access operator and a
+<code class="sourceCode cpp"><em>qualified-id</em></code> are used to
+<span class="rm" style="color: #bf0303"><del>name</del></span> <span class="addu">designate</span> the member (as in <code class="sourceCode cpp">p<span class="op">-&gt;</span>T<span class="op">::</span>m</code>),
+the class <span class="rm" style="color: #bf0303"><del>naming</del></span> <span class="addu">designating</span> the member is the class denoted by the
+<code class="sourceCode cpp"><em>nested-name-specifier</em></code> of
+the <code class="sourceCode cpp"><em>qualified-id</em></code> (that is,
+<code class="sourceCode cpp">T</code>).<span> — <em>end
+note</em> ]</span></span></p>
+<p>A member <code class="sourceCode cpp">m</code> is accessible at the
+point <code class="sourceCode cpp"><em>R</em></code> when <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> in class
+<code class="sourceCode cpp">N</code> if</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(5.3)</a></span>
+<code class="sourceCode cpp">m</code> as a member of
+<code class="sourceCode cpp">N</code> is public, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(5.4)</a></span>
+<code class="sourceCode cpp">m</code> as a member of
+<code class="sourceCode cpp">N</code> is private, and
+<code class="sourceCode cpp"><em>R</em></code> occurs in a direct member
+or friend of class <code class="sourceCode cpp"><em>N</em></code>,
+or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(5.5)</a></span>
+<code class="sourceCode cpp">m</code> as a member of
+<code class="sourceCode cpp">N</code> is protected, and
+<code class="sourceCode cpp"><em>R</em></code> occurs in a direct member
+or friend of class <code class="sourceCode cpp"><em>N</em></code>, or in
+a member of a class <code class="sourceCode cpp">P</code> derived from
+<code class="sourceCode cpp">N</code>, where
+<code class="sourceCode cpp">m</code> as a member of
+<code class="sourceCode cpp">P</code> is public, private, or protected,
+or</li>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(5.6)</a></span>
+<code class="sourceCode cpp">m</code> is designated by a
+<code class="sourceCode cpp"><em>splice-expression</em></code>,
+or</span></li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(5.7)</a></span>
+there exists a base class <code class="sourceCode cpp">B</code> of
+<code class="sourceCode cpp">N</code> that is accessible at
+<code class="sourceCode cpp"><em>R</em></code>, and
+<code class="sourceCode cpp">m</code> is accessible at
+<code class="sourceCode cpp"><em>R</em></code> when <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> in class
+<code class="sourceCode cpp">B</code>.</li>
+</ul>
+</blockquote>
+</div>
+<p>Update paragraph 6, and the note which follows, to use the term
+“designated class”:</p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">6</a></span>
+If a class member access operator, including an implicit “<code class="sourceCode cpp"><span class="kw">this</span><span class="op">-&gt;</span></code>”,
+is used to access a non-static data member or non-static member
+function, the reference is ill-formed if the left operand (considered as
+a pointer in the
+“<code class="sourceCode cpp"><span class="op">.</span></code>” case)
+cannot be implicitly converted to a pointer to the <span class="rm" style="color: #bf0303"><del>naming</del></span> <span class="addu">designating</span> class of the right operand.</p>
+<p><span class="note"><span>[ <em>Note 4:</em> </span>This requirement
+is in addition to the requirement that the member be accessible as <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span>.<span> — <em>end
+note</em> ]</span></span></p>
+</blockquote>
+</div>
 <h3 class="unnumbered" id="over.pre-preamble"><span>12.1 <a href="https://wg21.link/over.pre">[over.pre]</a></span> Preamble<a href="#over.pre-preamble" class="self-link"></a></h3>
 <p>Add a note explaining the expressions that form overload sets after
 paragraph 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">2</a></span>
 When a function is named <span class="addu">or designated</span> in a
 call, which function declaration is being referenced and the validity of
 the call are determined by comparing the types of the arguments at the
@@ -9505,29 +9599,6 @@ designating entities of the same kinds.<span> — <em>end
 note</em> ]</span></span></span></p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="over.match.general-general"><span>12.2.1 <a href="https://wg21.link/over.match.general">[over.match.general]</a></span>
-General<a href="#over.match.general-general" class="self-link"></a></h3>
-<p>Modify paragraphs 3 and 4 to clarify that access rules do not apply
-in all contexts.</p>
-<div class="std">
-<blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">3</a></span>
-If a best viable function exists and is unique, overload resolution
-succeeds and produces it as the result. Otherwise overload resolution
-fails and the invocation is ill-formed. When overload resolution
-succeeds, and the best viable function is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither
-designated in a manner exempt from access rules ([expr.prim.splice])
-nor</span> accessible in the context in which it is used, the program is
-ill-formed.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">4</a></span>
-Overload resolution results in a <em>usable candidate</em> if overload
-resolution succeeds and the selected candidate is either not a function
-(<span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>), or is a
-function that is not deleted and is <span class="addu">either designated
-in a manner exempt from access rules or is</span> accessible from the
-context in which overload resolution was performed.</p>
-</blockquote>
-</div>
 <h3 class="unnumbered" id="over.call.func-call-to-named-function"><span>12.2.2.2.2 <a href="https://wg21.link/over.call.func">[over.call.func]</a></span> Call
 to named function<a href="#over.call.func-call-to-named-function" class="self-link"></a></h3>
 <p>Change the section title:</p>
@@ -9540,7 +9611,7 @@ to named function<a href="#over.call.func-call-to-named-function" class="self-li
 splices of function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">1</a></span>
 Of interest in [over.call.func] are only those function calls in which
 the <code class="sourceCode cpp"><em>posfix-expression</em></code>
 ultimately contains an
@@ -9567,7 +9638,7 @@ qualified function calls and unqualified function calls.</p>
 the wording to better account for member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">2</a></span>
 In qualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -9604,7 +9675,7 @@ in the normalized member function call as the implied object argument
 the wording to better account for member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">3</a></span>
 In unqualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by a
 <code class="sourceCode cpp"><em>primary-expression</em></code> <span class="addu">(call it
 <code class="sourceCode cpp"><em>E</em></code>)</span>. <span class="rm" style="color: #bf0303"><del>The</del></span> <span class="addu">A set
@@ -9633,7 +9704,7 @@ augmented by the addition of an implied function argument as in a
 qualified function call. If the current class is, or is derived from,
 <code class="sourceCode cpp">T</code>, and the keyword
 <code class="sourceCode cpp"><span class="kw">this</span></code>
-(<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
+(<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
 refers to it, then the implied object argument is <code class="sourceCode cpp"><span class="op">(*</span><span class="kw">this</span><span class="op">)</span></code>.
 Otherwise, a contrived object of type
 <code class="sourceCode cpp">T</code> becomes the implied object
@@ -9648,7 +9719,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">1</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -9658,7 +9729,7 @@ where the <code class="sourceCode cpp"><em>template-name</em></code>
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -9667,7 +9738,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">3</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -9687,7 +9758,7 @@ Viable functions<a href="#over.match.viable-viable-functions" class="self-link">
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes to paragraph 2.3 (except for the wording related to
 <code class="sourceCode default"><em>splice-expression</em>s</code>) are
-a part of the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. These changes render
+a part of the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. These changes render
 [over.match.best.general]/4 redundant, hence the relocation of its
 associated example to this section. ]</span></p>
 <p>Specify rules for overload sets denoted by
@@ -9699,23 +9770,23 @@ example covering
 <code class="sourceCode cpp"><em>splice-expression</em></code>s).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">2</a></span>
 First, to be a viable function, a candidate function shall have enough
 parameters to agree in number with the arguments in the list.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(2.1)</a></span>
 If there are <code class="sourceCode cpp"><em>m</em></code> arguments in
 the lists, all candidate functions having exactly
 <code class="sourceCode cpp"><em>m</em></code> parameters are
 viable.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(2.2)</a></span>
 A candidate function having fewer than
 <code class="sourceCode cpp"><em>m</em></code> parameters is viable only
 if it has an ellipsis in its parameter list ([dcl.fct]). For the
 purposes of overload resolution, any argument for which there is no
 corresponding parameter is considered to “match the ellipsis”
 ([over.ics.ellipsis]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(2.3)</a></span>
 A candidate function having more than
 <code class="sourceCode cpp"><em>m</em></code> parameters is viable only
 if <span class="addu">there is a declaration
@@ -9772,13 +9843,13 @@ right, so that there are exactly
 General<a href="#over.match.best.general-general" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes to [over.match.viable]/2.3 included in this proposal (part of
-the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>) render paragraph 4 redundant;
+the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>) render paragraph 4 redundant;
 the contents of example 9 now follow [over.match.viable]/2. ]</span></p>
 <p>Delete paragraph 4 and example 9.</p>
 <div class="std">
 <blockquote>
 <div class="rm" style="color: #bf0303">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">4</a></span>
 If the best viable function resolves to a function for which multiple
 declarations were found, and if any two of these declarations inhabit
 different scopes and specify a default argument that made the function
@@ -9813,7 +9884,7 @@ paragraph 1 to allow taking the address of an overload set specified by
 a <code class="sourceCode cpp"><em>splice-expression</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">1</a></span>
 An <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span>
 whose terminal name refers to</del></span> <span class="addu">expression
 that designates</span> an overload set
@@ -9835,7 +9906,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -9877,7 +9948,7 @@ being used in a
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">3+</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of a <code class="sourceCode cpp"><em>type-constraint</em></code>, if
 any, shall not be dependent.</p>
@@ -9908,32 +9979,32 @@ and add it as a production for
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(3.1)</a></span>
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
 either appears in a type-only context or is preceded by
 <code class="sourceCode cpp"><span class="kw">template</span></code> or
 <code class="sourceCode cpp"><span class="kw">typename</span></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -9973,7 +10044,7 @@ disambiguation in paragraph 4 also applies to the parsing of
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">4</a></span>
 When parsing a
 <code class="sourceCode cpp"><em>template-argument-list</em></code>, the
 first non-nested
@@ -10002,27 +10073,27 @@ cast).<span> — <em>end note</em> ]</span></span></p>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">7</a></span>
 A <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is <em>valid</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(7.1)</a></span>
 there are at most as many arguments as there are parameters or a
 parameter is a template parameter pack (<span>13.7.4 <a href="https://wg21.link/temp.variadic">[temp.variadic]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">(7.2)</a></span>
 there is an argument for each non-deducible non-pack parameter that does
 not have a default
 <code class="sourceCode cpp"><em>template-argument</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(7.3)</a></span>
 each <code class="sourceCode cpp"><em>template-argument</em></code>
 matches the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>
 (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(7.4)</a></span>
 substitution of each template argument into the following template
 parameters (if any) succeeds, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(7.5)</a></span>
 if the <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is non-dependent, the associated constraints are satisfied as specified
@@ -10039,7 +10110,7 @@ shall be valid unless it names a function template specialization
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or the
 <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
@@ -10059,7 +10130,7 @@ of the constrained template shall be satisfied (<span>13.5.2 <a href="https://wg
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">108)</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">108)</a></span>
 A <code class="sourceCode cpp"><span class="op">&gt;</span></code> that
 encloses the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>,
@@ -10081,7 +10152,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>template-argument</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">1</a></span>
 The type and form of each
 <code class="sourceCode cpp"><em>template-argument</em></code> specified
 in a <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or in a
@@ -10104,7 +10175,7 @@ or more
 in paragraph 3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -10139,7 +10210,7 @@ form of the corresponding
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">9</a></span>
 When a <code class="sourceCode cpp"><em>simple-template-id</em></code>
 <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -10156,7 +10227,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 type template parameter shall <span class="addu">either</span> be a
 <code class="sourceCode cpp"><em>type-id</em></code> <span class="addu">or a
@@ -10177,7 +10248,7 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
@@ -10186,11 +10257,11 @@ for the variable x in the invented declaration</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">2</a></span>
 The value of a constant template parameter
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">3</a></span>
 Otherwise, a temporary variable</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
@@ -10198,11 +10269,10 @@ Otherwise, a temporary variable</p>
 </div>
 <h3 class="unnumbered" id="temp.arg.template-template-template-arguments"><span>13.4.4 <a href="https://wg21.link/temp.arg.template">[temp.arg.template]</a></span>
 Template template arguments<a href="#temp.arg.template-template-template-arguments" class="self-link"></a></h3>
-<p>Extend <span>13.4.4 <a href="https://wg21.link/temp.arg.template">[temp.arg.template]</a></span>/1
-to cover splice template arguments:</p>
+<p>Extend paragraph 1 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template template parameter shall <span class="addu">either</span> be
 the name of a template <span class="addu">or a
@@ -10235,27 +10305,27 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s</span>
 are the same if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(1.1)</a></span>
 their <code class="sourceCode cpp"><em>template-name</em></code>s,
 <code class="sourceCode cpp"><em>operator-function-id</em></code>s,
 <span class="rm" style="color: #bf0303"><del>or</del></span>
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>s<span class="addu">, or
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s</span>
 refer to the same template, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(1.2)</a></span>
 their corresponding type
 <code class="sourceCode cpp"><em>template-argument</em></code>s are the
 same type, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(1.3)</a></span>
 the template parameter values determined by their corresponding constant
 template arguments (<span>13.4.3 <a href="https://wg21.link/temp.arg.nontype">[temp.arg.nontype]</a></span>)
 are template-argument-equivalent (see below), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(1.4)</a></span>
 their corresponding template
 <code class="sourceCode cpp"><em>template-argument</em></code>s refer to
 the same template.</li>
@@ -10269,23 +10339,23 @@ that are the same refer to the same class, function, or variable.</p>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -10297,7 +10367,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -10338,7 +10408,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When a</del></span> <span class="addu">A</span>
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">that</span> refers to the specialization of an alias
 template<span class="rm" style="color: #bf0303"><del>, it is equivalent
@@ -10365,22 +10435,22 @@ be elided from a
 non-dependent contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">4</a></span>
 A qualified or unqualified name is said to be in a
 <code class="sourceCode cpp"><em>type-only context</em></code> if it is
 the terminal name of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(4.1)</a></span>
 a <code class="sourceCode cpp"><em>typename-specifier</em></code>,
 <code class="sourceCode cpp"><em>type-requirement</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>elaborated-type-specifier</em></code>,
 <code class="sourceCode cpp"><em>class-or-decltype</em></code>, <span class="addu"><code class="sourceCode cpp"><em>using-enum-declarator</em></code></span>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(4.2)</a></span>
 […]
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(4.4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">(4.4.6)</a></span>
 <code class="sourceCode cpp"><em>parameter-declaration</em></code> of a
 <code class="sourceCode cpp"><em>template-parameter</em></code> (which
 necessarily declares a constant template parameter).</li>
@@ -10427,19 +10497,19 @@ Dependent types<a href="#temp.dep.type-dependent-types" class="self-link"></a></
 paragraph 10:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">10</a></span>
 A type is dependent if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(10.1)</a></span>
 a template parameter,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(10.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(10.13)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(10.13)</a></span>
 denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>expression</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is
 type-dependent<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(10.14)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(10.14)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> in
 which either the
@@ -10476,7 +10546,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>
@@ -10493,10 +10563,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -10523,7 +10593,7 @@ contains a value-dependent or type-dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">6+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">6+</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>
@@ -10543,7 +10613,7 @@ and renumber accordingly.</p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent splice specifiers [temp.dep.splice]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if its converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
@@ -10557,7 +10627,7 @@ dependent if its
 <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 is dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> T, <span class="kw">auto</span> NS<span class="op">&gt;</span></span>
@@ -10576,7 +10646,7 @@ is dependent.</p>
 <span id="cb169-14"><a href="#cb169-14" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
 <div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">class</span> X<span class="op">&gt;</span></span>
@@ -10599,13 +10669,13 @@ Dependent template arguments<a href="#temp.dep.temp-dependent-template-arguments
 <p>Add a new paragraph to cover dependent splice template arguments.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">5</a></span>
 A template
 <code class="sourceCode cpp"><em>template-parameter</em></code> is
 dependent if it names a
 <code class="sourceCode cpp"><em>template-parameter</em></code> or if
 its terminal name is dependent.</p>
-<p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">5+</a></span>
+<p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">5+</a></span>
 A splice template argument is dependent if its
 <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent.</span></p>
@@ -10618,7 +10688,7 @@ dependent.</span></p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent namespaces [temp.dep.namespace]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">1</a></span>
 A namespace alias is dependent if it is introduced by a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 whose <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
@@ -10649,7 +10719,7 @@ Explicit specialization<a href="#temp.expl.spec-explicit-specialization" class="
 to be used like incompletely-defined classes.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">9</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 that <span class="rm" style="color: #bf0303"><del>names</del></span>
@@ -10667,7 +10737,7 @@ General<a href="#temp.deduct.general-general" class="self-link"></a></h3>
 in paragraph 2:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">2</a></span>
 When an explicit template argument list is specified, if the given
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -10688,7 +10758,7 @@ the same as parameter types that are specified using
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(4.3)</a></span>
 If <code class="sourceCode cpp">P</code> is a class and
 <code class="sourceCode cpp">P</code> has the form
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code></span>,
@@ -10720,27 +10790,27 @@ Deducing template arguments from a type<a href="#temp.deduct.type-deducing-templ
 list of non-deduced contexts in paragraph 5:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">5</a></span>
 The non-deduced contexts are:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(5.1)</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of a type that was specified using a
 <code class="sourceCode cpp"><em>qualified-id</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(5.2)</a></span>
 A <code class="sourceCode cpp"><em>pack-index-specifier</em></code> or a
 <code class="sourceCode cpp"><em>pack-index-expression</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(5.3)</a></span>
 The <code class="sourceCode cpp"><em>expression</em></code> of a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code>.</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(5.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(5.3+)</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(5.4)</a></span>
 A constant template argument or an array bound in which a subexpression
 references a template parameter.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(5.5)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -10750,7 +10820,7 @@ template argument might also be a
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">20</a></span>
 If <code class="sourceCode cpp">P</code> has a form that contains <code class="sourceCode cpp"><span class="op">&lt;</span>i<span class="op">&gt;</span></code>,
 and if the type of <code class="sourceCode cpp">i</code> differs from
 the type of the corresponding template parameter of the template named
@@ -10775,7 +10845,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">10</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -10793,25 +10863,25 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 the function to be a constant subexpression
 ([defns.const.subexpr]).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">4</a></span>
 […] Next, the semantics of the code sequence are determined by the
 <em>Constraints</em>, <em>Mandates</em>, <span class="addu"><em>Constant
 When</em>,</span> <em>Preconditions</em>, <em>Effects</em>,
@@ -11158,7 +11228,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -11166,7 +11236,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">6a</a></span>
 Let F denote a standard library function or function template. Unless F
 is designated an addressable function, it is unspecified if or how a
 reflection value designating the associated entity can be formed. <span class="note"><span>[ <em>Note 1:</em> </span>For example, it is possible
@@ -11174,14 +11244,14 @@ that <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="
 will not return reflections of standard library functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -11711,11 +11781,11 @@ synopsis</strong></p>
 <span id="cb178-338"><a href="#cb178-338" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb178-339"><a href="#cb178-339" aria-hidden="true" tabindex="-1"></a>  consteval strong_ordering type_order(info a, info b);</span>
 <span id="cb178-340"><a href="#cb178-340" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">1</a></span>
 Unless otherwise specified, each function, and each instantiation of any
 function template, specified in this header is a designated addressable
 function ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">2</a></span>
 The behavior of any function specified in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 implementation-defined when a reflection of a construct not otherwise
@@ -11746,7 +11816,7 @@ definition, the specialization is implicitly instantiated
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">3</a></span>
 Any function in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>
 whose return type is <code class="sourceCode cpp">string_view</code> or
@@ -11761,7 +11831,7 @@ equals <code class="sourceCode cpp"><span class="ch">&#39;</span><span class="sc
 <span id="cb180-4"><a href="#cb180-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>sv <span class="op">==</span> <span class="st">&quot;C&quot;</span><span class="op">)</span>;</span>
 <span id="cb180-5"><a href="#cb180-5" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>sv<span class="op">.</span>data<span class="op">()[</span><span class="dv">0</span><span class="op">]</span> <span class="op">==</span> <span class="ch">&#39;C&#39;</span><span class="op">)</span>;</span>
 <span id="cb180-6"><a href="#cb180-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>sv<span class="op">.</span>data<span class="op">()[</span><span class="dv">1</span><span class="op">]</span> <span class="op">==</span> <span class="ch">&#39;</span><span class="sc">\0</span><span class="ch">&#39;</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">4</a></span>
 Throughout this clause, variables are introduced to designate various
 source constructs. For the purpose of exposition,
 <code class="sourceCode cpp"><span class="op">^^</span><em>E</em></code>
@@ -11782,7 +11852,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb181-3"><a href="#cb181-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb181-4"><a href="#cb181-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -12035,10 +12105,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -12046,11 +12116,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">5</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -12065,21 +12135,21 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an entity that has a
 typedef name for linkage purposes ([dcl.typedef]), then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 unnamed entity, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -12087,7 +12157,7 @@ function, then
 and the function is not a constructor, destructor, operator function, or
 conversion function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -12095,30 +12165,30 @@ template, then
 template, operator function template, or conversion function template.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">false</span></code> if the
 declaration of that variable was instantiated from a function parameter
 pack. Otherwise, <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, then
 <code class="sourceCode cpp"><span class="kw">false</span></code> if the
 declaration of that structured binding was instantiated from a
 structured binding pack. Otherwise,
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a type
 alias, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">(1.9)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 enumerator, non-static data member, namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">(1.10)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">(1.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(1.11)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12131,38 +12201,38 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 </ul>
 <div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">4</a></span>
 <em>Returns</em>: An NTMBS, encoded with
 <code class="sourceCode cpp"><em>E</em></code>, determined as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an entity with a
 typedef name for linkage purposes, then that name.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a literal
 operator or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, then the identifier introduced by the declaration of that
 entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>
 or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>,
 respectively.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(4.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12176,21 +12246,21 @@ containing the identifier
 </ul>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a type other than a class type or an enumeration type, the global
 namespace, or a data member description, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity with a definition that is reachable from the
 evaluation context, a value corresponding to a definition should be
@@ -12204,7 +12274,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> <em>has-type</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value, object,
@@ -12213,23 +12283,23 @@ non-static data member, unnamed bit-field, direct base class
 relationship, or data member description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">3</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a value, object,
 variable, function, non-static data member, or unnamed bit-field, then
 the type of what is represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">(3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator <code class="sourceCode cpp"><em>N</em></code> of an
 enumeration <code class="sourceCode cpp"><em>E</em></code>, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">(3.2.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is defined by a
 declaration <code class="sourceCode cpp"><em>D</em></code> that is
 reachable from a point <code class="sourceCode cpp"><em>P</em></code> in
@@ -12238,17 +12308,17 @@ the evaluation context and
 <code class="sourceCode cpp"><em>enum-specifier</em></code> of
 <code class="sourceCode cpp"><em>D</em></code>, then a reflection of
 <code class="sourceCode cpp"><em>E</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(3.2.2)</a></span>
 Otherwise, a reflection of the type of
 <code class="sourceCode cpp"><em>N</em></code> prior to the closing
 brace of the <code class="sourceCode cpp"><em>enum-specifier</em></code>
 as specified in [dcl.enum].</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(3.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then a reflection of the type of the direct
 base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">(3.4)</a></span>
 Otherwise, for a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12259,36 +12329,36 @@ a reflection of the type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(4.1)</a></span>
 an object with static storage duration ([basic.stc.general]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(4.2)</a></span>
 a variable that either declares or refers to such an object, and if that
 variable is a reference <code class="sourceCode cpp"><em>R</em></code>
 then either
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">(4.2.1)</a></span>
 <code class="sourceCode cpp"><em>R</em></code> is usable in constant
 expressions ([expr.const]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">(4.2.2)</a></span>
 the lifetime of <code class="sourceCode cpp"><em>R</em></code> began
 within the core constant expression currently under evaluation.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">5</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(5.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an object, then
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(5.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 reference, then a reflection of the object referred to by that
 reference.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">(5.3)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents any other
 variable), a reflection of the object declared by that variable.</li>
 </ul>
@@ -12304,17 +12374,17 @@ variable), a reflection of the object declared by that variable.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">6</a></span>
 Let <code class="sourceCode cpp"><em>R</em></code> be a constant
 expression of type <code class="sourceCode cpp">info</code> such that
 <code class="sourceCode cpp"><em>R</em> <span class="op">==</span> r</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp"><span class="op">[:</span> <em>R</em> <span class="op">:]</span></code>
 is a valid
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 ([expr.prim.splice]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">8</a></span>
 <em>Effects</em>: Equivalent to:</p>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_value<span class="op">(</span>r<span class="op">))</span> <span class="op">{</span></span>
 <span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> r;</span>
@@ -12342,7 +12412,7 @@ is a valid
 <div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb195-3"><a href="#cb195-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or
@@ -12350,7 +12420,7 @@ direct base class relationship that is public, protected, or private,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -12358,7 +12428,7 @@ function or a direct base class relationship that is virtual. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb197-2"><a href="#cb197-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -12366,7 +12436,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -12374,7 +12444,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12383,7 +12453,7 @@ deleted function ([dcl.fct.def.delete]) or defaulted function
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -12391,7 +12461,7 @@ user-provided or user-declared ([dcl.fct.def.default]), respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -12406,7 +12476,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -12423,7 +12493,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -12437,7 +12507,7 @@ for which <code class="sourceCode cpp"><em>W</em></code> is not ⊥.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -12445,12 +12515,12 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">19</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a const or
@@ -12458,7 +12528,7 @@ volatile type, respectively, or a const- or volatile-qualified function
 type, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -12467,12 +12537,12 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">22</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a lvalue- or
@@ -12481,7 +12551,7 @@ rvalue-reference qualified function type, respectively. Otherwise,
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb208-3"><a href="#cb208-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -12495,7 +12565,7 @@ duration.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb209-3"><a href="#cb209-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb209-4"><a href="#cb209-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_c_language_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb209-5"><a href="#cb209-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -12504,7 +12574,7 @@ linkage, external linkage, C language linkage, or any linkage,
 respectively ([basic.link]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -12514,15 +12584,15 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerable_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">27</a></span>
 A type <code class="sourceCode cpp"><em>T</em></code> is
 <em>enumerable</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(27.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">(27.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a class type complete
 at <code class="sourceCode cpp"><em>P</em></code> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(27.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">(27.2)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is an enumeration type
 defined by a declaration <code class="sourceCode cpp"><em>D</em></code>
 such that <code class="sourceCode cpp"><em>D</em></code> is reachable
@@ -12531,7 +12601,7 @@ from <code class="sourceCode cpp"><em>P</em></code> but
 <code class="sourceCode cpp"><em>enum-specifier</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> ([dcl.enum]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">28</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
@@ -12561,14 +12631,14 @@ context. Otherwise,
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity whose
@@ -12576,7 +12646,7 @@ underlying entity is a type or namespace, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias or
@@ -12585,7 +12655,7 @@ namespace alias, respectively <span class="note"><span>[ <em>Note
 alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -12593,7 +12663,7 @@ alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb217-3"><a href="#cb217-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12609,7 +12679,7 @@ or literal operator ([over.literal]), respectively. Otherwise,
 <span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb218-9"><a href="#cb218-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12619,14 +12689,14 @@ operator, a copy assignment operator, a move assignment operator, or a
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">35</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">36</a></span>
 <span class="note"><span>[ <em>Note 5:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -12643,7 +12713,7 @@ is
 <span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb220-8"><a href="#cb220-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb220-9"><a href="#cb220-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">37</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -12653,14 +12723,14 @@ constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">38</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">39</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -12671,7 +12741,7 @@ Otherwise,
 <span id="cb223-3"><a href="#cb223-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb223-4"><a href="#cb223-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb223-5"><a href="#cb223-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">40</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -12679,72 +12749,72 @@ namespace member, non-static data member, static member, or direct base
 class relationship, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">41</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_parent<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">42</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">(42.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">(42.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents the global
 namespace, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">(42.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">(42.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 that has C language linkage ([dcl.link]), then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(42.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(42.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 that has a language linkage other than C++ language linkage, then an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(42.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(42.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a type
 that is neither a class nor enumeration type, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(42.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(42.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 or direct base class relationship, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(42.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(42.6)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">43</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_parent<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">44</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">44</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(44.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">(44.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member that is a direct member of an anonymous union, or an unnamed
 bit-field declared within the
 <code class="sourceCode cpp"><em>member-specification</em></code> of
 such a union, then a reflection representing the innermost enclosing
 anonymous union.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(44.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">(44.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator, then a reflection representing the corresponding enumeration
 type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(44.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">(44.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship between a class
 <code class="sourceCode cpp"><em>D</em></code> and a direct base class
 <code class="sourceCode cpp"><em>B</em></code>, then a reflection
 representing <code class="sourceCode cpp"><em>D</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(44.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">(44.4)</a></span>
 Otherwise, let <code class="sourceCode cpp"><em>E</em></code> be the
 class, function, or namespace whose class scope, function parameter
 scope, or namespace scope is, respectively, the innermost such scope
 that either is, or encloses, the target scope of a declaration of what
 is represented by <code class="sourceCode cpp">r</code>.
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">(44.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">(44.5)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is the function call
 operator of a closure type for a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
@@ -12754,7 +12824,7 @@ first <code class="sourceCode cpp">parent_of</code> will be the closure
 type, so the second <code class="sourceCode cpp">parent_of</code> is
 necessary to give the parent of that closure type.<span> — <em>end
 note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">(44.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">(44.6)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="op">^^</span><em>E</em></code>.</li>
 </ul></li>
@@ -12783,13 +12853,13 @@ Otherwise,
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">46</a></span>
 <em>Returns</em>: A reflection representing the underlying entity of
 what <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 5:</em> </span>
 <div class="sourceCode" id="cb229"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -12800,7 +12870,7 @@ what <code class="sourceCode cpp">r</code> represents.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">48</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">48</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -12808,17 +12878,17 @@ function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">49</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">49</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">50</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">50</a></span>
 <em>Returns</em>: A reflection of the primary template of the
 specialization represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb232"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">51</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">51</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">52</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">52</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of the template arguments of the template
 specialization represented by <code class="sourceCode cpp">r</code>, in
@@ -12828,7 +12898,7 @@ its corresponding reflection
 <code class="sourceCode cpp"><em>R</em></code> is determined as
 follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(52.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(52.1)</a></span>
 If <code class="sourceCode cpp"><em>A</em></code> denotes a type or a
 type alias, then <code class="sourceCode cpp"><em>R</em></code> is a
 reflection representing the underlying entity of
@@ -12836,27 +12906,27 @@ reflection representing the underlying entity of
 </span><code class="sourceCode cpp"><em>R</em></code> always represents
 a type, never a type alias.<span> — <em>end
 note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(52.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">(52.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>A</em></code> denotes a
 class template, variable template, concept, or alias template, then
 <code class="sourceCode cpp"><em>R</em></code> is a reflection
 representing <code class="sourceCode cpp"><em>A</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(52.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">(52.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>A</em></code> is a constant
 template argument ([temp.arg.nontype]). Let
 <code class="sourceCode cpp"><em>P</em></code> be the corresponding
 template parameter.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(52.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">(52.3.1)</a></span>
 If <code class="sourceCode cpp"><em>P</em></code> has reference type,
 then <code class="sourceCode cpp"><em>R</em></code> is a reflection
 representing the object referred to by
 <code class="sourceCode cpp"><em>A</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">(52.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(52.3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>P</em></code> has class
 type, then <code class="sourceCode cpp"><em>R</em></code> represents the
 corresponding template parameter object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(52.3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(52.3.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> is a
 reflection representing the value computed by
 <code class="sourceCode cpp"><em>A</em></code>.</li>
@@ -12895,12 +12965,12 @@ Access control context<a href="#meta.reflection.access.context-access-control-co
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">1</a></span>
 The <code class="sourceCode cpp">access_context</code> class is a
 non-aggregate type that represents a namespace, class, or function from
 which queries pertaining to access rules may be performed, as well as
 the naming class ([class.access.base]), if any.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">2</a></span>
 An <code class="sourceCode cpp">access_context</code> has an associated
 scope and naming class.</p>
 <div class="sourceCode" id="cb234"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> access_context <span class="op">{</span></span>
@@ -12914,7 +12984,7 @@ scope and naming class.</p>
 <span id="cb234-9"><a href="#cb234-9" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span>
 <span id="cb234-10"><a href="#cb234-10" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span>
 <span id="cb234-11"><a href="#cb234-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">3</a></span>
 <code class="sourceCode cpp">access_context</code> is a structural type.
 Two values <code class="sourceCode cpp">ac1</code> and
 <code class="sourceCode cpp">ac2</code> of type
@@ -12926,20 +12996,20 @@ and <code class="sourceCode cpp">ac2<span class="op">.</span>naming_class<span c
 are template-argument-equivalent.</p>
 <div class="sourceCode" id="cb235"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb235-1"><a href="#cb235-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info scope<span class="op">()</span> <span class="kw">const</span>;</span>
 <span id="cb235-2"><a href="#cb235-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info naming_class<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">4</a></span>
 <em>Returns</em>: The
 <code class="sourceCode cpp">access_context</code>’s associated scope
 and naming class, respectively.</p>
 <div class="sourceCode" id="cb236"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb236-1"><a href="#cb236-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context current<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">5</a></span>
 <code class="sourceCode cpp">current</code> is not an addressable
 function ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">6</a></span>
 Given a program point <code class="sourceCode cpp"><em>P</em></code>,
 let <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
 be the following program point:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">(6.1)</a></span>
 If a potentially-evaluated subexpression ([intro.execution]) of a
 default member initializer
 <code class="sourceCode cpp"><em>I</em></code> for a member of a class
@@ -12947,27 +13017,27 @@ default member initializer
 appears at <code class="sourceCode cpp"><em>P</em></code>, then a point
 determined as follows:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(6.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(6.1.1)</a></span>
 If <code class="sourceCode cpp"><em>I</em></code> is being used by an
 aggregate initialization that appears at point
 <code class="sourceCode cpp"><em>Q</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(6.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(6.1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>I</em></code> is being
 used for an initialization by an inherited constructor
 ([class.inhctor.init]), a point whose immediate scope is the class scope
 corresponding to <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(6.1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">(6.1.3)</a></span>
 Otherwise, a point whose immediate scope is the function parameter scope
 corresponding to the constructor definition that is using
 <code class="sourceCode cpp"><em>I</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(6.2)</a></span>
 Otherwise, if a potentially-evaluated subexpression of a default
 argument ([dcl.fct.default]) appears at
 <code class="sourceCode cpp"><em>P</em></code>, and that default
 argument is being used by an invocation of a function ([expr.call]) that
 appears at point <code class="sourceCode cpp"><em>Q</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">(6.3)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a function parameter
 scope introduced by a declaration
@@ -12979,7 +13049,7 @@ trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
 scope is the innermost scope enclosing the locus of
 <code class="sourceCode cpp"><em>D</em></code> that is not a template
 parameter scope.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">(6.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">(6.4)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a function parameter
 scope introduced by a
@@ -12991,7 +13061,7 @@ at point <code class="sourceCode cpp"><em>Q</em></code>, and
 <code class="sourceCode cpp"><em>trailing-return-type</em></code> or the
 trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
 <code class="sourceCode cpp"><em>L</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(6.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">(6.5)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a block scope and the
 innermost function parameter scope enclosing
@@ -13000,41 +13070,41 @@ innermost function parameter scope enclosing
 <code class="sourceCode cpp"><em>D</em></code> ([dcl.pre]), a point
 whose immediate scope is the scope inhabited by
 <code class="sourceCode cpp"><em>D</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(6.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">(6.6)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>P</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">7</a></span>
 Given a scope <code class="sourceCode cpp"><em>S</em></code>, let <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="op">)</span></code>
 be the following scope:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">(7.1)</a></span>
 If <code class="sourceCode cpp"><em>S</em></code> is a class scope or a
 namespace scope, <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">(7.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a lambda
 scope introduced by a
 <code class="sourceCode cpp"><em>lambda-expression</em></code>
 <code class="sourceCode cpp"><em>L</em></code>, the function parameter
 scope corresponding to the call operator of the closure type for
 <code class="sourceCode cpp"><em>L</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">(7.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 function parameter scope introduced by the declaration of a function,
 <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">(7.4)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="ch">&#39;)</span></code>
 where
 <code class="sourceCode cpp"><em>S</em><span class="ch">&#39;</span></code>
 is the parent scope of
 <code class="sourceCode cpp"><em>S</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">8</a></span>
 An invocation of <code class="sourceCode cpp">current</code> that
 appears at a program point
 <code class="sourceCode cpp"><em>P</em></code> is value-dependent
 ([temp.dep.contexpr]) if <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
 is enclosed by a scope corresponding to a templated entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">9</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class is the null reflection and whose scope represents the
 function, class, or namespace whose corresponding function parameter
@@ -13085,19 +13155,19 @@ appears.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb238"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb238-1"><a href="#cb238-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unprivileged<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">10</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class is the null reflection and whose scope is the global
 namespace.</p>
 <div class="sourceCode" id="cb239"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb239-1"><a href="#cb239-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">11</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class and scope are both the null reflection.</p>
 <div class="sourceCode" id="cb240"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb240-1"><a href="#cb240-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">cls</code> is
 either the null reflection or a reflection of a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">13</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose scope is <code class="sourceCode cpp"><span class="kw">this</span><span class="op">-&gt;</span>scope<span class="op">()</span></code>
 and whose naming class is <code class="sourceCode cpp">cls</code>.</p>
@@ -13110,44 +13180,44 @@ Member accessibility queries<a href="#meta.reflection.access.queries-member-acce
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb241"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb241-1"><a href="#cb241-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">1</a></span>
 Let <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">(1.1)</a></span>
 If <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 the class <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">(1.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>parent_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">2</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">(2.1)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a class member
 for which <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 is an incomplete class and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">(2.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a direct base
 class relationship between a base class and an incomplete derived
 class.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">3</a></span>
-Let <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">3</a></span>
+Let <code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">(3.1)</a></span>
 If <code class="sourceCode cpp">ctx<span class="op">.</span>naming_class<span class="op">()</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">(4.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed bit-field
 <code class="sourceCode cpp"><em>F</em></code>, then <code class="sourceCode cpp">is_accessible<span class="op">(</span>r<sub><span class="math inline"><em>H</em></span></sub>, ctx<span class="op">)</span></code>
 where
@@ -13159,49 +13229,49 @@ with the same access as <code class="sourceCode cpp"><em>F</em></code>.
 are treated as class members for the purpose of
 <code class="sourceCode cpp">is_accessible</code>.<span> — <em>end
 note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">(4.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> does not represent a
 class member or a direct base class relationship, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">(4.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">(4.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">(4.3.1)</a></span>
 a class member that is not a (possibly indirect or variant) member of
-<code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
+<code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(4.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(4.3.2)</a></span>
 a direct base class relationship such that <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
-does not represent <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
+does not represent <code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or a (direct or indirect) base class thereof,</li>
 </ul>
 <p>then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(4.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>
 is the null reflection, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(4.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">(4.5)</a></span>
 Otherwise, letting <code class="sourceCode cpp"><em>P</em></code> be a
 program point whose immediate scope is the function parameter scope,
 class scope, or namespace scope corresponding to the function, class, or
 namespace represented by <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(4.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">(4.5.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a direct base class
 relationship with base class
 <code class="sourceCode cpp"><em>B</em></code>, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if base
-class <code class="sourceCode cpp"><em>B</em></code> of <code class="sourceCode cpp"><em>NAMING-CLASS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
+class <code class="sourceCode cpp"><em>B</em></code> of <code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 is accessible at <code class="sourceCode cpp"><em>P</em></code>
 ([class.access.base]); otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(4.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">(4.5.2)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a class
 member <code class="sourceCode cpp"><em>M</em></code>;
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>M</em></code> is accessible at
-<code class="sourceCode cpp"><em>P</em></code> when named in <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
+<code class="sourceCode cpp"><em>P</em></code> when designated in <code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 ([class.access.base]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul></li>
@@ -13235,17 +13305,17 @@ note</em> ]</span></p>
 <div class="sourceCode" id="cb243"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb243-1"><a href="#cb243-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_nonstatic_data_members<span class="op">(</span></span>
 <span id="cb243-2"><a href="#cb243-2" aria-hidden="true" tabindex="-1"></a>      info r,</span>
 <span id="cb243-3"><a href="#cb243-3" aria-hidden="true" tabindex="-1"></a>      access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">5</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">(5.1)</a></span>
 <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">(5.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a closure
 type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13254,10 +13324,10 @@ any <code class="sourceCode cpp"><em>R</em></code> in <code class="sourceCode cp
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb244"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb244-1"><a href="#cb244-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_bases<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">bases_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13274,11 +13344,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb245"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb245-1"><a href="#cb245-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing either a class type that is complete from
 some point in the evaluation context or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">2</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>members-of-precedes</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if
@@ -13288,31 +13358,31 @@ following the
 <code class="sourceCode cpp"><em>class-specifier</em></code> of the
 outermost class for which <code class="sourceCode cpp"><em>P</em></code>
 is in a complete-class context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> of a member
 <code class="sourceCode cpp"><em>M</em></code> of a class or namespace
 <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible</em>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">(3.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a closure type
 ([expr.prim.lambda.closure]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">(3.2)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a specialization
 of a template ([temp.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">(3.3)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a class that is not
 a closure type, then <code class="sourceCode cpp"><em>M</em></code> is a
 direct member of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.mem.general]) that is not a variant member of a nested anonymous
 union of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.union.anon]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">(3.4)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a namespace, then
 <code class="sourceCode cpp"><em>D</em></code> inhabits the namespace
 scope of <code class="sourceCode cpp"><em>Q</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">(3.5)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a closure type,
 then <code class="sourceCode cpp"><em>M</em></code> is a function call
 operator or function call operator template.</li>
@@ -13320,7 +13390,7 @@ operator or function call operator template.</li>
 <p>It is implementation-defined whether declarations of other members of
 a closure type <code class="sourceCode cpp"><em>Q</em></code> are
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">4</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-representable</em>
@@ -13330,34 +13400,34 @@ declaration of <code class="sourceCode cpp"><em>M</em></code>
 members-of-precedes <code class="sourceCode cpp"><em>P</em></code> and
 <code class="sourceCode cpp"><em>M</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">(4.1)</a></span>
 a class or enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">(4.2)</a></span>
 a type alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">(4.3)</a></span>
 a primary class template, function template, primary variable template,
 alias template, or concept,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">(4.4)</a></span>
 a variable or reference,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">(4.5)</a></span>
 a function <code class="sourceCode cpp"><em>F</em></code> for which
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">(4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">(4.6)</a></span>
 the type of <code class="sourceCode cpp"><em>F</em></code> does not
 contain an undeduced placeholder type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">(4.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">(4.7)</a></span>
 the constraints (if any) of
 <code class="sourceCode cpp"><em>F</em></code> are satisfied, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">(4.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">(4.8)</a></span>
 if <code class="sourceCode cpp"><em>F</em></code> is a prospective
 destructor, <code class="sourceCode cpp"><em>F</em></code> is the
 selected destructor ([class.dtor]),</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">(4.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">(4.9)</a></span>
 a non-static data member,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">(4.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">(4.10)</a></span>
 a namespace, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">(4.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">(4.11)</a></span>
 a namespace alias.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Examples of direct
@@ -13368,18 +13438,18 @@ unscoped enumerators ([enum]), partial specializations of templates
 ([temp.spec.partial]), and closure types
 ([expr.prim.lambda.closure]).<span> — <em>end
 note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members
 <code class="sourceCode cpp"><em>M</em></code> of the entity
 <code class="sourceCode cpp"><em>Q</em></code> represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 for which</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">(5.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-representable
 from some point in the evaluation context and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">(5.2)</a></span>
 <code class="sourceCode cpp">is_accessible<span class="op">(^^</span><em>M</em>, ctx<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
@@ -13413,10 +13483,10 @@ note</em> ]</span></span></p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb247"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb247-1"><a href="#cb247-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">7</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp"><em>C</em></code> be
 the class represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -13429,31 +13499,31 @@ corresponding base classes appear in the
 <code class="sourceCode cpp"><em>base-specifier-list</em></code> of
 <code class="sourceCode cpp"><em>C</em></code>.</p>
 <div class="sourceCode" id="cb248"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb248-1"><a href="#cb248-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">8</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">9</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_variable<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
 <div class="sourceCode" id="cb249"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb249-1"><a href="#cb249-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_nonstatic_data_member<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
 <div class="sourceCode" id="cb250"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb250-1"><a href="#cb250-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">is_enumerable_type<span class="op">(</span>type_enum<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">13</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
@@ -13474,22 +13544,22 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <span id="cb251-6"><a href="#cb251-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb251-7"><a href="#cb251-7" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb251-8"><a href="#cb251-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb252"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb252-1"><a href="#cb252-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or direct base class
 relationship other than a virtual base class of an abstract class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the offset in bits
 from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb253"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb253-1"><a href="#cb253-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member that is not a bit-field, direct base class
@@ -13502,7 +13572,7 @@ relationship, or data member description
 where <code class="sourceCode cpp"><em>W</em></code> is not ⊥. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>, a data member
@@ -13524,34 +13594,34 @@ If <code class="sourceCode cpp">b</code> represents a direct base class
 relationship of an empty base class, then <code class="sourceCode cpp">size_of<span class="op">(</span>b<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb254"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb254-1"><a href="#cb254-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing a type, object, variable of non-reference
 type, non-static data member that is not a bit-field, direct base class
 relationship, or data member description. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">(8.1)</a></span>
 If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp"><em>T</em></code>, then
 the alignment requirement for the layout-associated type
 ([class.mem.general]) for a non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a variable or object, then the alignment requirement of the
 variable or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">(8.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">(8.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">(8.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>TR</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13565,7 +13635,7 @@ where the corresponding subobject of
 <code class="sourceCode cpp"><em>T</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb255"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, unnamed bit-field, direct base class
@@ -13573,15 +13643,15 @@ relationship, or data member description. If <code class="sourceCode cpp">dealia
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">10</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">(10.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member that is a bit-field or an unnamed bit-field with width
 <code class="sourceCode cpp"><em>W</em></code>, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">(10.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13590,7 +13660,7 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>NUA</em></code>) ([class.mem.general])
 and <code class="sourceCode cpp"><em>W</em></code> is not ⊥, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">(10.3)</a></span>
 Otherwise, <code class="sourceCode cpp">CHAR_BIT <span class="op">*</span> size_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
 </div>
@@ -13601,25 +13671,25 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when its type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb256"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb256-1"><a href="#cb256-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb256-2"><a href="#cb256-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">(4.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a variable or object of
 type <code class="sourceCode cpp">U</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">(4.2)</a></span>
 <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, and
 <span class="note"><span>[ <em>Note 2:</em> </span>The intent is to
@@ -13627,13 +13697,13 @@ allow only qualification conversions from
 <code class="sourceCode cpp">U</code> to
 <code class="sourceCode cpp">T</code>.<span> — <em>end
 note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">(4.3)</a></span>
 if <code class="sourceCode cpp">r</code> represents a variable, then
 either that variable is usable in constant expressions or its lifetime
 began within the core constant expression currently under
 evaluation.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">5</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 object <code class="sourceCode cpp"><em>O</em></code>, then a reference
 to <code class="sourceCode cpp"><em>O</em></code>. Otherwise, a
@@ -13641,17 +13711,17 @@ reference to the object declared, or referred to, by the variable
 represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb257"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb257-1"><a href="#cb257-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb257-2"><a href="#cb257-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">(6.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-static data
 member with type <code class="sourceCode cpp">X</code>, that is not a
 bit-field, that is a direct member of a class
 <code class="sourceCode cpp">C</code> and
 <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">X C<span class="op">::*</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">(6.2)</a></span>
 <code class="sourceCode cpp">r</code> represents an implicit object
 member function with type <code class="sourceCode cpp">F</code> or
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>
@@ -13659,7 +13729,7 @@ that is a direct member of a class <code class="sourceCode cpp">C</code>
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>;
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">(6.3)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-member function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -13667,49 +13737,49 @@ type <code class="sourceCode cpp">F</code> or
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">7</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a pointer type, then a
 pointer value pointing to the function represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">(7.2)</a></span>
 Otherwise, a pointer-to-member value designating the non-static data
 member or function represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb258"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb258-1"><a href="#cb258-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb258-2"><a href="#cb258-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-value</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value that
 <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value that <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">10</a></span>
 <em>Returns</em>: The value that <code class="sourceCode cpp">r</code>
 represents, converted to <code class="sourceCode cpp">T</code>.</p>
 <div class="sourceCode" id="cb259"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb259-1"><a href="#cb259-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb259-2"><a href="#cb259-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">11</a></span>
 <em>Effects</em>: Equivalent to:</p>
 <div class="sourceCode" id="cb260"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb260-1"><a href="#cb260-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_reference_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
 <span id="cb260-2"><a href="#cb260-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</span>
@@ -13733,51 +13803,67 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb261-5"><a href="#cb261-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb262"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb262-1"><a href="#cb262-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb262-2"><a href="#cb262-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the reflections
 held by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
-is a valid <em>template-id</em> ([temp.names]). Otherwise,
+is a valid <code class="sourceCode cpp"><em>template-id</em></code>
+([temp.names]) that does not name a function whose type contains an
+undeduced placeholder type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">4</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If forming <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 leads to a failure outside of the immediate context, the program is
 ill-formed.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb263"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb263-1"><a href="#cb263-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb263-2"><a href="#cb263-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the reflections
 held by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^^</span>Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">8</a></span>
-<span class="note"><span>[ <em>Note 2:</em> </span>The specialization
-<code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
-is only instantiated if needed.<span> — <em>end
-note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">9</a></span>
-<span class="note"><span>[ <em>Note 3:</em> </span>If forming <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">8</a></span>
+<span class="note"><span>[ <em>Note 2:</em> </span>If forming <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 leads to a failure outside of the immediate context, the program is
 ill-formed.<span> — <em>end note</em> ]</span></span></p>
+<div class="example">
+<span>[ <em>Example 1:</em> </span>
+<div class="sourceCode" id="cb264"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb264-2"><a href="#cb264-2" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> fn1<span class="op">()</span>;</span>
+<span id="cb264-3"><a href="#cb264-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb264-4"><a href="#cb264-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>can_substitute<span class="op">(^^</span>fn1, <span class="op">{^^</span><span class="dt">int</span><span class="op">}))</span>;  <span class="co">// OK</span></span>
+<span id="cb264-5"><a href="#cb264-5" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> info r1 <span class="op">=</span> substitute<span class="op">(^^</span>fn1, <span class="op">{^^</span><span class="dt">int</span><span class="op">})</span>;</span>
+<span id="cb264-6"><a href="#cb264-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">// error: fn&lt;int&gt; contains an undeduced placeholder type</span></span>
+<span id="cb264-7"><a href="#cb264-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb264-8"><a href="#cb264-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb264-9"><a href="#cb264-9" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> fn2<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb264-10"><a href="#cb264-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(^^</span>T <span class="op">!=</span> <span class="op">^^</span><span class="dt">int</span><span class="op">)</span>; <span class="co">// static assertion failed during instantiation of fn&lt;int&gt;</span></span>
+<span id="cb264-11"><a href="#cb264-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="dv">0</span>;</span>
+<span id="cb264-12"><a href="#cb264-12" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb264-13"><a href="#cb264-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb264-14"><a href="#cb264-14" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">bool</span> r2 <span class="op">=</span> can_substitute<span class="op">(^^</span>fn2, <span class="op">{^^</span><span class="dt">int</span><span class="op">})</span>;</span>
+<span id="cb264-15"><a href="#cb264-15" aria-hidden="true" tabindex="-1"></a>  <span class="co">// error: instantiation of body of fn&lt;int&gt; is needed to deduce return type</span></span></code></pre></div>
+<span> — <em>end example</em> ]</span>
+</div>
 </div>
 </blockquote>
 </div>
@@ -13786,7 +13872,7 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">1</a></span>
 An object <code class="sourceCode cpp"><em>O</em></code> of type
 <code class="sourceCode cpp"><em>T</em></code> is
 <em>meta-reflectable</em> if an lvalue expression denoting
@@ -13794,80 +13880,78 @@ An object <code class="sourceCode cpp"><em>O</em></code> of type
 constant template argument for a constant template parameter of type
 <code class="sourceCode cpp"><em>T</em><span class="op">&amp;</span></code>
 ([temp.arg.nontype]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">reflect_value</code>:</p>
-<div class="sourceCode" id="cb264"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb264-2"><a href="#cb264-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info <em>reflect-value-scalar</em><span class="op">(</span>T expr<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<div class="sourceCode" id="cb265"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb265-2"><a href="#cb265-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info <em>reflect-value-scalar</em><span class="op">(</span>T expr<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
 <p>Let <code class="sourceCode cpp"><em>V</em></code> be the value
 computed by an lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp"><em>V</em></code>
-satisfies the constraints for for a value computed by a prvalue constant
+satisfies the constraints for the result of a prvalue constant
 expression ([expr.const]) and, if
-<code class="sourceCode cpp"><em>V</em></code> has pointer type, then it
-is not a pointer to an object that is not meta-reflectable.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">4</a></span>
+<code class="sourceCode cpp"><em>V</em></code> is a pointer to an
+object, then that object is meta-reflectable.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">4</a></span>
 <em>Returns</em>: A reflection of a value of type
 <code class="sourceCode cpp"><em>T</em></code> associated with the
 computed value <code class="sourceCode cpp"><em>V</em></code>.</p>
-<div class="sourceCode" id="cb265"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb265-2"><a href="#cb265-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info <em>reflect-value-class</em><span class="op">(</span>T <span class="kw">const</span><span class="op">&amp;</span> expr<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">5</a></span>
+<div class="sourceCode" id="cb266"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb266-1"><a href="#cb266-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb266-2"><a href="#cb266-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info <em>reflect-value-class</em><span class="op">(</span>T <span class="kw">const</span><span class="op">&amp;</span> expr<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">5</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is copy
 constructible and structural ([temp.param]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">6</a></span>
-Let <code class="sourceCode cpp"><em>O</em></code> be a template
-parameter object ([temp.param]) copy-initialized from
-<code class="sourceCode cpp">expr</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">6</a></span>
+Let <code class="sourceCode cpp"><em>O</em></code> be an object
+copy-initialized from <code class="sourceCode cpp">expr</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">7</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">(7.1)</a></span>
 <code class="sourceCode cpp"><em>O</em></code> satisfies the constraints
-for a constant expression ([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">(7.2)</a></span>
-no constituent reference of
-<code class="sourceCode cpp"><em>O</em></code> refers to an object that
-is not meta-reflectable, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">(7.3)</a></span>
-no constituent value of <code class="sourceCode cpp"><em>O</em></code>
-of pointer type is a pointer to an object that is not
+for the result of a glvalue constant expression ([expr.const]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">(7.2)</a></span>
+every object referred to by a constituent reference of
+<code class="sourceCode cpp"><em>O</em></code>, or pointed to by a
+constituent pointer value of
+<code class="sourceCode cpp"><em>O</em></code>, is
 meta-reflectable.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">8</a></span>
 <em>Returns</em>: A reflection of a value of type
-<code class="sourceCode cpp">T</code> associated with the template
-parameter object <code class="sourceCode cpp"><em>O</em></code>.</p>
-<div class="sourceCode" id="cb266"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb266-1"><a href="#cb266-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb266-2"><a href="#cb266-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<code class="sourceCode cpp">T</code> associated with a template
+parameter object that is template-argument-equivalent to
+<code class="sourceCode cpp"><em>O</em></code>.</p>
+<div class="sourceCode" id="cb267"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb267-1"><a href="#cb267-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb267-2"><a href="#cb267-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
 <p><em>Effects</em>: Equivalent to:</p>
-<div class="sourceCode" id="cb267"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb267-1"><a href="#cb267-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_class_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb267-2"><a href="#cb267-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>reflect-value-class</em><span class="op">(</span>expr<span class="op">)</span>;</span>
-<span id="cb267-3"><a href="#cb267-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb267-4"><a href="#cb267-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>reflect-value-scalar</em><span class="op">(</span>expr<span class="op">)</span>;</span>
-<span id="cb267-5"><a href="#cb267-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb268"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb268-1"><a href="#cb268-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_class_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb268-2"><a href="#cb268-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>reflect-value-class</em><span class="op">(</span>expr<span class="op">)</span>;</span>
+<span id="cb268-3"><a href="#cb268-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb268-4"><a href="#cb268-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>reflect-value-scalar</em><span class="op">(</span>expr<span class="op">)</span>;</span>
+<span id="cb268-5"><a href="#cb268-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Array-to-pointer
 and function-to-function-pointer decay occur.<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb268"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb268-1"><a href="#cb268-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb268-2"><a href="#cb268-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">9</a></span>
+<div class="sourceCode" id="cb269"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb269-1"><a href="#cb269-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb269-2"><a href="#cb269-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">9</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates a meta-reflectable object.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">11</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb269"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb269-1"><a href="#cb269-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb269-2"><a href="#cb269-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> fn<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">12</a></span>
+<div class="sourceCode" id="cb270"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb270-1"><a href="#cb270-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb270-2"><a href="#cb270-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> fn<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">12</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">13</a></span>
 <em>Returns</em>: A reflection of the function designated by
 <code class="sourceCode cpp">fn</code>.</p>
 </div>
@@ -13878,36 +13962,36 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb270"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb270-1"><a href="#cb270-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> data_member_options <span class="op">{</span></span>
-<span id="cb270-2"><a href="#cb270-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> <em>name-type</em> <span class="op">{</span> <span class="co">// exposition only</span></span>
-<span id="cb270-3"><a href="#cb270-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb270-4"><a href="#cb270-4" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
-<span id="cb270-5"><a href="#cb270-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb270-6"><a href="#cb270-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb270-7"><a href="#cb270-7" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
-<span id="cb270-8"><a href="#cb270-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb270-9"><a href="#cb270-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
-<span id="cb270-10"><a href="#cb270-10" aria-hidden="true" tabindex="-1"></a>    variant<span class="op">&lt;</span>u8string, string<span class="op">&gt;</span> <em>contents</em>;    <span class="co">// exposition only</span></span>
-<span id="cb270-11"><a href="#cb270-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
-<span id="cb270-12"><a href="#cb270-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb270-13"><a href="#cb270-13" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><em>name-type</em><span class="op">&gt;</span> name;</span>
-<span id="cb270-14"><a href="#cb270-14" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> alignment;</span>
-<span id="cb270-15"><a href="#cb270-15" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> bit_width;</span>
-<span id="cb270-16"><a href="#cb270-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
-<span id="cb270-17"><a href="#cb270-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">1</a></span>
+<div class="sourceCode" id="cb271"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb271-1"><a href="#cb271-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> data_member_options <span class="op">{</span></span>
+<span id="cb271-2"><a href="#cb271-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> <em>name-type</em> <span class="op">{</span> <span class="co">// exposition only</span></span>
+<span id="cb271-3"><a href="#cb271-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb271-4"><a href="#cb271-4" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
+<span id="cb271-5"><a href="#cb271-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb271-6"><a href="#cb271-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb271-7"><a href="#cb271-7" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
+<span id="cb271-8"><a href="#cb271-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb271-9"><a href="#cb271-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
+<span id="cb271-10"><a href="#cb271-10" aria-hidden="true" tabindex="-1"></a>    variant<span class="op">&lt;</span>u8string, string<span class="op">&gt;</span> <em>contents</em>;    <span class="co">// exposition only</span></span>
+<span id="cb271-11"><a href="#cb271-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
+<span id="cb271-12"><a href="#cb271-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb271-13"><a href="#cb271-13" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><em>name-type</em><span class="op">&gt;</span> name;</span>
+<span id="cb271-14"><a href="#cb271-14" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> alignment;</span>
+<span id="cb271-15"><a href="#cb271-15" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> bit_width;</span>
+<span id="cb271-16"><a href="#cb271-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
+<span id="cb271-17"><a href="#cb271-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">data_member_options<span class="op">::</span><em>name-type</em></code>
 are consteval-only types ([basic.types.general]), and are not structural
 types ([temp.param]).</p>
-<div class="sourceCode" id="cb271"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb271-1"><a href="#cb271-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb271-2"><a href="#cb271-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">2</a></span>
+<div class="sourceCode" id="cb272"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb272-1"><a href="#cb272-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb272-2"><a href="#cb272-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
-<div class="sourceCode" id="cb272"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb272-1"><a href="#cb272-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb272-2"><a href="#cb272-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">3</a></span>
+<div class="sourceCode" id="cb273"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb273-1"><a href="#cb273-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb273-2"><a href="#cb273-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="note">
@@ -13921,71 +14005,73 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 <code class="sourceCode cpp">u8string</code>, etc.) equally well.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb273"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb273-1"><a href="#cb273-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
-<span id="cb273-2"><a href="#cb273-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb274"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb274-1"><a href="#cb274-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">void</span> fn<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb274-2"><a href="#cb274-2" aria-hidden="true" tabindex="-1"></a>  data_member_options o1 <span class="op">=</span> <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">}</span>;</span>
+<span id="cb274-3"><a href="#cb274-3" aria-hidden="true" tabindex="-1"></a>  data_member_options o2 <span class="op">=</span> <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">}</span>;</span>
+<span id="cb274-4"><a href="#cb274-4" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<div class="sourceCode" id="cb274"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb274-1"><a href="#cb274-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb274-2"><a href="#cb274-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">4</a></span>
+<div class="sourceCode" id="cb275"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb275-1"><a href="#cb275-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
+<span id="cb275-2"><a href="#cb275-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp">cv <em>T</em></code>
 where <code class="sourceCode cpp"><em>T</em></code> is either an object
 type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">(4.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">(4.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">(4.4.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">(4.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">(4.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">(4.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">(4.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">(4.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">(4.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em></code> equals
 <code class="sourceCode cpp"><span class="dv">0</span></code> then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value; and</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13994,31 +14080,31 @@ contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type represented
 by <code class="sourceCode cpp">delias<span class="op">(</span>type<span class="op">)</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 or ⊥ if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 does not contain a value, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">6</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>; it can also be
@@ -14027,16 +14113,16 @@ queried by certain other functions in
 (e.g., <code class="sourceCode cpp">type_of</code>,
 <code class="sourceCode cpp">identifier_of</code>).<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb275"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb275-1"><a href="#cb275-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">7</a></span>
+<div class="sourceCode" id="cb276"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb276-1"><a href="#cb276-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
 description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb276"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb276-1"><a href="#cb276-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb276-2"><a href="#cb276-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">8</a></span>
+<div class="sourceCode" id="cb277"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb277-1"><a href="#cb277-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb277-2"><a href="#cb277-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">8</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -14044,24 +14130,24 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">(8.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">(8.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context; <span class="note"><span>[ <em>Note
 3:</em> </span><code class="sourceCode cpp"><em>C</em></code> can be a
 class template specialization for which there is a reachable definition
 of the primary class template. In this case, an explicit specialization
 is injected.<span> — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">(8.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">(8.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>;</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">(8.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">(8.3)</a></span>
 <code class="sourceCode cpp">is_complete_type<span class="op">(</span>type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>; and</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">(8.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">(8.4)</a></span>
 for every pair
 (<code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>) where
@@ -14070,11 +14156,11 @@ for every pair
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 then either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">(8.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">(8.4.1)</a></span>
 <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">(8.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">(8.4.2)</a></span>
 <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">==</span> <span class="st">u8&quot;_&quot;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 <span class="note"><span>[ <em>Note 4:</em> </span>Every provided
@@ -14082,7 +14168,7 @@ identifier is unique or <code class="sourceCode cpp"><span class="st">&quot;_&qu
 — <em>end note</em> ]</span></span></li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">9</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -14093,28 +14179,28 @@ values such that <code class="sourceCode cpp">data_member_spec<span class="op">(
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">(10.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">(10.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the core constant expression currently under
 evaluation.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization,
 that is not a local class, of a templated class
 <code class="sourceCode cpp"><em>T</em></code>; then
 <code class="sourceCode cpp"><em>D</em></code> is an explicit
 specialization of
 <code class="sourceCode cpp"><em>T</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">(10.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">(10.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>. For every
@@ -14125,27 +14211,27 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">(10.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">(10.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">(10.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">(10.5.1)</a></span>
 It has the type represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">(10.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">(10.5.2)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, it
 is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">(10.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">(10.5.3)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value, it is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">(10.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">(10.5.4)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value, it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(*</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">(10.5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">(10.5.5)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>name</code>
 does not contain a value, it is an unnamed bit-field. Otherwise, it is a
 non-static data member with an identifier determined by the character
@@ -14153,7 +14239,7 @@ sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op"
 in UTF-8.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -14163,14 +14249,14 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
-the function is a non-constant library call (<span>3.35 <a href="https://wg21.link/defns.nonconst.libcall">[defns.nonconst.libcall]</a></span>)
+the function is a non-constant library call (<span>3.34 <a href="https://wg21.link/defns.nonconst.libcall">[defns.nonconst.libcall]</a></span>)
 if that argument is not a reflection of a type or type alias. For each
 function taking an argument named
 <code class="sourceCode cpp">type_args</code>, a call to the function is
@@ -14185,43 +14271,43 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp"><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.unary.cat]</a></span>.</p>
-<div class="sourceCode" id="cb277"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb277-1"><a href="#cb277-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-2"><a href="#cb277-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-3"><a href="#cb277-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-4"><a href="#cb277-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-5"><a href="#cb277-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-6"><a href="#cb277-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-7"><a href="#cb277-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-8"><a href="#cb277-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-9"><a href="#cb277-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-10"><a href="#cb277-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-11"><a href="#cb277-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-12"><a href="#cb277-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-13"><a href="#cb277-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-14"><a href="#cb277-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb277-15"><a href="#cb277-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">2</a></span></p>
+<div class="sourceCode" id="cb278"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb278-1"><a href="#cb278-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-2"><a href="#cb278-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-3"><a href="#cb278-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-4"><a href="#cb278-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-5"><a href="#cb278-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-6"><a href="#cb278-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-7"><a href="#cb278-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-8"><a href="#cb278-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-9"><a href="#cb278-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-10"><a href="#cb278-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-11"><a href="#cb278-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-12"><a href="#cb278-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-13"><a href="#cb278-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-14"><a href="#cb278-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb278-15"><a href="#cb278-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb278"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb278-1"><a href="#cb278-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb278-2"><a href="#cb278-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
-<span id="cb278-3"><a href="#cb278-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
-<span id="cb278-4"><a href="#cb278-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^^is_void_v, {type}));</span>
-<span id="cb278-5"><a href="#cb278-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb278-6"><a href="#cb278-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
-<span id="cb278-7"><a href="#cb278-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
-<span id="cb278-8"><a href="#cb278-8" aria-hidden="true" tabindex="-1"></a>    return type == ^^void</span>
-<span id="cb278-9"><a href="#cb278-9" aria-hidden="true" tabindex="-1"></a>        || type == ^^const void</span>
-<span id="cb278-10"><a href="#cb278-10" aria-hidden="true" tabindex="-1"></a>        || type == ^^volatile void</span>
-<span id="cb278-11"><a href="#cb278-11" aria-hidden="true" tabindex="-1"></a>        || type == ^^const volatile void;</span>
-<span id="cb278-12"><a href="#cb278-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb278-13"><a href="#cb278-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb279"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb279-1"><a href="#cb279-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb279-2"><a href="#cb279-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
+<span id="cb279-3"><a href="#cb279-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
+<span id="cb279-4"><a href="#cb279-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^^is_void_v, {type}));</span>
+<span id="cb279-5"><a href="#cb279-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb279-6"><a href="#cb279-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
+<span id="cb279-7"><a href="#cb279-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
+<span id="cb279-8"><a href="#cb279-8" aria-hidden="true" tabindex="-1"></a>    return type == ^^void</span>
+<span id="cb279-9"><a href="#cb279-9" aria-hidden="true" tabindex="-1"></a>        || type == ^^const void</span>
+<span id="cb279-10"><a href="#cb279-10" aria-hidden="true" tabindex="-1"></a>        || type == ^^volatile void</span>
+<span id="cb279-11"><a href="#cb279-11" aria-hidden="true" tabindex="-1"></a>        || type == ^^const volatile void;</span>
+<span id="cb279-12"><a href="#cb279-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb279-13"><a href="#cb279-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -14232,19 +14318,19 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp"><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.3 <a href="https://wg21.link/meta.unary.comp">[meta.unary.comp]</a></span>.</p>
-<div class="sourceCode" id="cb279"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb279-1"><a href="#cb279-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb279-2"><a href="#cb279-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb279-3"><a href="#cb279-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb279-4"><a href="#cb279-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb279-5"><a href="#cb279-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb279-6"><a href="#cb279-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb279-7"><a href="#cb279-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb280"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb280-1"><a href="#cb280-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-2"><a href="#cb280-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-3"><a href="#cb280-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-4"><a href="#cb280-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-5"><a href="#cb280-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-6"><a href="#cb280-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-7"><a href="#cb280-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14253,7 +14339,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -14262,7 +14348,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TYPE</em></code>
@@ -14271,7 +14357,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14281,74 +14367,74 @@ each function template <code class="sourceCode cpp">meta<span class="op">::</spa
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-TRAIT</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>VARIADIC-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<div class="sourceCode" id="cb280"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb280-1"><a href="#cb280-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-2"><a href="#cb280-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-3"><a href="#cb280-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-4"><a href="#cb280-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-5"><a href="#cb280-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_replaceable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-6"><a href="#cb280-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-7"><a href="#cb280-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-8"><a href="#cb280-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-9"><a href="#cb280-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-10"><a href="#cb280-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-11"><a href="#cb280-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-12"><a href="#cb280-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_consteval_only_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-13"><a href="#cb280-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-14"><a href="#cb280-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-15"><a href="#cb280-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-16"><a href="#cb280-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-17"><a href="#cb280-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-18"><a href="#cb280-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-19"><a href="#cb280-19" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb280-20"><a href="#cb280-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb280-21"><a href="#cb280-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-22"><a href="#cb280-22" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-23"><a href="#cb280-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-24"><a href="#cb280-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-25"><a href="#cb280-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb280-26"><a href="#cb280-26" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-27"><a href="#cb280-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-28"><a href="#cb280-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-29"><a href="#cb280-29" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb280-30"><a href="#cb280-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-31"><a href="#cb280-31" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-32"><a href="#cb280-32" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-33"><a href="#cb280-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-34"><a href="#cb280-34" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb280-35"><a href="#cb280-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb280-36"><a href="#cb280-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-37"><a href="#cb280-37" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-38"><a href="#cb280-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-39"><a href="#cb280-39" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-40"><a href="#cb280-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb280-41"><a href="#cb280-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-42"><a href="#cb280-42" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-43"><a href="#cb280-43" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-44"><a href="#cb280-44" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-45"><a href="#cb280-45" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb280-46"><a href="#cb280-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb280-47"><a href="#cb280-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-48"><a href="#cb280-48" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-49"><a href="#cb280-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-50"><a href="#cb280-50" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-51"><a href="#cb280-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb280-52"><a href="#cb280-52" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-53"><a href="#cb280-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-54"><a href="#cb280-54" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-55"><a href="#cb280-55" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb280-56"><a href="#cb280-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-57"><a href="#cb280-57" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-58"><a href="#cb280-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-59"><a href="#cb280-59" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-60"><a href="#cb280-60" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-61"><a href="#cb280-61" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-62"><a href="#cb280-62" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-63"><a href="#cb280-63" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-64"><a href="#cb280-64" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-65"><a href="#cb280-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-66"><a href="#cb280-66" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb280-67"><a href="#cb280-67" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb280-68"><a href="#cb280-68" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb281"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb281-1"><a href="#cb281-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-2"><a href="#cb281-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-3"><a href="#cb281-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-4"><a href="#cb281-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-5"><a href="#cb281-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_replaceable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-6"><a href="#cb281-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-7"><a href="#cb281-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-8"><a href="#cb281-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-9"><a href="#cb281-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-10"><a href="#cb281-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-11"><a href="#cb281-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-12"><a href="#cb281-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_consteval_only_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-13"><a href="#cb281-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-14"><a href="#cb281-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-15"><a href="#cb281-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-16"><a href="#cb281-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-17"><a href="#cb281-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-18"><a href="#cb281-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-19"><a href="#cb281-19" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb281-20"><a href="#cb281-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb281-21"><a href="#cb281-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-22"><a href="#cb281-22" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-23"><a href="#cb281-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-24"><a href="#cb281-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-25"><a href="#cb281-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb281-26"><a href="#cb281-26" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-27"><a href="#cb281-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-28"><a href="#cb281-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-29"><a href="#cb281-29" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb281-30"><a href="#cb281-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-31"><a href="#cb281-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-32"><a href="#cb281-32" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-33"><a href="#cb281-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-34"><a href="#cb281-34" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb281-35"><a href="#cb281-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb281-36"><a href="#cb281-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-37"><a href="#cb281-37" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-38"><a href="#cb281-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-39"><a href="#cb281-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-40"><a href="#cb281-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb281-41"><a href="#cb281-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-42"><a href="#cb281-42" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-43"><a href="#cb281-43" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-44"><a href="#cb281-44" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-45"><a href="#cb281-45" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb281-46"><a href="#cb281-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb281-47"><a href="#cb281-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-48"><a href="#cb281-48" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-49"><a href="#cb281-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-50"><a href="#cb281-50" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-51"><a href="#cb281-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb281-52"><a href="#cb281-52" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-53"><a href="#cb281-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-54"><a href="#cb281-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-55"><a href="#cb281-55" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb281-56"><a href="#cb281-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-57"><a href="#cb281-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-58"><a href="#cb281-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-59"><a href="#cb281-59" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-60"><a href="#cb281-60" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-61"><a href="#cb281-61" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-62"><a href="#cb281-62" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-63"><a href="#cb281-63" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-64"><a href="#cb281-64" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-65"><a href="#cb281-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb281-66"><a href="#cb281-66" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-67"><a href="#cb281-67" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb281-68"><a href="#cb281-68" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14357,13 +14443,13 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb281"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb281-1"><a href="#cb281-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">1</a></span>
+<div class="sourceCode" id="cb282"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb282-1"><a href="#cb282-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb282"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb282-1"><a href="#cb282-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">2</a></span>
+<div class="sourceCode" id="cb283"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb283-1"><a href="#cb283-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
@@ -14377,17 +14463,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">1</a></span>
 The consteval functions specified in this subclause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type</code>
 defined in this subclause with type <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>meta<span class="op">::</span>info, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14397,7 +14483,7 @@ each binary function template <code class="sourceCode cpp">meta<span class="op">
 <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14407,24 +14493,24 @@ each ternary function template <code class="sourceCode cpp">meta<span class="op"
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-REL-R</em><span class="op">(^^</span>R, <span class="op">^^</span>T, r<span class="op">)</span>_type</code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>VARIADIC-REL-R</em>_v<span class="op">&lt;</span>R, T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<div class="sourceCode" id="cb283"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb283-1"><a href="#cb283-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb283-2"><a href="#cb283-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb283-3"><a href="#cb283-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb283-4"><a href="#cb283-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb283-5"><a href="#cb283-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb283-6"><a href="#cb283-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb283-7"><a href="#cb283-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb283-8"><a href="#cb283-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb283-9"><a href="#cb283-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb283-10"><a href="#cb283-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb283-11"><a href="#cb283-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb283-12"><a href="#cb283-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb283-13"><a href="#cb283-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb283-14"><a href="#cb283-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb283-15"><a href="#cb283-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb283-16"><a href="#cb283-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb283-17"><a href="#cb283-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">5</a></span>
+<div class="sourceCode" id="cb284"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb284-1"><a href="#cb284-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb284-2"><a href="#cb284-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb284-3"><a href="#cb284-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb284-4"><a href="#cb284-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb284-5"><a href="#cb284-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb284-6"><a href="#cb284-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb284-7"><a href="#cb284-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb284-8"><a href="#cb284-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb284-9"><a href="#cb284-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb284-10"><a href="#cb284-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb284-11"><a href="#cb284-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb284-12"><a href="#cb284-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb284-13"><a href="#cb284-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb284-14"><a href="#cb284-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb284-15"><a href="#cb284-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb284-16"><a href="#cb284-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb284-17"><a href="#cb284-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -14446,7 +14532,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -14458,19 +14544,19 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
-<div class="sourceCode" id="cb284"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb284-1"><a href="#cb284-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb284-2"><a href="#cb284-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb284-3"><a href="#cb284-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb284-4"><a href="#cb284-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb284-5"><a href="#cb284-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb284-6"><a href="#cb284-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb285"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb285-1"><a href="#cb285-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb285-2"><a href="#cb285-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb285-3"><a href="#cb285-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb285-4"><a href="#cb285-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb285-5"><a href="#cb285-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb285-6"><a href="#cb285-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14479,16 +14565,16 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
-<div class="sourceCode" id="cb285"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb285-1"><a href="#cb285-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb285-2"><a href="#cb285-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb285-3"><a href="#cb285-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb286"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb286-1"><a href="#cb286-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb286-2"><a href="#cb286-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb286-3"><a href="#cb286-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14497,15 +14583,15 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
-<div class="sourceCode" id="cb286"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb286-1"><a href="#cb286-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb286-2"><a href="#cb286-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb287"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb287-1"><a href="#cb287-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb287-2"><a href="#cb287-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14514,15 +14600,15 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
-<div class="sourceCode" id="cb287"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb287-1"><a href="#cb287-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb287-2"><a href="#cb287-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb288"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb288-1"><a href="#cb288-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb288-2"><a href="#cb288-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14531,15 +14617,15 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.6 <a href="https://wg21.link/meta.trans.ptr">[meta.trans.ptr]</a></span>.</p>
-<div class="sourceCode" id="cb288"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb288-1"><a href="#cb288-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb288-2"><a href="#cb288-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb289"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb289-1"><a href="#cb289-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb289-2"><a href="#cb289-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14558,7 +14644,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14566,7 +14652,7 @@ defined in this subclause with type <code class="sourceCode cpp">meta<span class
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>equal<span class="op">(</span>r, vector<span class="op">{^^</span>T<span class="op">...})</span></code>
@@ -14575,7 +14661,7 @@ each unary function template <code class="sourceCode cpp">meta<span class="op">:
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14584,29 +14670,29 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span>invoke_result<span class="op">(^^</span>T, r<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp">invoke_result_t<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 (<span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>).</p>
-<div class="sourceCode" id="cb289"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb289-1"><a href="#cb289-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb289-2"><a href="#cb289-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb289-3"><a href="#cb289-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb289-4"><a href="#cb289-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb289-5"><a href="#cb289-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb289-6"><a href="#cb289-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb289-7"><a href="#cb289-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb289-8"><a href="#cb289-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb289-9"><a href="#cb289-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb289-10"><a href="#cb289-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb289-11"><a href="#cb289-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">4</a></span></p>
+<div class="sourceCode" id="cb290"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb290-1"><a href="#cb290-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb290-2"><a href="#cb290-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb290-3"><a href="#cb290-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb290-4"><a href="#cb290-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb290-5"><a href="#cb290-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb290-6"><a href="#cb290-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb290-7"><a href="#cb290-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb290-8"><a href="#cb290-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb290-9"><a href="#cb290-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb290-10"><a href="#cb290-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb290-11"><a href="#cb290-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb290"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb290-1"><a href="#cb290-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
-<span id="cb290-2"><a href="#cb290-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb290-3"><a href="#cb290-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb290-4"><a href="#cb290-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb290-5"><a href="#cb290-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb290-6"><a href="#cb290-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb290-7"><a href="#cb290-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
-<span id="cb290-8"><a href="#cb290-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb290-9"><a href="#cb290-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb291"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb291-1"><a href="#cb291-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
+<span id="cb291-2"><a href="#cb291-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb291-3"><a href="#cb291-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
+<span id="cb291-4"><a href="#cb291-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb291-5"><a href="#cb291-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb291-6"><a href="#cb291-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb291-7"><a href="#cb291-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
+<span id="cb291-8"><a href="#cb291-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb291-9"><a href="#cb291-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -14617,76 +14703,76 @@ Miscellaneous Reflection Queries<a href="#meta.reflection.misc-miscellaneous-ref
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 below inclusion of
 <code class="sourceCode default">meta::type_order</code> assumes the
-acceptance of <span class="citation" data-cites="P2830R10"><a href="https://wg21.link/p2830r10" role="doc-biblioref">[P2830R10]</a></span>. ]</span></p>
+acceptance of <span class="citation" data-cites="P2830R10">[<a href="https://wg21.link/p2830r10" role="doc-biblioref">P2830R10</a>]</span>. ]</span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_777" id="pnum_777">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 value <code class="sourceCode cpp">I</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp">info<span class="op">(</span><span class="dt">size_t</span>, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^^</span>T<span class="op">)</span></code>
 returns a reflection representing the type denoted by <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_778" id="pnum_778">3</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, <code class="sourceCode cpp">meta<span class="op">::</span>type_order<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of <code class="sourceCode cpp">type_order_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
-as defined in <span>17.12 <a href="https://wg21.link/cmp">[cmp]</a></span>.</p>
-<div class="sourceCode" id="cb291"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb291-1"><a href="#cb291-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb291-2"><a href="#cb291-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb291-3"><a href="#cb291-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb291-4"><a href="#cb291-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb291-5"><a href="#cb291-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb291-6"><a href="#cb291-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb291-7"><a href="#cb291-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> strong_ordering type_order<span class="op">(</span>info a, info b<span class="op">)</span>;</span></code></pre></div>
+as defined in <span>17.11 <a href="https://wg21.link/cmp">[cmp]</a></span>.</p>
+<div class="sourceCode" id="cb292"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb292-1"><a href="#cb292-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb292-2"><a href="#cb292-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb292-3"><a href="#cb292-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb292-4"><a href="#cb292-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb292-5"><a href="#cb292-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb292-6"><a href="#cb292-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb292-7"><a href="#cb292-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> strong_ordering type_order<span class="op">(</span>info a, info b<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
+<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
 template <code class="sourceCode cpp">bit_cast</code><a href="#bit.cast-function-template-bit_cast" class="self-link"></a></h3>
 <p>And we have adjust the requirements of
 <code class="sourceCode cpp">bit_cast</code> to not allow casting to or
 from
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>,
-in <span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
+in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
 as a mandates:</p>
 <div class="std">
 <blockquote>
-<div class="sourceCode" id="cb292"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb292-1"><a href="#cb292-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> To, <span class="kw">class</span> From<span class="op">&gt;</span></span>
-<span id="cb292-2"><a href="#cb292-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> To bit_cast<span class="op">(</span><span class="kw">const</span> From<span class="op">&amp;</span> from<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">1</a></span>
+<div class="sourceCode" id="cb293"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb293-1"><a href="#cb293-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> To, <span class="kw">class</span> From<span class="op">&gt;</span></span>
+<span id="cb293-2"><a href="#cb293-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> To bit_cast<span class="op">(</span><span class="kw">const</span> From<span class="op">&amp;</span> from<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_779" id="pnum_779">1</a></span>
 <em>Constraints</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_780" id="pnum_780">(1.1)</a></span>
 <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>To<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span>From<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_777" id="pnum_777">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_781" id="pnum_781">(1.2)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>To<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_778" id="pnum_778">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_782" id="pnum_782">(1.3)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>From<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
 </ul>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_779" id="pnum_779">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_783" id="pnum_783">*</a></span>
 <em>Mandates</em>: Neither <code class="sourceCode cpp">To</code> nor
 <code class="sourceCode cpp">From</code> are consteval-only types
 ([expr.const]).</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_780" id="pnum_780">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_784" id="pnum_784">2</a></span>
 <em>Returns</em>: […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_781" id="pnum_781">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_785" id="pnum_785">3</a></span>
 <span class="rm" style="color: #bf0303"><del><em>Remarks</em></del></span> <span class="addu"><em>Constant When</em></span>: <span class="rm" style="color: #bf0303"><del>This function is constexpr if and only
 if</del></span> <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -14694,23 +14780,23 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_782" id="pnum_782">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_786" id="pnum_786">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_783" id="pnum_783">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_787" id="pnum_787">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_784" id="pnum_784">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_788" id="pnum_788">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_785" id="pnum_785">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_789" id="pnum_789">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_786" id="pnum_786">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_790" id="pnum_790">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -14731,9 +14817,9 @@ contains two consecutive
 be ill-formed in this revision of C++.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb293"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb293-1"><a href="#cb293-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> C <span class="op">{</span> <span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span><span class="op">)</span>; <span class="op">}</span>;</span>
-<span id="cb293-2"><a href="#cb293-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span> <span class="op">(</span>C<span class="op">::*</span>p<span class="op">)(</span><span class="dt">int</span><span class="op">)</span>, C<span class="op">)</span>;</span>
-<span id="cb293-3"><a href="#cb293-3" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> i <span class="op">=</span> <span class="op">&amp;</span>C<span class="op">::</span><span class="kw">operator</span><span class="op">^^</span>C<span class="op">{}</span>; <span class="co">// ill-formed; previously well-formed</span></span></code></pre></div>
+<div class="sourceCode" id="cb294"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb294-1"><a href="#cb294-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> C <span class="op">{</span> <span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span><span class="op">)</span>; <span class="op">}</span>;</span>
+<span id="cb294-2"><a href="#cb294-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span> <span class="op">(</span>C<span class="op">::*</span>p<span class="op">)(</span><span class="dt">int</span><span class="op">)</span>, C<span class="op">)</span>;</span>
+<span id="cb294-3"><a href="#cb294-3" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> i <span class="op">=</span> <span class="op">&amp;</span>C<span class="op">::</span><span class="kw">operator</span><span class="op">^^</span>C<span class="op">{}</span>; <span class="co">// ill-formed; previously well-formed</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </blockquote>
@@ -14766,14 +14852,14 @@ usual practice is to provide something like
 since the two pieces are so closely tied together, maybe it really only
 makes sense to provide one?</p>
 <p>For now, we’ll add both.</p>
-<p>To <span>15.12 <a href="https://wg21.link/cpp.predefined">[cpp.predefined]</a></span>:</p>
+<p>To <span>15.11 <a href="https://wg21.link/cpp.predefined">[cpp.predefined]</a></span>:</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb294"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb294-1"><a href="#cb294-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
-<span id="cb294-2"><a href="#cb294-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
-<span id="cb294-3"><a href="#cb294-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
-<span id="cb294-4"><a href="#cb294-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2025XXL</span></span></code></pre></div>
+<div class="sourceCode" id="cb295"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb295-1"><a href="#cb295-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
+<span id="cb295-2"><a href="#cb295-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
+<span id="cb295-3"><a href="#cb295-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
+<span id="cb295-4"><a href="#cb295-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2025XXL</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14781,19 +14867,19 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb295"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb295-1"><a href="#cb295-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2025XXL // also in &lt;meta&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb296"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb296-1"><a href="#cb296-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2025XXL // also in &lt;meta&gt;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
 <h1 data-number="6" style="border-bottom:1px solid #cccccc" id="appendix-design-changes-approved-in-hagenberg"><span class="header-section-number">6</span> Appendix: Design changes approved
 in Hagenberg<a href="#appendix-design-changes-approved-in-hagenberg" class="self-link"></a></h1>
-<p><span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span> was forwarded to CWG in
+<p><span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span> was forwarded to CWG in
 St. Louis (June 2024). In the time after, some minor design changes were
 shown to be necessary. The following changes were confirmed by EWG
 during the Hagenberg 2025 meeting.</p>
 <p>One small change was needed to the reflection operator.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_787" id="pnum_787">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_791" id="pnum_791">1</a></span>
 Application of the
 <code class="sourceCode cpp"><span class="op">^^</span></code> operator
 to a non-type template parameter
@@ -14822,7 +14908,7 @@ as appropriate.</li>
 <p>A few changes were needed to “consteval-only types” to ensure that
 objects of such types cannot reach runtime.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_788" id="pnum_788">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_792" id="pnum_792">2</a></span>
 Relaxed linkage restrictions on objects of consteval-only types
 <ul>
 <li><strong>P2996R4</strong>: Rigid rules prevented objects of
@@ -14840,7 +14926,7 @@ imported across TUs and modules without issue.
 <li>Try it with <a href="https://godbolt.org/z/Y8cdd9sGo">Clang</a>.</li>
 </ul></li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_789" id="pnum_789">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_793" id="pnum_793">3</a></span>
 Immediate-escalation of expressions of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Every expression of consteval-only type
@@ -14850,7 +14936,7 @@ to persist to runtime (e.g., passing a reference to a <code class="sourceCode cp
 to a runtime function).</li>
 <li>Fully implemented; try it with Clang <a href="https://godbolt.org/z/5sfe7vdzE">here</a> and <a href="https://godbolt.org/z/T3MY1Yqo4">here</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_790" id="pnum_790">4</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_794" id="pnum_794">4</a></span>
 Immediate-escalation of non-constexpr variables of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Immediate-escalating functions containing
@@ -14861,7 +14947,7 @@ of consteval-only type (for which an expression does not necessarily
 appear) from reaching runtime.</li>
 <li>Fully implemented; try it with <a href="https://godbolt.org/z/3asrnK13G">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_791" id="pnum_791">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_795" id="pnum_795">5</a></span>
 No “erasure” of consteval-only-ness from results of constant
 expressions.
 <ul>
@@ -14880,7 +14966,7 @@ seen <a href="https://godbolt.org/z/E4faezfr3">here</a>).</li>
 </ul>
 <p>Two changes were needed for splicers.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_792" id="pnum_792">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_796" id="pnum_796">6</a></span>
 A slight syntactic change is needed for template splicers.
 <ul>
 <li><strong>P2994R4</strong>:
@@ -14901,14 +14987,14 @@ were supposed to work.</li>
 </ul></li>
 <li>Try it on godbolt with <a href="https://godbolt.org/z/GKj5of839">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_793" id="pnum_793">7</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_797" id="pnum_797">7</a></span>
 Reflections of concepts cannot be spliced.
 <ul>
 <li><strong>P2996R4</strong>: Concepts could be spliced within both
 <code class="sourceCode cpp"><em>type-constraint</em></code>s and
 <code class="sourceCode cpp"><em>concept-id</em></code>s.</li>
 <li><strong>D2996R10</strong>: Splicing a concept is ill-formed.</li>
-<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5"><a href="https://wg21.link/p2841r5" role="doc-biblioref">[P2841R5]</a></span> has already done the work to
+<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5">[<a href="https://wg21.link/p2841r5" role="doc-biblioref">P2841R5</a>]</span> has already done the work to
 figure out dependent concepts. CWG requested that we wait for that to
 land first, and revisit concept splicers in a future paper.</li>
 <li><strong>Instead</strong>: For the case of a
@@ -14924,7 +15010,7 @@ after P2996R4. When the evaluation of an expression calls
 evaluation produces an <em>injected declaration</em> of the completed
 type (try it on <a href="https://godbolt.org/z/PTeb9qqcW">godbolt</a>).</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_794" id="pnum_794">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_798" id="pnum_798">1</a></span>
 Recent revisions lock down the context from which
 <code class="sourceCode cpp">define_aggregate</code> can be called.
 <ul>
@@ -14943,7 +15029,7 @@ for code injection due to e.g., template instantiation behavior,
 immediate-escalating expression behavior, etc.</li>
 <li>Fully implemented with Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_795" id="pnum_795">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_799" id="pnum_799">2</a></span>
 The scope that a given expression can inject a declaration <em>into</em>
 has been constrained.
 <ul>
@@ -14958,7 +15044,7 @@ use <code class="sourceCode cpp">define_aggregate</code> to observe
 failed substitutions, overload resolution order, etc.</li>
 <li>Fully implemented in Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_796" id="pnum_796">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_800" id="pnum_800">3</a></span>
 Strengthening order of evaluation for core constant expressions removes
 the need for more IFNDR.
 <ul>

--- a/2996_reflection/d2996r12.html
+++ b/2996_reflection/d2996r12.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-05-05" />
+  <meta name="dcterms.date" content="2025-05-08" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -575,7 +575,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-05-05</td>
+    <td>2025-05-08</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -6544,34 +6544,71 @@ Fundamental types<a href="#basic.fundamental-fundamental-types" class="self-link
 as follows:</p>
 <div class="std">
 <blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">16</a></span>
+The types denoted by <code class="sourceCode cpp"><em>cv</em> std​<span class="op">::</span>​nullptr_t</code>
+are distinct types. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">17 - 1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">x</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
 <ul>
-<li>a value of structural type ([temp.param]),</li>
-<li>an object with static storage duration ([basic.stc]),</li>
-<li>a variable ([basic.pre]),</li>
-<li>a structured binding ([dcl.struct.bind]),</li>
-<li>a function ([dcl.fct]),</li>
-<li>an enumerator ([dcl.enum]),</li>
-<li>a type alias ([dcl.typedef]),</li>
-<li>a type ([basic.types]),</li>
-<li>a class member ([class.mem]),</li>
-<li>an unnamed bit-field ([class.bit]),</li>
-<li>a primary class template ([temp.pre]),</li>
-<li>a function template ([temp.pre]),</li>
-<li>a primary variable template ([temp.pre]),</li>
-<li>an alias template ([temp.alias]),</li>
-<li>a concept ([temp.concept]),</li>
-<li>a namespace alias ([namespace.alias]),</li>
-<li>a namespace ([basic.namespace.general]),</li>
-<li>a direct base class relationship ([class.derived.general]), or</li>
-<li>a data member description ([class.mem.general]).</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">(x.1)</a></span>
+a value (see below) of structural type ([temp.param]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(x.2)</a></span>
+an object with static storage duration ([basic.stc]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(x.3)</a></span>
+a variable ([basic.pre]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(x.4)</a></span>
+a structured binding ([dcl.struct.bind]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(x.5)</a></span>
+a function ([dcl.fct]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(x.6)</a></span>
+an enumerator ([dcl.enum]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(x.7)</a></span>
+a type alias ([dcl.typedef]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(x.8)</a></span>
+a type ([basic.types]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(x.9)</a></span>
+a class member ([class.mem]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(x.10)</a></span>
+an unnamed bit-field ([class.bit]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(x.11)</a></span>
+a primary class template ([temp.pre]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(x.12)</a></span>
+a function template ([temp.pre]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(x.13)</a></span>
+a primary variable template ([temp.pre]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(x.14)</a></span>
+an alias template ([temp.alias]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(x.15)</a></span>
+a concept ([temp.concept]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(x.16)</a></span>
+a namespace alias ([namespace.alias]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(x.17)</a></span>
+a namespace ([basic.namespace.general]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(x.18)</a></span>
+a direct base class relationship ([class.derived.general]), or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(x.19)</a></span>
+a data member description ([class.mem.general]).</li>
 </ul>
 <p>A reflection is said to <em>represent</em> the corresponding
 construct.</p>
+<p>A reflection of a value of type <code class="sourceCode cpp">T</code>
+is associated with</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(x.20)</a></span>
+if <code class="sourceCode cpp">T</code> is a scalar type, then a
+computed value of type <code class="sourceCode cpp">T</code>, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(x.21)</a></span>
+if <code class="sourceCode cpp">T</code> is a class type, then a
+template parameter object ([temp.param]) of type
+<code class="sourceCode cpp">T</code>.</li>
+</ul>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>A reflection of a
+value can be produced by library functions such as <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>value_of</code>
+and <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>reflect_value</code><span>
+— <em>end note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb119"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> arr<span class="op">[]</span> <span class="op">=</span> <span class="op">{</span><span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span><span class="op">}</span>;</span>
@@ -6622,16 +6659,19 @@ construct.</p>
 <span id="cb119-46"><a href="#cb119-46" aria-hidden="true" tabindex="-1"></a>    <span class="co">// represents a data member description</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">17 - 2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">y</a></span>
 <em>Recommended practice</em>: Implementations should not represent
 other constructs specified in this document, such as partial template
 specializations, attributes, placeholder types, statements, or
 expressions, as values of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">17 - 3</a></span>
-<span class="note"><span>[ <em>Note 1:</em> </span>Future revisions of
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">z</a></span>
+<span class="note"><span>[ <em>Note 2:</em> </span>Future revisions of
 this document can specify semantics for reflections representing any
 such constructs.<span> — <em>end note</em> ]</span></span></p>
 </div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">17</a></span>
+The types described in this subclause are called <em>fundamental
+types</em>.</p>
 </blockquote>
 </div>
 <h3 class="unnumbered" id="intro.execution-sequential-execution"><span>6.9.1 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>
@@ -6640,7 +6680,7 @@ Sequential execution<a href="#intro.execution-sequential-execution" class="self-
 declaration).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">7</a></span>
 Reading an object designated by a
 <code class="sourceCode cpp"><span class="kw">volatile</span></code>
 glvalue ([basic.lval]), modifying an object, <span class="addu">producing an injected declaration ([expr.const]),</span>
@@ -6664,7 +6704,7 @@ stronger sequencing during constant evaluation.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">15+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">15+</a></span>
 During the evaluation of an expression as a core constant expression
 ([expr.const]), evaluations of operands of individual operators and of
 subexpressions of individual expresssions that are otherwise either
@@ -6680,7 +6720,7 @@ determine the identity of a non-static data member.</p>
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(1.1)</a></span>
 A <em>glvalue</em> is an expression whose evaluation determines the
 identity of an object<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>or</del></span> function<span class="addu">,
 or non-static data member</span>.</li>
@@ -6693,7 +6733,7 @@ bullet 4.1 of Note 3.</p>
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(4.1)</a></span>
 a move-eligible
 <code class="sourceCode cpp"><em>id-expression</em></code>
 ([expr.prim.id.unqual]) <span class="addu">or
@@ -6709,7 +6749,7 @@ Context dependence<a href="#expr.context-context-dependence" class="self-link"><
 to the list of unevaluated operands in paragraph 1.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">1</a></span>
 In some contexts, <em>unevaluated operands</em> appear ([expr.prim.req],
 [expr.typeid], [expr.sizeof], [expr.unary.noexcept], <span class="addu">[expr.reflect],</span> [dcl.type.decltype], [temp.pre],
 [temp.concept]). An unevaluated operand is not evaluated.</p>
@@ -6719,7 +6759,7 @@ In some contexts, <em>unevaluated operands</em> appear ([expr.prim.req],
 the list of expressions in paragraph 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">2</a></span>
 In some contexts, an expression only appears for its side effects. Such
 an expression is called a <em>discarded-value expression</em>. The
 array-to-pointer and function-to-pointer standard conversions are not
@@ -6727,17 +6767,17 @@ applied. The lvalue-to-rvalue conversion is applied if and only if the
 expression is a glvalue of volatile-qualified type and it is one of the
 following:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(2.1)</a></span>
 <code class="sourceCode cpp"><span class="op">(</span> <em>expression</em> <span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is one of
 these expressions,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(2.2)</a></span>
 <code class="sourceCode cpp"><em>id-expression</em></code>
 ([expr.prim.id]),</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(2.2+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(2.2+)</a></span>
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 ([expr.prim.splice]),</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(2.3)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -6770,28 +6810,28 @@ implicit member accesses when named as operands to
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">2</a></span>
 If an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><em>E</em></code> denotes a non-static
 non-type member of some class <code class="sourceCode cpp">C</code> at a
 point where the current class (<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
 <code class="sourceCode cpp">X</code> and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(2.1)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is potentially evaluated
 or <code class="sourceCode cpp">C</code> is
 <code class="sourceCode cpp">X</code> or a base class of
 <code class="sourceCode cpp">X</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">(2.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not the
 <code class="sourceCode cpp"><em>id-expression</em></code> of a class
 member access expression (<span>7.6.1.5 <a href="https://wg21.link/expr.ref">[expr.ref]</a></span>), and</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(2.2+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(2.2+)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not the
 <code class="sourceCode cpp"><em>id-expression</em></code> of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]), and</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(2.3)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> is a
 <code class="sourceCode cpp"><em>qualified-id</em></code>,
 <code class="sourceCode cpp"><em>E</em></code> is not the
@@ -6807,19 +6847,19 @@ as the object expression.</p>
 <p>And extend paragraph 4 to account for splices:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">4</a></span>
 An <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
 that denotes a non-static data member or implicit object member function
 of a class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(4.1)</a></span>
 as part of a class member access (after any implicit transformation (see
 above)) in which the object expression refers to the member’s class or a
 class derived from that class, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">(4.2)</a></span>
 to form a pointer to member ([expr.unary.op]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(4.3)</a></span>
 if that <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 designates</span> <span class="rm" style="color: #bf0303"><del>denotes</del></span> a non-static data
@@ -6846,7 +6886,7 @@ Unqualified names<a href="#expr.prim.id.unqual-unqualified-names" class="self-li
 move-eligible:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">15</a></span>
 An <em>implicitly movable entity</em> is a variable with automatic
 storage duration that is either a non-volatile object or an rvalue
 reference to a non-volatile object type. An
@@ -6854,9 +6894,9 @@ reference to a non-volatile object type. An
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 ([expr.prim.splice])</span> is <em>move-eligible</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(15.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(15.1)</a></span>
 it <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an implicitly movable entity,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(15.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(15.2)</a></span>
 it is the (possibly parenthesized) operand of a
 <code class="sourceCode cpp"><span class="cf">return</span></code>
 ([stmt.return]) or
@@ -6864,7 +6904,7 @@ it is the (possibly parenthesized) operand of a
 ([stmt.return.coroutine]) statement or of a
 <code class="sourceCode cpp"><em>throw-expression</em></code>
 ([expr.throw]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(15.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(15.3)</a></span>
 each intervening scope between the declaration of the entity and the
 innermost enclosing scope of the <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
 <span class="addu">expression</span> is a block scope and, for a
@@ -6904,7 +6944,7 @@ well as an example:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">1+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">1+</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 that is not followed by
@@ -6948,7 +6988,7 @@ is preceded by
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -6985,15 +7025,15 @@ prvalue) precludes us from generically saying that a
 designates an entity. ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">3</a></span>
 <span class="addu">The entity designated by a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 determined as follows:</span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(3.1)</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <code class="sourceCode cpp"><span class="op">::</span></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace.<span class="addu"> </span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(3.2)</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 with a
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
@@ -7003,7 +7043,7 @@ type <span class="rm" style="color: #bf0303"><del>denoted</del></span>
 <span class="addu">designated</span> by the
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>,
 which shall be a class or enumeration type.<span class="addu"> </span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(3.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(3.3)</a></span>
 For a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of the form <code class="sourceCode cpp"><em>splice-specifier</em> <span class="op">::</span></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
@@ -7011,7 +7051,7 @@ designate a class or enumeration type or a namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(3.4)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(3.4)</a></span>
 For a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of the form <code class="sourceCode cpp">template<sub><em>opt</em></sub> <em>splice-specialization-specifier</em> <span class="op">::</span></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -7032,7 +7072,7 @@ designates <code class="sourceCode cpp"><em>S</em></code> if
 the type denoted by <code class="sourceCode cpp"><em>S</em></code> if
 <code class="sourceCode cpp"><em>T</em></code> is an alias
 template.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">(3.5)</a></span>
 If a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <em>N</em> is declarative and has a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> with a
@@ -7040,7 +7080,7 @@ template argument list <em>A</em> that involves a template parameter,
 let <em>T</em> be the template <span class="rm" style="color: #bf0303"><del>nominated</del></span> <span class="addu">designated</span> by <em>N</em> without <em>A</em>.
 <em>T</em> shall be a class template.
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">(3.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">(3.5.1)</a></span>
 If <code class="sourceCode cpp"><em>A</em></code> is the template
 argument list (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>) of the
 corresponding <code class="sourceCode cpp"><em>template-head</em></code>
@@ -7050,7 +7090,7 @@ corresponding <code class="sourceCode cpp"><em>template-head</em></code>
 <code class="sourceCode cpp"><em>H</em></code> shall be equivalent to
 the <code class="sourceCode cpp"><em>template-head</em></code> of
 <code class="sourceCode cpp"><em>T</em></code> (<span>13.7.7.2 <a href="https://wg21.link/temp.over.link">[temp.over.link]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(3.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(3.5.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>N</em></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the partial specialization (<span>13.7.6
 <a href="https://wg21.link/temp.spec.partial">[temp.spec.partial]</a></span>)
 of <code class="sourceCode cpp"><em>T</em></code> whose template
@@ -7058,7 +7098,7 @@ argument list is equivalent to
 <code class="sourceCode cpp"><em>A</em></code> (<span>13.7.7.2 <a href="https://wg21.link/temp.over.link">[temp.over.link]</a></span>);
 the program is ill-formed if no such partial specialization exists.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(3.6)</a></span>
 Any other
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the entity <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> by its
 <code class="sourceCode cpp"><em>type-name</em></code>,
@@ -7076,12 +7116,12 @@ Closure types<a href="#expr.prim.lambda.closure-closure-types" class="self-link"
 <code class="sourceCode cpp"><span class="op">}</span></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">1</a></span>
 The type of a lambda-expression (which is also the type of the closure
 object) is a unique, unnamed non-union class type, called the closure
 type, whose properties are described below.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">x</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">x</a></span>
 The closure type is not complete until the end of its corresponding
 <code class="sourceCode cpp"><em>compound-statement</em></code>.</p>
 </div>
@@ -7090,7 +7130,7 @@ The closure type is not complete until the end of its corresponding
 <p>And say that the call operator is a direct member:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">4</a></span>
 The closure type for a <em>lambda-expression</em> has a public inline
 function call operator (for a non-generic lambda) or function call
 operator template (for a generic lambda) ([over.call]) whose parameters
@@ -7106,7 +7146,7 @@ call operator template […]</p>
 <p>And that the conversion function is:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">10</a></span>
 The closure type for a non-generic lambda-expression with no
 lambda-capture and no explicit object parameter ([dcl.fct]) whose
 constraints (if any) are satisfied has a conversion function to pointer
@@ -7114,7 +7154,7 @@ to function with C++ language linkage having the same parameter and
 return types as the closure type’s function call operator. <span class="addu">The conversion function is a direct member of the closure
 type.</span> The conversion is to “pointer to noexcept function” if the
 function call operator has a non-throwing exception specification.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">11</a></span>
 For a generic lambda with no lambda-capture and no explicit object
 parameter ([dcl.fct]), the closure type has a conversion function
 template to pointer to function. <span class="addu">The conversion
@@ -7134,7 +7174,7 @@ Type requirements<a href="#expr.prim.req.type-type-requirements" class="self-lin
 <span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   typename <em>splice-specifier</em></span></span>
 <span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a><span class="va">+   typename <em>splice-specialization-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">1</a></span>
 A <code class="sourceCode cpp"><em>type-requirement</em></code> asserts
 the validity of a type. The component names <span class="addu">(if
 any)</span> of a
@@ -7174,7 +7214,7 @@ of its
 <span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
 <span id="cb126-3"><a href="#cb126-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em></span>
 <span id="cb126-4"><a href="#cb126-4" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -7200,36 +7240,36 @@ never interpreted as part of a
 <span id="cb127-13"><a href="#cb127-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">// [:^^int:] forms part of a type, not a splice-expression</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 let <code class="sourceCode cpp"><em>S</em></code> be the construct
 designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(2.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(2.1)</a></span>
 The expression is ill-formed if
 <code class="sourceCode cpp"><em>S</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(2.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(2.1.1)</a></span>
 a constructor,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(2.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(2.1.2)</a></span>
 a destructor, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(2.1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(2.1.3)</a></span>
 a local entity ([basic.pre]) such that
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(2.1.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(2.1.3.1)</a></span>
 there is a lambda scope that intervenes between the expression and the
 point at which <code class="sourceCode cpp"><em>S</em></code> was
 introduced and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(2.1.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(2.1.3.2)</a></span>
 the expression would be potentially evaluated if the effect of any
 enclosing
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expressions ([expr.typeid]) were ignored.</li>
 </ul></li>
 </ul></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(2.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(2.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 function <code class="sourceCode cpp"><em>F</em></code>, the expression
 denotes an overload set containing all declarations of
@@ -7239,7 +7279,7 @@ expression or the point immediately following the
 outermost class for which the expression is in a complete-class context;
 overload resolution is performed to select a unique function
 ([over.match], [over.over]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(2.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is an
 object or a non-static data member, the expression is an lvalue
 designating <code class="sourceCode cpp"><em>S</em></code>. The
@@ -7252,7 +7292,7 @@ an <code class="sourceCode cpp"><em>id-expression</em></code> denoting a
 non-static member becomes a class member access does not apply to a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.<span>
 — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(2.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(2.4)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 variable or a structured binding,
 <code class="sourceCode cpp"><em>S</em></code> shall either have static
@@ -7268,15 +7308,29 @@ is a bit-field.</p>
 designating a variable or structured binding of reference type will be
 adjusted to a non-reference type (<span>7.2.2 <a href="https://wg21.link/expr.type">[expr.type]</a></span>).<span>
 — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(2.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(2.5)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a value
-or an enumerator, the expression is a prvalue that computes
-<code class="sourceCode cpp"><em>S</em></code> and whose type is the
-same as that of <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(2.6)</a></span>
+or an enumerator, the expression is a prvalue whose type is the same of
+<code class="sourceCode cpp"><em>S</em></code> and whose value is
+determined as follows:</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(2.5.1)</a></span>
+if <code class="sourceCode cpp"><em>S</em></code> is an enumerator, then
+the value is the value of the enumerator;</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(2.5.2)</a></span>
+otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a value
+of scalar type, then the value is
+<code class="sourceCode cpp"><em>S</em></code>’s associated value;</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(2.5.3)</a></span>
+otherwise (if <code class="sourceCode cpp"><em>S</em></code> is a value
+of class type), then the value is the result of the lvalue-to-rvalue
+conversion applied to <code class="sourceCode cpp"><em>S</em></code>’s
+associated template parameter object.</li>
+</ul></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(2.6)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
@@ -7291,7 +7345,7 @@ overload resolution is performed to select a unique function. <span class="note"
 candidate function templates undergo template argument deduction and the
 resulting specializations are considered as candidate functions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">4</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -7299,7 +7353,7 @@ the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
 shall designate a template
 <code class="sourceCode cpp"><em>T</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">(4.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(4.1)</a></span>
 If <code class="sourceCode cpp"><em>T</em></code> is a function
 template, the expression denotes an overload set containing all
 declarations of <code class="sourceCode cpp"><em>T</em></code> that
@@ -7308,7 +7362,7 @@ precede either the expression or the point immediately following the
 outermost class for which the expression is in a complete-class context;
 overload resolution is performed to select a unique function
 ([over.match], [over.over]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(4.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>T</em></code> is a
 primary variable template, let
 <code class="sourceCode cpp"><em>S</em></code> be the specialiation of
@@ -7319,13 +7373,13 @@ any) of the
 The expression is an lvalue referring to the same object associated with
 <code class="sourceCode cpp"><em>S</em></code> and has the same type as
 <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(4.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(4.3)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 4:</em> </span>Access checking of
 class members occurs during lookup, and therefore does not pertain to
 splicing.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">5</a></span>
 While performing overload resolution to determine the entity referred to
 by a <code class="sourceCode cpp"><em>splice-expression</em></code>, the
 best viable function is <em>designated in a manner exempt from access
@@ -7358,7 +7412,7 @@ access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -7384,7 +7438,7 @@ and is followed by a
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">2</a></span>
 For <span class="rm" style="color: #bf0303"><del>the first option (dot),
 if the</del></span> <span class="addu">a dot that is followed by
 an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
@@ -7408,7 +7462,7 @@ the remainder of [expr.ref] will address only <span class="rm" style="color: #bf
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">3</a></span>
 The postfix expression before the dot is evaluated;<sup>50</sup> the
 result of that evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -7420,7 +7474,7 @@ determines the result of the entire postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">4</a></span>
 Abbreviating
 <code class="sourceCode cpp"><em>postfix-expression</em></code>.<code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="addu">or <code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span><em>splice-expression</em></code></span>
@@ -7436,17 +7490,17 @@ ill-formed.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">*</a></span>
 If <code class="sourceCode cpp">E2</code> is a
 <code class="sourceCode cpp"><em>splice-expression</em></code>, then
 <code class="sourceCode cpp">E2</code> shall designate a member of the
 type of <code class="sourceCode cpp">E1</code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">7</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="addu">designates
 an entity that</span> is declared to have type “reference to
 <code class="sourceCode cpp">T</code>”, then
@@ -7461,13 +7515,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(7.2)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
@@ -7486,15 +7540,15 @@ member, then the type of
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 “<em>cq12</em> <em>vq12</em>
 <code class="sourceCode cpp">T</code>”.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(7.3)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> is an overload set, […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(7.4)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(7.5)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
@@ -7502,10 +7556,10 @@ ill-formed.</p></li>
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(7.6)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(7.6)</a></span>
 Otherwise, the program is ill-formed.</span></p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">8</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static member, the program is
 ill-formed if the class of which <code class="sourceCode cpp">E2</code>
 <span class="rm" style="color: #bf0303"><del>is directly</del></span>
@@ -7513,7 +7567,7 @@ ill-formed if the class of which <code class="sourceCode cpp">E2</code>
 (<span>6.5.2 <a href="https://wg21.link/class.member.lookup">[class.member.lookup]</a></span>)
 of the naming class (<span>11.8.3 <a href="https://wg21.link/class.access.base">[class.access.base]</a></span>)
 of <code class="sourceCode cpp">E2</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -7529,7 +7583,7 @@ to the grammar for
 paragraph 1:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb129"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -7546,13 +7600,13 @@ Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -7562,7 +7616,7 @@ object member function, the result has type “pointer to member of class
 <code class="sourceCode cpp">C</code> of type
 <code class="sourceCode cpp">T</code>” and designates
 <code class="sourceCode cpp">C<span class="op">::</span>m</code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -7573,7 +7627,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -7599,7 +7653,7 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a><em>qualified-reflection-name</em>:</span>
 <span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>   <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
 <span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a>   <em>nested-name-specifier</em> template <em>identifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -7609,14 +7663,14 @@ places no restriction on representing, by reflections, constructs not
 described by this document or using such constructs as operands of
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 are those of its
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> (if
 any) and its
 <code class="sourceCode cpp"><em>identifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">3</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 parsed as the longest possible sequence of tokens that could
 syntactically form a
@@ -7644,17 +7698,17 @@ followed by
 <span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">4</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <span class="op">::</span></code>
 represents the global namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">5</a></span>
 If a <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> matches the form <code class="sourceCode cpp"><span class="op">^^</span> <em>qualified-reflection-name</em></code>,
 it is interpreted as such and its representation is determined as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(5.1)</a></span>
 If the <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>namespace-name</em></code> that names a
 namespace alias ([namespace.alias]),
@@ -7663,36 +7717,36 @@ alias. For any other
 <code class="sourceCode cpp"><em>namespace-name</em></code>,
 <code class="sourceCode cpp"><em>R</em></code> represents the denoted
 namespace.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(5.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>concept-name</em></code>
 ([temp.concept]), <code class="sourceCode cpp"><em>R</em></code>
 represents the denoted concept.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(5.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>template-name</em></code>
 ([temp.names]), the representation of
 <code class="sourceCode cpp"><em>R</em></code> is determined as follows:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(5.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(5.3.1)</a></span>
 If the <code class="sourceCode cpp"><em>template-name</em></code> names
 an injected-class-name ([class.pre]), then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">(5.3.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(5.3.1.1)</a></span>
 If the
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 is of the form <code class="sourceCode cpp"><em>nested-name-specifier</em> <span class="kw">template</span> <em>identifier</em></code>,
 then <code class="sourceCode cpp"><em>R</em></code> represents the class
 template named by the injected-class-name.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">(5.3.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(5.3.1.2)</a></span>
 Otherwise, the injected-class-name shall be unambiguous when considered
 as a <code class="sourceCode cpp"><em>type-name</em></code> and
 <code class="sourceCode cpp"><em>R</em></code> represents the class
 template specialization so named.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(5.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(5.3.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>template-name</em></code> names a
 function template <code class="sourceCode cpp"><em>F</em></code>, then
@@ -7703,14 +7757,14 @@ an overload set containing only
 <code class="sourceCode cpp"><em>F</em></code>.
 <code class="sourceCode cpp"><em>R</em></code> represents
 <code class="sourceCode cpp"><em>F</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(5.3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(5.3.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>template-name</em></code> denotes a
 primary class template, primary variable template, or alias template,
 <code class="sourceCode cpp"><em>R</em></code> represents that
 template.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(5.4)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> names a type
 alias that was introduced by the declaration of a template parameter,
@@ -7719,14 +7773,14 @@ entity of that type alias. For any other
 <code class="sourceCode cpp"><em>identifier</em></code> that names a
 type alias, <code class="sourceCode cpp"><em>R</em></code> represents
 that type alias.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(5.5)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>class-name</em></code> or an
 <code class="sourceCode cpp"><em>enum-name</em></code>,
 <code class="sourceCode cpp"><em>R</em></code> represents the denoted
 type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">(5.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(5.6)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 shall be an <code class="sourceCode cpp"><em>id-expression</em></code>
@@ -7735,22 +7789,22 @@ shall be an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><span class="op">^^</span> <em>I</em></code>
 (see below).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">6</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> of the form
 <code class="sourceCode cpp"><span class="op">^^</span> <em>type-id</em></code>
 represents an entity determined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(6.1)</a></span>
 If the <code class="sourceCode cpp"><em>type-id</em></code> designates a
 placeholder type, <code class="sourceCode cpp"><em>R</em></code> is
 ill-formed.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(6.2)</a></span>
 Otherwise, if the <code class="sourceCode cpp"><em>type-id</em></code>
 names a type alias that is a specialization of an alias template,
 <code class="sourceCode cpp"><em>R</em></code> represents that type
 alias.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> represents the
 type denoted by the
 <code class="sourceCode cpp"><em>type-id</em></code>.</li>
@@ -7761,12 +7815,12 @@ other cases for
 by
 <code class="sourceCode default"><em>qualified-reflection-name</em></code>.
 ]</span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">7</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> of the form <code class="sourceCode cpp"><span class="op">^^</span> <em>id-expression</em></code>
 represents an entity determined as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(7.1)</a></span>
 If the <code class="sourceCode cpp"><em>id-expression</em></code>
 denotes an overload set <code class="sourceCode cpp"><em>S</em></code>,
 overload resolution for the expression
@@ -7774,21 +7828,21 @@ overload resolution for the expression
 with no target shall select a unique function ([over.over]);
 <code class="sourceCode cpp"><em>R</em></code> represents that
 function.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(7.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 variable declared by an
 <code class="sourceCode cpp"><em>init-capture</em></code>
 ([expr.prim.lambda.capture]),
 <code class="sourceCode cpp"><em>R</em></code> is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(7.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 local parameter introduced by a
 <code class="sourceCode cpp"><em>requires-expression</em></code>
 ([expr.prim.req]), <code class="sourceCode cpp"><em>R</em></code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(7.4)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 local entity <code class="sourceCode cpp"><em>E</em></code>
@@ -7796,7 +7850,7 @@ local entity <code class="sourceCode cpp"><em>E</em></code>
 <code class="sourceCode cpp"><em>R</em></code> and the point at which
 <code class="sourceCode cpp"><em>E</em></code> was introduced,
 <code class="sourceCode cpp"><em>R</em></code> is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">(7.5)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 function-local predefined variable ([dcl.fct.def.general]),
@@ -7804,13 +7858,13 @@ function-local predefined variable ([dcl.fct.def.general]),
 other <code class="sourceCode cpp"><em>id-expression</em></code> that
 denotes a variable, <code class="sourceCode cpp"><em>R</em></code>
 represents that variable.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(7.6)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(7.6)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 structured binding, enumerator, or non-static data member,
 <code class="sourceCode cpp"><em>R</em></code> represents that
 entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(7.7)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(7.7)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> is ill-formed.
 <span class="note"><span>[ <em>Note 2:</em> </span>This includes
 <code class="sourceCode cpp"><em>pack-index-expression</em></code>s and
@@ -7853,33 +7907,33 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <p>Add a new paragraph between paragraphs 5 and 6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">5</a></span>
 Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">5+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">5+</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(5+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(5+.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">(5+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(5+.2)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a value that is
 template-argument-equivalent (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(5+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(5+.3)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(5+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(5+.4)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(5+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(5+.5)</a></span>
 Otherwise, if one operand represents a direct base class relationship,
 then they compare equal if and only if the other operand represents the
 same direct base class relationship.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(5+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(5+.6)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -7890,7 +7944,7 @@ data member descriptions represented by
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -7912,7 +7966,7 @@ production of injected declarations from any core constant expression
 that isn’t a consteval block.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">10</a></span>
 An expression <code class="sourceCode cpp"><em>E</em></code> is a
 <em>core constant expression</em> unless the evaluation of
 <code class="sourceCode cpp"><em>E</em></code>, following the rules of
@@ -7920,7 +7974,7 @@ the abstract machine ([intro.execution]), would evaluate one of the
 following:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(10.27)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(10.27)</a></span>
 a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>
 ([expr.dynamic.cast]) expression,
@@ -7929,16 +7983,16 @@ a
 <code class="sourceCode cpp"><em>new-expression</em></code> ([expr.new])
 that would throw an exception where no definition of the exception type
 is reachable;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(10.27+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(10.27+)</a></span>
 an expression that would produce an injected declaration (see below),
 unless <code class="sourceCode cpp"><em>E</em></code> is the
 corresponding expression of a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
 ([dcl.pre]);</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(10.28)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(10.28)</a></span>
 an <code class="sourceCode cpp"><em>asm-declaration</em></code>
 ([dcl.asm]);</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(10.29)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(10.29)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -7947,7 +8001,7 @@ an <code class="sourceCode cpp"><em>asm-declaration</em></code>
 <code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">17</a></span>
 During the evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> as a core constant
 expression, all
@@ -7965,15 +8019,15 @@ includes the entire constant evaluation. […]</p>
 and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">22</a></span>
 A <em>constant expression</em> is either a glvalue core constant
 expression <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> that
 <span class="addu"> </span></p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(22.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(22.1)</a></span>
 refers to an object or a non-immediate function<span class="addu">,
 and</span></p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(22.2)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(22.2)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> designates a function
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>)
 or an object whose complete object is of consteval-only type, then
@@ -7998,22 +8052,22 @@ type,</span></p>
 <p>or a prvalue core constant expression whose result object
 ([basic.lval]) satisfies the following constraints:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(22.3)</a></span>
 each constituent reference refers to an object or a non-immediate
 function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(22.4)</a></span>
 no constituent value of scalar type is an indeterminate value or
 erroneous value (<span>6.7.5 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(22.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(22.5)</a></span>
 no constituent value of pointer type is a pointer to an immediate
 function or an invalid pointer value ([basic.compound]), <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(22.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(22.6)</a></span>
 no constituent value of pointer-to-member type designates an immediate
 function<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(22.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(22.7)</a></span>
 unless the value is of consteval-only type, no constituent value of
 pointer or pointer-to-member type is
 <ul>
@@ -8032,13 +8086,13 @@ expression</em> in paragraph 25 to also apply to expressions of
 consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">25</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it is <span class="rm" style="color: #bf0303"><del>either</del></span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(25.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(25.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -8046,10 +8100,10 @@ potentially-evaluated</del></span> <span class="addu">an</span>
 that <span class="rm" style="color: #bf0303"><del>denotes</del></span>
 <span class="addu">designates</span> an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that
 is not a subexpression of an immediate invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(25.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(25.2)</a></span>
 an immediate invocation that is not a constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(25.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(25.3)</a></span>
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>).</span></li>
 </ul>
 </blockquote>
@@ -8059,21 +8113,21 @@ to include functions containing a declaration of a variable of
 consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">27</a></span>
 An <em>immediate function</em> is a function or constructor that is
 <span class="addu">either</span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(27.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(27.1)</a></span>
 declared with the
 <code class="sourceCode cpp"><span class="kw">consteval</span></code>
 specifier, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(27.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(27.2)</a></span>
 an immediate-escalating function <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>F</em></code></span></del></span>
 whose function <span class="rm" style="color: #bf0303"><del>body
 contains</del></span> <span class="addu">parameter scope is the
 innermost non-block scope enclosing either</span>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(27.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(27.2.1)</a></span>
 an immediate-escalating expression <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>E</em></code></span>
 such that
 <span><code class="sourceCode default"><em>E</em></code></span>’s
@@ -8081,7 +8135,7 @@ innermost enclosing non-block scope is
 <span><code class="sourceCode default"><em>F</em></code></span>’s
 function parameter scope.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(27.2.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(27.2.2)</a></span>
 a definition of a non-constexpr variable with consteval-only
 type.</span></li>
 </ul></li>
@@ -8094,7 +8148,7 @@ injecting declarations and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">28</a></span>
 The evaluation of an expression can introduce one or more <em>injected
 declarations</em>. Each such declaration has an associated
 <em>synthesized point</em> which follows the last non-synthesized
@@ -8103,7 +8157,7 @@ evaluation is said to <em>produce</em> the declaration.</p>
 <p><span class="note13"><span>[ <em>Note 13:</em> </span>Special rules
 concerning reachability apply to synthesized points (<span>10.7 <a href="https://wg21.link/module.reach">[module.reach]</a></span>).<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">29</a></span>
 Let <code class="sourceCode cpp"><em>C</em></code> be a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>,
 the evaluation of whose corresponding expression produces an injected
@@ -8116,9 +8170,9 @@ encloses exactly one of <code class="sourceCode cpp"><em>C</em></code>
 or <code class="sourceCode cpp"><em>D</em></code> where
 <code class="sourceCode cpp"><em>S</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(29.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(29.1)</a></span>
 a function parameter scope, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(29.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(29.2)</a></span>
 a class scope.</li>
 </ul>
 <div class="example">
@@ -8177,7 +8231,7 @@ a class scope.</li>
 <span id="cb134-52"><a href="#cb134-52" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">30</a></span>
 The <em>evaluation context</em> is a set of points within the program
 that determines the behavior of certain functions used for reflection
 ([meta.reflection]). During the evaluation of an expression
@@ -8186,11 +8240,11 @@ expression, the evaluation context of an evaluation
 <code class="sourceCode cpp"><em>E</em></code> comprises the union
 of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(30.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">(30.1)</a></span>
 the instantiation context of
 <code class="sourceCode cpp"><em>C</em></code> ([module.context]),
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(30.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(30.2)</a></span>
 the synthesized points corresponding to any injected declarations
 produced by evaluations sequenced before
 <code class="sourceCode cpp"><em>E</em></code> (<span>6.9.1 <a href="https://wg21.link/intro.execution">[intro.execution]</a></span>).</li>
@@ -8239,7 +8293,7 @@ with its associated type from paragraph 8 (type aliases are entities
 now).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">8</a></span>
 If the <code class="sourceCode cpp"><em>decl-specifier-seq</em></code>
 contains the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -8253,12 +8307,12 @@ type</del></span> (<span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.type
 blocks:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">14</a></span>
 <em>Recommended practice</em>: When a
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 fails, […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">*</a></span>
 For a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
 <code class="sourceCode cpp"><em>D</em></code>, the expression
@@ -8288,7 +8342,7 @@ can produce injected declarations as side effects ([expr.const]).<span>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">15</a></span>
 An <code class="sourceCode cpp"><em>empty-declaration</em></code> has no
 effect.</p>
 </blockquote>
@@ -8301,7 +8355,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 specifier now introduces an entity.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">1</a></span>
 Declarations containing the
 <code class="sourceCode cpp"><em>decl-specifier</em></code>
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -8344,7 +8398,7 @@ a <code class="sourceCode cpp"><em>typedef-name</em></code> <span class="rm" sty
 <code class="sourceCode cpp"><em>typedef-name</em></code> does not
 introduce a new type the way a class declaration (<span>11.3 <a href="https://wg21.link/class.name">[class.name]</a></span>) or enum
 declaration (<span>9.8.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">2</a></span>
 A <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span> can also be <span class="rm" style="color: #bf0303"><del>introduced</del></span> <span class="addu">declared</span> by an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>. The
@@ -8382,7 +8436,7 @@ to accommodate
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -8390,10 +8444,10 @@ is a placeholder for a type to be deduced ([dcl.spec.auto]). A
 is a placeholder for a deduced class type ([dcl.type.class.deduct])
 <span class="addu">if it either </span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(3.1)</a></span>
 is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(3.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(3.2)</a></span>
 is of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>
 and the <code class="sourceCode cpp"><em>splice-specifier</em></code>
@@ -8494,13 +8548,13 @@ Decltype specifiers<a href="#dcl.type.decltype-decltype-specifiers" class="self-
 extend the example that follows the paragraph:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">1</a></span>
 For an expression <code class="sourceCode cpp"><em>E</em></code>, the
 type denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
 is defined as follows:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">(1.3)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>id-expression</em></code> or an
@@ -8508,7 +8562,7 @@ unparenthesized class member access ([expr.ref]), <code class="sourceCode cpp"><
 is the type of the entity named by
 <code class="sourceCode cpp"><em>E</em></code>. If there is no such
 entity, the program is ill-formed;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(1.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">(1.3+)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>splice-expression</em></code>, <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
@@ -8549,7 +8603,7 @@ Placeholder type specifiers<a href="#dcl.spec.auto.general-placeholder-type-spec
 to account for splicing:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">13</a></span>
 If a variable or function with an undeduced placeholder type is <span class="addu">either</span> named by an expression ([basic.def.odr])
 <span class="addu">or designated by a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> in an
@@ -8593,7 +8647,7 @@ statements.</p>
 <div class="sourceCode" id="cb144"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
 <span id="cb144-2"><a href="#cb144-2" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specifier</em></span>
 <span id="cb144-3"><a href="#cb144-3" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -8622,7 +8676,7 @@ within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.gen
 <span id="cb145-11"><a href="#cb145-11" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> alias <span class="op">=</span> <span class="op">[:^^</span>S<span class="op">::</span>type<span class="op">:]</span>;    <span class="co">// OK, type-only context</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>,
@@ -8631,7 +8685,7 @@ designate a type, a primary class template, or an alias template. The
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -8652,7 +8706,7 @@ change is part of the resolution to <span class="citation" data-cites="CWG2701">
 <p>Use “host scope” in lieu of “inhabits” in paragraph 8:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">8</a></span>
 Furthermore, if there is a reachable declaration of the entity that
 <span class="rm" style="color: #bf0303"><del>inhabits</del></span> <span class="addu">has</span> the same <span class="addu">host</span> scope in
 which the bound was specified, an omitted array bound is taken to be the
@@ -8666,7 +8720,7 @@ clear about the entity being referred to, and add a bullet to allow for
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
@@ -8675,19 +8729,19 @@ type <span class="rm" style="color: #bf0303"><del>named</del></span>
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -8696,7 +8750,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -8729,7 +8783,7 @@ resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.
 <p>Use “host scope” in lieu of “inhabits” in paragraph 4:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">4</a></span>
 For non-template functions, default arguments can be added in later
 declarations of a function that <span class="rm" style="color: #bf0303"><del>inhabit</del></span> <span class="addu">have</span> the same <span class="addu">host</span> scope.
 Declarations that <span class="rm" style="color: #bf0303"><del>inhabit</del></span> <span class="addu">have</span> different <span class="addu">host</span> scopes
@@ -8741,7 +8795,7 @@ appear in default function arguments, extend example 8 which follows,
 and use “host scope” rather than “inhabits” following example 9.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">9</a></span>
 A default argument is evaluated each time the function is called with no
 argument for the corresponding parameter.</p>
 <p>[…]</p>
@@ -8792,46 +8846,46 @@ are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>),
 the object is initialized to the value obtained by converting the
 integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -8839,7 +8893,7 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible class type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
@@ -8851,13 +8905,13 @@ a <code class="sourceCode cpp"><span class="kw">consteval</span></code>
 block:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">7</a></span>
 A <em>function-local predefined variable</em> is a variable with static
 storage duration that is implicitly defined in a function parameter
 scope<span class="addu">, other than the function parameter scope of the
 expression corresponding to a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">8</a></span>
 The function-local predefined variable
 <code class="sourceCode cpp"><span class="ot">__func__</span></code> is
 defined as if a definition of the form […]</p>
@@ -8869,7 +8923,7 @@ Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 a <code class="sourceCode cpp"><em>reflect-expression</em></code>
@@ -8898,7 +8952,7 @@ follows:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">1</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> of
 the form
@@ -8926,7 +8980,7 @@ in paragraph 1, and clarify that such declarations declare a “namespace
 alias” (which is now an entity as per [basic.pre]).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">1</a></span>
 A
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 declares <span class="rm" style="color: #bf0303"><del>an alternative
@@ -8954,7 +9008,7 @@ this will fall out from the “underlying entity” of the namespace alias
 defined below:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -8968,7 +9022,7 @@ note:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">2+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">2+</a></span>
 The underlying entity (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>) of the
 namespace alias is the namespace either denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
@@ -8996,7 +9050,7 @@ renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> (if
 any) shall designate a namespace other than the global namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
@@ -9004,7 +9058,7 @@ any) shall designate a namespace other than the global namespace. The
 <code class="sourceCode cpp"><em>splice-specifier</em></code> shall not
 be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -9068,7 +9122,7 @@ follows:</p>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -9092,7 +9146,7 @@ Deprecated attribute<a href="#dcl.attr.deprecated-deprecated-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">2</a></span>
 The attribute may be applied to the declaration of a class, a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, a variable, a non-static data
 member, a function, a namespace, an enumeration, an enumerator, a
@@ -9106,7 +9160,7 @@ Maybe unused attribute<a href="#dcl.attr.unused-maybe-unused-attribute" class="s
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">2</a></span>
 The attribute may be applied to the declaration of a class, <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, variable (including a structured
 binding declaration), structured binding, non-static data member,
@@ -9123,11 +9177,11 @@ additional bullet further clarifying that it is unspecified whether any
 splice specifier is replaced.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">3</a></span>
 […]</p>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -9136,22 +9190,22 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>template-name</em></code> names an
 alias template is replaced by its denoted type prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">(3.8)</a></span>
 whether a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 that does not <span class="rm" style="color: #bf0303"><del>denote</del></span> <span class="addu">designate</span> a dependent type is replaced by its <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> type prior to this determination, <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(3.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">(3.9)</a></span>
 whether a non-value-dependent constant expression is replaced by the
 result of constant evaluation prior to this determination<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(3.10)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">(3.10)</a></span>
 whether a <code class="sourceCode cpp"><em>splice-specifier</em></code>
 or <code class="sourceCode cpp"><em>splice-expression</em></code> that
 is not dependent is replaced by the construct that it designates prior
@@ -9165,23 +9219,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 a synthesized point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 synthesized point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 (<span>10.4 <a href="https://wg21.link/module.global.frag">[module.global.frag]</a></span>),
 appears in a translation unit that is reachable from
@@ -9237,25 +9291,25 @@ follows:</p>
 <p>Update paragraph 4 accordingly:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">4</a></span>
 A <code class="sourceCode cpp"><em>member-declaration</em></code> does
 not declare new members of the class if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">(4.1)</a></span>
 a friend declaration ([class.friend]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(4.2)</a></span>
 a <code class="sourceCode cpp"><em>deduction-guide</em></code>
 ([temp.deduct.guide]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.3)</a></span>
 a <code class="sourceCode cpp"><em>template-declaration</em></code>
 whose declaration is one of the above,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.4)</a></span>
 a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>static_assert-declaration</em></code></span>,</del></span>
 <span class="addu"><code class="sourceCode cpp"><em>vacuous-declaration</em></code></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(4.5)</a></span>
 a <code class="sourceCode cpp"><em>using-declaration</em></code>
 ([namespace.udecl]) , or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(4.6)</a></span>
 an <code class="sourceCode cpp"><em>empty-declaration</em></code>.</li>
 </ul>
 </blockquote>
@@ -9265,7 +9319,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">6</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <code class="sourceCode cpp"><em>member-declaration</em></code>, in
@@ -9294,7 +9348,7 @@ member description</em>:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">30+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">30+</a></span>
 A <em>data member description</em> is a quintuple
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -9303,19 +9357,19 @@ A <em>data member description</em> is a quintuple
 <code class="sourceCode cpp"><em>NUA</em></code>) describing the
 potential declaration of a nonstatic data member where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(30+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">(30+.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a type or type
 alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">(30+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(30+.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is an
 <code class="sourceCode cpp"><em>identifier</em></code> or ⊥,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(30+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(30+.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is an alignment or
 ⊥,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(30+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(30+.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is a bit-field width or
 ⊥, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(30+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(30+.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is a boolean
 value.</li>
 </ul>
@@ -9325,15 +9379,15 @@ components are same types, same identifiers, and equal values.</p>
 <p><span>[ <em>Note 4:</em> </span>The components of a data member
 description describe a data member such that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(30+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(30+.6)</a></span>
 its type is specified using the type or type alias given by
 <code class="sourceCode cpp"><em>T</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(30+.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(30+.7)</a></span>
 it is declared with the name given by
 <code class="sourceCode cpp"><em>N</em></code> if
 <code class="sourceCode cpp"><em>N</em></code> does not equal ⊥ and is
 otherwise unnamed,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">(30+.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(30+.8)</a></span>
 it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>
 (<span>9.13.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
@@ -9341,12 +9395,12 @@ it is declared with the
 if <code class="sourceCode cpp"><em>A</em></code> does not equal ⊥ and
 is otherwise declared without an
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">(30+.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(30+.9)</a></span>
 it is a bit-field (<span>11.4.10 <a href="https://wg21.link/class.bit">[class.bit]</a></span>) with the
 width given by <code class="sourceCode cpp"><em>W</em></code> if
 <code class="sourceCode cpp"><em>W</em></code> does not equal ⊥ and is
 otherwise not a bit-field,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">(30+.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(30+.10)</a></span>
 it is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
 (<span>9.13.11 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
 if <code class="sourceCode cpp"><em>NUA</em></code> is
@@ -9372,7 +9426,7 @@ with <code class="sourceCode cpp"><em>vacuous-declaration</em></code> in
 paragraph 1.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">1</a></span>
 […] Each <code class="sourceCode cpp"><em>member-declaration</em></code>
 in the <code class="sourceCode cpp"><em>member-specification</em></code>
 of an anonymous union shall either define one or more public non-static
@@ -9388,7 +9442,7 @@ General<a href="#class.derived.general-general" class="self-link"></a></h3>
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>class-or-decltype</em></code> are those
 of its
@@ -9435,7 +9489,7 @@ the
 paragraph 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">2</a></span>
 When a function is named <span class="addu">or designated</span> in a
 call, which function declaration is being referenced and the validity of
 the call are determined by comparing the types of the arguments at the
@@ -9457,7 +9511,7 @@ General<a href="#over.match.general-general" class="self-link"></a></h3>
 in all contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">3</a></span>
 If a best viable function exists and is unique, overload resolution
 succeeds and produces it as the result. Otherwise overload resolution
 fails and the invocation is ill-formed. When overload resolution
@@ -9465,7 +9519,7 @@ succeeds, and the best viable function is <span class="rm" style="color: #bf0303
 designated in a manner exempt from access rules ([expr.prim.splice])
 nor</span> accessible in the context in which it is used, the program is
 ill-formed.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">4</a></span>
 Overload resolution results in a <em>usable candidate</em> if overload
 resolution succeeds and the selected candidate is either not a function
 (<span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>), or is a
@@ -9486,7 +9540,7 @@ to named function<a href="#over.call.func-call-to-named-function" class="self-li
 splices of function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">1</a></span>
 Of interest in [over.call.func] are only those function calls in which
 the <code class="sourceCode cpp"><em>posfix-expression</em></code>
 ultimately contains an
@@ -9513,7 +9567,7 @@ qualified function calls and unqualified function calls.</p>
 the wording to better account for member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">2</a></span>
 In qualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -9550,7 +9604,7 @@ in the normalized member function call as the implied object argument
 the wording to better account for member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">3</a></span>
 In unqualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by a
 <code class="sourceCode cpp"><em>primary-expression</em></code> <span class="addu">(call it
 <code class="sourceCode cpp"><em>E</em></code>)</span>. <span class="rm" style="color: #bf0303"><del>The</del></span> <span class="addu">A set
@@ -9594,7 +9648,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">1</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -9604,7 +9658,7 @@ where the <code class="sourceCode cpp"><em>template-name</em></code>
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -9613,7 +9667,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">3</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -9645,23 +9699,23 @@ example covering
 <code class="sourceCode cpp"><em>splice-expression</em></code>s).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">2</a></span>
 First, to be a viable function, a candidate function shall have enough
 parameters to agree in number with the arguments in the list.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(2.1)</a></span>
 If there are <code class="sourceCode cpp"><em>m</em></code> arguments in
 the lists, all candidate functions having exactly
 <code class="sourceCode cpp"><em>m</em></code> parameters are
 viable.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(2.2)</a></span>
 A candidate function having fewer than
 <code class="sourceCode cpp"><em>m</em></code> parameters is viable only
 if it has an ellipsis in its parameter list ([dcl.fct]). For the
 purposes of overload resolution, any argument for which there is no
 corresponding parameter is considered to “match the ellipsis”
 ([over.ics.ellipsis]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(2.3)</a></span>
 A candidate function having more than
 <code class="sourceCode cpp"><em>m</em></code> parameters is viable only
 if <span class="addu">there is a declaration
@@ -9724,7 +9778,7 @@ the contents of example 9 now follow [over.match.viable]/2. ]</span></p>
 <div class="std">
 <blockquote>
 <div class="rm" style="color: #bf0303">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">4</a></span>
 If the best viable function resolves to a function for which multiple
 declarations were found, and if any two of these declarations inhabit
 different scopes and specify a default argument that made the function
@@ -9759,7 +9813,7 @@ paragraph 1 to allow taking the address of an overload set specified by
 a <code class="sourceCode cpp"><em>splice-expression</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">1</a></span>
 An <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span>
 whose terminal name refers to</del></span> <span class="addu">expression
 that designates</span> an overload set
@@ -9781,7 +9835,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -9823,7 +9877,7 @@ being used in a
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">3+</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of a <code class="sourceCode cpp"><em>type-constraint</em></code>, if
 any, shall not be dependent.</p>
@@ -9854,32 +9908,32 @@ and add it as a production for
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(3.1)</a></span>
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
 either appears in a type-only context or is preceded by
 <code class="sourceCode cpp"><span class="kw">template</span></code> or
 <code class="sourceCode cpp"><span class="kw">typename</span></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -9919,7 +9973,7 @@ disambiguation in paragraph 4 also applies to the parsing of
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">4</a></span>
 When parsing a
 <code class="sourceCode cpp"><em>template-argument-list</em></code>, the
 first non-nested
@@ -9948,27 +10002,27 @@ cast).<span> — <em>end note</em> ]</span></span></p>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">7</a></span>
 A <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is <em>valid</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(7.1)</a></span>
 there are at most as many arguments as there are parameters or a
 parameter is a template parameter pack (<span>13.7.4 <a href="https://wg21.link/temp.variadic">[temp.variadic]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(7.2)</a></span>
 there is an argument for each non-deducible non-pack parameter that does
 not have a default
 <code class="sourceCode cpp"><em>template-argument</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(7.3)</a></span>
 each <code class="sourceCode cpp"><em>template-argument</em></code>
 matches the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>
 (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(7.4)</a></span>
 substitution of each template argument into the following template
 parameters (if any) succeeds, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(7.5)</a></span>
 if the <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is non-dependent, the associated constraints are satisfied as specified
@@ -9985,7 +10039,7 @@ shall be valid unless it names a function template specialization
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or the
 <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
@@ -10005,7 +10059,7 @@ of the constrained template shall be satisfied (<span>13.5.2 <a href="https://wg
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">108)</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">108)</a></span>
 A <code class="sourceCode cpp"><span class="op">&gt;</span></code> that
 encloses the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>,
@@ -10027,7 +10081,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>template-argument</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">1</a></span>
 The type and form of each
 <code class="sourceCode cpp"><em>template-argument</em></code> specified
 in a <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or in a
@@ -10050,7 +10104,7 @@ or more
 in paragraph 3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">3</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>template-argument</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> is
@@ -10085,7 +10139,7 @@ form of the corresponding
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">9</a></span>
 When a <code class="sourceCode cpp"><em>simple-template-id</em></code>
 <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -10102,7 +10156,7 @@ Template type arguments<a href="#temp.arg.type-template-type-arguments" class="s
 cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 type template parameter shall <span class="addu">either</span> be a
 <code class="sourceCode cpp"><em>type-id</em></code> <span class="addu">or a
@@ -10123,7 +10177,7 @@ requirements already fall out based on how paragraphs 1 and 3 are
 already worded ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">1</a></span>
 If the type <code class="sourceCode cpp">T</code> of a
 <em>template-parameter</em> ([temp.param]) contains a placeholder type
 ([dcl.spec.auto]) or a placeholder for a deduced class type
@@ -10132,11 +10186,11 @@ for the variable x in the invented declaration</p>
 <div class="sourceCode" id="cb164"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a>T x <span class="op">=</span> <em>E</em> ;</span></code></pre></div>
 <p>where <code class="sourceCode cpp"><em>E</em></code> is the template
 argument provided for the parameter.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">2</a></span>
 The value of a constant template parameter
 <code class="sourceCode cpp">P</code> of (possibly deduced) type
 <code class="sourceCode cpp">T</code> […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">3</a></span>
 Otherwise, a temporary variable</p>
 <div class="sourceCode" id="cb165"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> T v <span class="op">=</span> <em>A</em>;</span></code></pre></div>
 <p>is introduced.</p>
@@ -10148,7 +10202,7 @@ Template template arguments<a href="#temp.arg.template-template-template-argumen
 to cover splice template arguments:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">1</a></span>
 A <code class="sourceCode cpp"><em>template-argument</em></code> for a
 template template parameter shall <span class="addu">either</span> be
 the name of a template <span class="addu">or a
@@ -10181,27 +10235,27 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s</span>
 are the same if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(1.1)</a></span>
 their <code class="sourceCode cpp"><em>template-name</em></code>s,
 <code class="sourceCode cpp"><em>operator-function-id</em></code>s,
 <span class="rm" style="color: #bf0303"><del>or</del></span>
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>s<span class="addu">, or
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s</span>
 refer to the same template, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(1.2)</a></span>
 their corresponding type
 <code class="sourceCode cpp"><em>template-argument</em></code>s are the
 same type, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(1.3)</a></span>
 the template parameter values determined by their corresponding constant
 template arguments (<span>13.4.3 <a href="https://wg21.link/temp.arg.nontype">[temp.arg.nontype]</a></span>)
 are template-argument-equivalent (see below), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(1.4)</a></span>
 their corresponding template
 <code class="sourceCode cpp"><em>template-argument</em></code>s refer to
 the same template.</li>
@@ -10215,23 +10269,23 @@ that are the same refer to the same class, function, or variable.</p>
 <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are the same, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.5)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -10243,7 +10297,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -10284,7 +10338,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When a</del></span> <span class="addu">A</span>
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">that</span> refers to the specialization of an alias
 template<span class="rm" style="color: #bf0303"><del>, it is equivalent
@@ -10311,22 +10365,22 @@ be elided from a
 non-dependent contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">4</a></span>
 A qualified or unqualified name is said to be in a
 <code class="sourceCode cpp"><em>type-only context</em></code> if it is
 the terminal name of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(4.1)</a></span>
 a <code class="sourceCode cpp"><em>typename-specifier</em></code>,
 <code class="sourceCode cpp"><em>type-requirement</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>elaborated-type-specifier</em></code>,
 <code class="sourceCode cpp"><em>class-or-decltype</em></code>, <span class="addu"><code class="sourceCode cpp"><em>using-enum-declarator</em></code></span>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(4.2)</a></span>
 […]
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">(4.4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(4.4.6)</a></span>
 <code class="sourceCode cpp"><em>parameter-declaration</em></code> of a
 <code class="sourceCode cpp"><em>template-parameter</em></code> (which
 necessarily declares a constant template parameter).</li>
@@ -10373,19 +10427,19 @@ Dependent types<a href="#temp.dep.type-dependent-types" class="self-link"></a></
 paragraph 10:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">10</a></span>
 A type is dependent if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(10.1)</a></span>
 a template parameter,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(10.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(10.13)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(10.13)</a></span>
 denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>expression</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is
 type-dependent<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(10.14)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(10.14)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> in
 which either the
@@ -10422,7 +10476,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>
@@ -10439,10 +10493,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -10469,7 +10523,7 @@ contains a value-dependent or type-dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">6+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">6+</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>
@@ -10489,7 +10543,7 @@ and renumber accordingly.</p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent splice specifiers [temp.dep.splice]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if its converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
@@ -10503,7 +10557,7 @@ dependent if its
 <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 is dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb169"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> T, <span class="kw">auto</span> NS<span class="op">&gt;</span></span>
@@ -10522,7 +10576,7 @@ is dependent.</p>
 <span id="cb169-14"><a href="#cb169-14" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
 <div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">class</span> X<span class="op">&gt;</span></span>
@@ -10545,13 +10599,13 @@ Dependent template arguments<a href="#temp.dep.temp-dependent-template-arguments
 <p>Add a new paragraph to cover dependent splice template arguments.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">5</a></span>
 A template
 <code class="sourceCode cpp"><em>template-parameter</em></code> is
 dependent if it names a
 <code class="sourceCode cpp"><em>template-parameter</em></code> or if
 its terminal name is dependent.</p>
-<p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">5+</a></span>
+<p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">5+</a></span>
 A splice template argument is dependent if its
 <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent.</span></p>
@@ -10564,7 +10618,7 @@ dependent.</span></p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent namespaces [temp.dep.namespace]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">1</a></span>
 A namespace alias is dependent if it is introduced by a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 whose <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
@@ -10595,7 +10649,7 @@ Explicit specialization<a href="#temp.expl.spec-explicit-specialization" class="
 to be used like incompletely-defined classes.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">9</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 that <span class="rm" style="color: #bf0303"><del>names</del></span>
@@ -10613,7 +10667,7 @@ General<a href="#temp.deduct.general-general" class="self-link"></a></h3>
 in paragraph 2:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">2</a></span>
 When an explicit template argument list is specified, if the given
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -10634,7 +10688,7 @@ the same as parameter types that are specified using
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(4.3)</a></span>
 If <code class="sourceCode cpp">P</code> is a class and
 <code class="sourceCode cpp">P</code> has the form
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code></span>,
@@ -10666,27 +10720,27 @@ Deducing template arguments from a type<a href="#temp.deduct.type-deducing-templ
 list of non-deduced contexts in paragraph 5:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">5</a></span>
 The non-deduced contexts are:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(5.1)</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of a type that was specified using a
 <code class="sourceCode cpp"><em>qualified-id</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(5.2)</a></span>
 A <code class="sourceCode cpp"><em>pack-index-specifier</em></code> or a
 <code class="sourceCode cpp"><em>pack-index-expression</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(5.3)</a></span>
 The <code class="sourceCode cpp"><em>expression</em></code> of a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code>.</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">(5.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(5.3+)</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(5.4)</a></span>
 A constant template argument or an array bound in which a subexpression
 references a template parameter.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(5.5)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -10696,7 +10750,7 @@ template argument might also be a
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">20</a></span>
 If <code class="sourceCode cpp">P</code> has a form that contains <code class="sourceCode cpp"><span class="op">&lt;</span>i<span class="op">&gt;</span></code>,
 and if the type of <code class="sourceCode cpp">i</code> differs from
 the type of the corresponding template parameter of the template named
@@ -10721,7 +10775,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">10</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb172"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -10739,25 +10793,25 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 the function to be a constant subexpression
 ([defns.const.subexpr]).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">4</a></span>
 […] Next, the semantics of the code sequence are determined by the
 <em>Constraints</em>, <em>Mandates</em>, <span class="addu"><em>Constant
 When</em>,</span> <em>Preconditions</em>, <em>Effects</em>,
@@ -11104,7 +11158,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -11112,7 +11166,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">6a</a></span>
 Let F denote a standard library function or function template. Unless F
 is designated an addressable function, it is unspecified if or how a
 reflection value designating the associated entity can be formed. <span class="note"><span>[ <em>Note 1:</em> </span>For example, it is possible
@@ -11120,14 +11174,14 @@ that <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="
 will not return reflections of standard library functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -11657,11 +11711,11 @@ synopsis</strong></p>
 <span id="cb178-338"><a href="#cb178-338" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb178-339"><a href="#cb178-339" aria-hidden="true" tabindex="-1"></a>  consteval strong_ordering type_order(info a, info b);</span>
 <span id="cb178-340"><a href="#cb178-340" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">1</a></span>
 Unless otherwise specified, each function, and each instantiation of any
 function template, specified in this header is a designated addressable
 function ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">2</a></span>
 The behavior of any function specified in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 implementation-defined when a reflection of a construct not otherwise
@@ -11692,7 +11746,7 @@ definition, the specialization is implicitly instantiated
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">3</a></span>
 Any function in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>
 whose return type is <code class="sourceCode cpp">string_view</code> or
@@ -11707,7 +11761,7 @@ equals <code class="sourceCode cpp"><span class="ch">&#39;</span><span class="sc
 <span id="cb180-4"><a href="#cb180-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>sv <span class="op">==</span> <span class="st">&quot;C&quot;</span><span class="op">)</span>;</span>
 <span id="cb180-5"><a href="#cb180-5" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>sv<span class="op">.</span>data<span class="op">()[</span><span class="dv">0</span><span class="op">]</span> <span class="op">==</span> <span class="ch">&#39;C&#39;</span><span class="op">)</span>;</span>
 <span id="cb180-6"><a href="#cb180-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>sv<span class="op">.</span>data<span class="op">()[</span><span class="dv">1</span><span class="op">]</span> <span class="op">==</span> <span class="ch">&#39;</span><span class="sc">\0</span><span class="ch">&#39;</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">4</a></span>
 Throughout this clause, variables are introduced to designate various
 source constructs. For the purpose of exposition,
 <code class="sourceCode cpp"><span class="op">^^</span><em>E</em></code>
@@ -11728,7 +11782,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb181-2"><a href="#cb181-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb181-3"><a href="#cb181-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb181-4"><a href="#cb181-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">1</a></span>
 This enum class specifies constants used to identify operators that can
 be overloaded, with the meanings listed in Table 1. The values of the
 constants are distinct.</p>
@@ -11981,10 +12035,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb182"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb182-1"><a href="#cb182-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -11992,11 +12046,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb183-2"><a href="#cb183-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">5</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -12011,21 +12065,21 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an entity that has a
 typedef name for linkage purposes ([dcl.typedef]), then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 unnamed entity, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -12033,7 +12087,7 @@ function, then
 and the function is not a constructor, destructor, operator function, or
 conversion function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -12041,30 +12095,30 @@ template, then
 template, operator function template, or conversion function template.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">false</span></code> if the
 declaration of that variable was instantiated from a function parameter
 pack. Otherwise, <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, then
 <code class="sourceCode cpp"><span class="kw">false</span></code> if the
 declaration of that structured binding was instantiated from a
 structured binding pack. Otherwise,
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a type
 alias, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">(1.9)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 enumerator, non-static data member, namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">(1.10)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(1.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">(1.11)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12077,38 +12131,38 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 </ul>
 <div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">2</a></span>
 Let <em>E</em> be UTF-8 if returning a
 <code class="sourceCode cpp">u8string_view</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">4</a></span>
 <em>Returns</em>: An NTMBS, encoded with
 <code class="sourceCode cpp"><em>E</em></code>, determined as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an entity with a
 typedef name for linkage purposes, then that name.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a literal
 operator or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, then the identifier introduced by the declaration of that
 entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>
 or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>,
 respectively.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(4.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12122,21 +12176,21 @@ containing the identifier
 </ul>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a type other than a class type or an enumeration type, the global
 namespace, or a data member description, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity with a definition that is reachable from the
 evaluation context, a value corresponding to a definition should be
@@ -12150,7 +12204,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> <em>has-type</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value, object,
@@ -12159,23 +12213,23 @@ non-static data member, unnamed bit-field, direct base class
 relationship, or data member description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">3</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a value, object,
 variable, function, non-static data member, or unnamed bit-field, then
 the type of what is represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator <code class="sourceCode cpp"><em>N</em></code> of an
 enumeration <code class="sourceCode cpp"><em>E</em></code>, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.2.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is defined by a
 declaration <code class="sourceCode cpp"><em>D</em></code> that is
 reachable from a point <code class="sourceCode cpp"><em>P</em></code> in
@@ -12184,17 +12238,17 @@ the evaluation context and
 <code class="sourceCode cpp"><em>enum-specifier</em></code> of
 <code class="sourceCode cpp"><em>D</em></code>, then a reflection of
 <code class="sourceCode cpp"><em>E</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.2.2)</a></span>
 Otherwise, a reflection of the type of
 <code class="sourceCode cpp"><em>N</em></code> prior to the closing
 brace of the <code class="sourceCode cpp"><em>enum-specifier</em></code>
 as specified in [dcl.enum].</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(3.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then a reflection of the type of the direct
 base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(3.4)</a></span>
 Otherwise, for a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12205,36 +12259,36 @@ a reflection of the type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">(4.1)</a></span>
 an object with static storage duration ([basic.stc.general]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">(4.2)</a></span>
 a variable that either declares or refers to such an object, and if that
 variable is a reference <code class="sourceCode cpp"><em>R</em></code>
 then either
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(4.2.1)</a></span>
 <code class="sourceCode cpp"><em>R</em></code> is usable in constant
 expressions ([expr.const]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(4.2.2)</a></span>
 the lifetime of <code class="sourceCode cpp"><em>R</em></code> began
 within the core constant expression currently under evaluation.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">5</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">(5.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an object, then
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(5.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 reference, then a reflection of the object referred to by that
 reference.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(5.3)</a></span>
 Otherwise (if <code class="sourceCode cpp">r</code> represents any other
 variable), a reflection of the object declared by that variable.</li>
 </ul>
@@ -12250,132 +12304,94 @@ variable), a reflection of the object declared by that variable.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb192"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info value_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">6</a></span>
-Let <code class="sourceCode cpp"><em>Q</em></code> be</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(6.1)</a></span>
-If <code class="sourceCode cpp">r</code> represents a reference, then
-the object referred to by that reference.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(6.2)</a></span>
-Otherwise, if <code class="sourceCode cpp">r</code> represents any other
-variable, then the object declared by that variable.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(6.3)</a></span>
-Otherwise, the construct represented by
-<code class="sourceCode cpp">r</code>.</li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">7</a></span>
-<em>Constant When</em>: <code class="sourceCode cpp"><em>Q</em></code>
-is</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">(7.1)</a></span>
-a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">(7.2)</a></span>
-an enumerator, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">(7.3)</a></span>
-an object such that
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">(7.3.1)</a></span>
-the lifetime of <code class="sourceCode cpp"><em>Q</em></code> has not
-ended,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(7.3.2)</a></span>
-the type of <code class="sourceCode cpp"><em>Q</em></code> is a
-structural type ([temp.param]) that is copyable, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(7.3.3)</a></span>
-either <code class="sourceCode cpp"><em>Q</em></code> is usable in
-constant expressions from some point in the evaluation context or the
-lifetime of <code class="sourceCode cpp"><em>Q</em></code> began within
-the core constant expression currently under evaluation
-([expr.const]).</li>
-</ul></li>
-</ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">8</a></span>
-<em>Returns</em>:</p>
-<ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(8.1)</a></span>
-If <code class="sourceCode cpp"><em>Q</em></code> is an object
-<code class="sourceCode cpp">o</code>, then a reflection of the value
-held by <code class="sourceCode cpp">o</code>. The reflected value has
-the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span>o<span class="op">)</span></code>,
-with the cv-qualifiers removed if this is a scalar type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(8.2)</a></span>
-Otherwise, if <code class="sourceCode cpp"><em>Q</em></code> is an
-enumerator, then a reflection of the value of the enumerator. The
-reflected value has the type represented by <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
-with the cv-qualifiers removed.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(8.3)</a></span>
-Otherwise, <code class="sourceCode cpp">r</code>.</li>
-</ul>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">6</a></span>
+Let <code class="sourceCode cpp"><em>R</em></code> be a constant
+expression of type <code class="sourceCode cpp">info</code> such that
+<code class="sourceCode cpp"><em>R</em> <span class="op">==</span> r</code>
+is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">7</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp"><span class="op">[:</span> <em>R</em> <span class="op">:]</span></code>
+is a valid
+<code class="sourceCode cpp"><em>splice-expression</em></code>
+([expr.prim.splice]).</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">8</a></span>
+<em>Effects</em>: Equivalent to:</p>
+<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_value<span class="op">(</span>r<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> r;</span>
+<span id="cb193-3"><a href="#cb193-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb193-4"><a href="#cb193-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> reflect_value<span class="op">([:</span> <em>R</em> <span class="op">:])</span>;</span>
+<span id="cb193-5"><a href="#cb193-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
-<div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb193-3"><a href="#cb193-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb193-4"><a href="#cb193-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^^</span>x <span class="op">!=</span> <span class="op">^^</span>y<span class="op">)</span>;                        <span class="co">// OK, x and y are different variables so their</span></span>
-<span id="cb193-5"><a href="#cb193-5" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// reflections compare different</span></span>
-<span id="cb193-6"><a href="#cb193-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^^</span>y<span class="op">))</span>;    <span class="co">// OK, both value_of(^^x) and value_of(^^y) represent</span></span>
-<span id="cb193-7"><a href="#cb193-7" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// the value 0</span></span>
-<span id="cb193-8"><a href="#cb193-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span>
-<span id="cb193-9"><a href="#cb193-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb193-10"><a href="#cb193-10" aria-hidden="true" tabindex="-1"></a>info fn<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb193-11"><a href="#cb193-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">42</span>;</span>
-<span id="cb193-12"><a href="#cb193-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">^^</span>x;</span>
-<span id="cb193-13"><a href="#cb193-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb193-14"><a href="#cb193-14" aria-hidden="true" tabindex="-1"></a>info r <span class="op">=</span> value_of<span class="op">(</span>fn<span class="op">())</span>;  <span class="co">// error: x is outside its lifetime</span></span></code></pre></div>
+<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> y <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb194-3"><a href="#cb194-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-4"><a href="#cb194-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(^^</span>x <span class="op">!=</span> <span class="op">^^</span>y<span class="op">)</span>;                        <span class="co">// OK, x and y are different variables so their</span></span>
+<span id="cb194-5"><a href="#cb194-5" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// reflections compare different</span></span>
+<span id="cb194-6"><a href="#cb194-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> value_of<span class="op">(^^</span>y<span class="op">))</span>;    <span class="co">// OK, both value_of(^^x) and value_of(^^y) represent</span></span>
+<span id="cb194-7"><a href="#cb194-7" aria-hidden="true" tabindex="-1"></a>                                                  <span class="co">// the value 0</span></span>
+<span id="cb194-8"><a href="#cb194-8" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>value_of<span class="op">(^^</span>x<span class="op">)</span> <span class="op">==</span> reflect_value<span class="op">(</span><span class="dv">0</span><span class="op">))</span>; <span class="co">// OK, likewise</span></span>
+<span id="cb194-9"><a href="#cb194-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb194-10"><a href="#cb194-10" aria-hidden="true" tabindex="-1"></a>info fn<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb194-11"><a href="#cb194-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">int</span> x <span class="op">=</span> <span class="dv">42</span>;</span>
+<span id="cb194-12"><a href="#cb194-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <span class="op">^^</span>x;</span>
+<span id="cb194-13"><a href="#cb194-13" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb194-14"><a href="#cb194-14" aria-hidden="true" tabindex="-1"></a>info r <span class="op">=</span> value_of<span class="op">(</span>fn<span class="op">())</span>;  <span class="co">// error: x is outside its lifetime</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb194-3"><a href="#cb194-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">9</a></span>
+<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb195-3"><a href="#cb195-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member or
 direct base class relationship that is public, protected, or private,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb195"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">10</a></span>
+<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
 function or a direct base class relationship that is virtual. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">11</a></span>
+<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb197-2"><a href="#cb197-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
 is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">12</a></span>
+<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
 final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">13</a></span>
+<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
 deleted function ([dcl.fct.def.delete]) or defaulted function
 ([dcl.fct.def.default]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb199-2"><a href="#cb199-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">14</a></span>
+<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
 user-provided or user-declared ([dcl.fct.def.default]), respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">15</a></span>
+<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -12389,8 +12405,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">16</a></span>
+<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -12406,8 +12422,8 @@ is still
 <code class="sourceCode cpp"><span class="kw">false</span></code>
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">17</a></span>
+<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -12420,52 +12436,52 @@ description (<code class="sourceCode cpp"><em>T</em></code>,
 for which <code class="sourceCode cpp"><em>W</em></code> is not ⊥.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">18</a></span>
+<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb204-2"><a href="#cb204-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">19</a></span>
+<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb205-2"><a href="#cb205-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">19</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a const or
 volatile type, respectively, or a const- or volatile-qualified function
 type, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">21</a></span>
+<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
 <code class="sourceCode cpp"><span class="kw">mutable</span></code>
 non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">22</a></span>
+<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">22</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a lvalue- or
 rvalue-reference qualified function type, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb207-2"><a href="#cb207-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb207-3"><a href="#cb207-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">24</a></span>
+<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb208-3"><a href="#cb208-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -12474,12 +12490,12 @@ that has static, thread, or automatic storage duration, respectively
 <code class="sourceCode cpp"><span class="kw">false</span></code>. <span class="note"><span>[ <em>Note 3:</em> </span>It is not possible to have
 a reflection representing an object or variable having dynamic storage
 duration.<span> — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb208-3"><a href="#cb208-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb208-4"><a href="#cb208-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_c_language_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb208-5"><a href="#cb208-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">25</a></span>
+<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_internal_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_module_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb209-3"><a href="#cb209-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb209-4"><a href="#cb209-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_c_language_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb209-5"><a href="#cb209-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -12487,8 +12503,8 @@ type, template, or namespace whose name has internal linkage, module
 linkage, external linkage, C language linkage, or any linkage,
 respectively ([basic.link]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">26</a></span>
+<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -12497,16 +12513,16 @@ there is some point in the evaluation context from which the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb210"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerable_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">27</a></span>
+<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerable_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">27</a></span>
 A type <code class="sourceCode cpp"><em>T</em></code> is
 <em>enumerable</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">(27.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(27.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a class type complete
 at <code class="sourceCode cpp"><em>P</em></code> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">(27.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(27.2)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is an enumeration type
 defined by a declaration <code class="sourceCode cpp"><em>D</em></code>
 such that <code class="sourceCode cpp"><em>D</em></code> is reachable
@@ -12515,7 +12531,7 @@ from <code class="sourceCode cpp"><em>P</em></code> but
 <code class="sourceCode cpp"><em>enum-specifier</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> ([dcl.enum]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">28</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
@@ -12524,43 +12540,43 @@ context. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="example">
 <span>[ <em>Example 3:</em> </span>
-<div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S;</span>
-<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E;</span>
-<span id="cb211-3"><a href="#cb211-3" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb211-4"><a href="#cb211-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
-<span id="cb211-5"><a href="#cb211-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb211-6"><a href="#cb211-6" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S <span class="op">{</span></span>
-<span id="cb211-7"><a href="#cb211-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> mfn<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb211-8"><a href="#cb211-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb211-9"><a href="#cb211-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb211-10"><a href="#cb211-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb211-11"><a href="#cb211-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb211-12"><a href="#cb211-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
-<span id="cb211-13"><a href="#cb211-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb211-14"><a href="#cb211-14" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E <span class="op">{</span></span>
-<span id="cb211-15"><a href="#cb211-15" aria-hidden="true" tabindex="-1"></a>  A <span class="op">=</span> is_enumerable_type<span class="op">(^^</span>E<span class="op">)</span> <span class="op">?</span> <span class="dv">1</span> <span class="op">:</span> <span class="dv">2</span></span>
-<span id="cb211-16"><a href="#cb211-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb211-17"><a href="#cb211-17" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
-<span id="cb211-18"><a href="#cb211-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span><span class="kw">static_cast</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;(</span>E<span class="op">::</span>A<span class="op">)</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S;</span>
+<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E;</span>
+<span id="cb212-3"><a href="#cb212-3" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb212-4"><a href="#cb212-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
+<span id="cb212-5"><a href="#cb212-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb212-6"><a href="#cb212-6" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> S <span class="op">{</span></span>
+<span id="cb212-7"><a href="#cb212-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">void</span> mfn<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb212-8"><a href="#cb212-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb212-9"><a href="#cb212-9" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb212-10"><a href="#cb212-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">static_assert</span><span class="op">(!</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb212-11"><a href="#cb212-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb212-12"><a href="#cb212-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>S<span class="op">))</span>;</span>
+<span id="cb212-13"><a href="#cb212-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb212-14"><a href="#cb212-14" aria-hidden="true" tabindex="-1"></a><span class="kw">enum</span> <span class="kw">class</span> E <span class="op">{</span></span>
+<span id="cb212-15"><a href="#cb212-15" aria-hidden="true" tabindex="-1"></a>  A <span class="op">=</span> is_enumerable_type<span class="op">(^^</span>E<span class="op">)</span> <span class="op">?</span> <span class="dv">1</span> <span class="op">:</span> <span class="dv">2</span></span>
+<span id="cb212-16"><a href="#cb212-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb212-17"><a href="#cb212-17" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_enumerable_type<span class="op">(^^</span>E<span class="op">))</span>;</span>
+<span id="cb212-18"><a href="#cb212-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span><span class="kw">static_cast</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;(</span>E<span class="op">::</span>A<span class="op">)</span> <span class="op">==</span> <span class="dv">2</span><span class="op">)</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">29</a></span>
+<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb213"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">30</a></span>
+<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity whose
 underlying entity is a type or namespace, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">31</a></span>
+<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias or
@@ -12568,32 +12584,32 @@ namespace alias, respectively <span class="note"><span>[ <em>Note
 4:</em> </span>A specialization of an alias template is a type
 alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">32</a></span>
+<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb216-3"><a href="#cb216-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">33</a></span>
+<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb217-3"><a href="#cb217-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
 conversion function ([class.conv.fct]), operator function ([over.oper]),
 or literal operator ([over.literal]), respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-3"><a href="#cb217-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-4"><a href="#cb217-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-5"><a href="#cb217-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-6"><a href="#cb217-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-7"><a href="#cb217-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-8"><a href="#cb217-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb217-9"><a href="#cb217-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">34</a></span>
+<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_special_member_function<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-4"><a href="#cb218-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-5"><a href="#cb218-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructor<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-6"><a href="#cb218-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb218-9"><a href="#cb218-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12602,15 +12618,15 @@ constructor, a copy constructor, a move constructor, an assignment
 operator, a copy assignment operator, a move assignment operator, or a
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">35</a></span>
+<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">35</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">36</a></span>
 <span class="note"><span>[ <em>Note 5:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -12618,16 +12634,16 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code> but
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb219"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">37</a></span>
+<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_alias_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-8"><a href="#cb220-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb220-9"><a href="#cb220-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">37</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -12635,100 +12651,100 @@ variable template, class template, alias template, conversion function
 template, operator function template, literal operator template,
 constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">38</a></span>
+<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">38</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb221"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">39</a></span>
+<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">39</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb222-3"><a href="#cb222-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb222-4"><a href="#cb222-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
-<span id="cb222-5"><a href="#cb222-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">40</a></span>
+<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb223-3"><a href="#cb223-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb223-4"><a href="#cb223-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
+<span id="cb223-5"><a href="#cb223-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">40</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
 namespace member, non-static data member, static member, or direct base
 class relationship, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">41</a></span>
+<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">41</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb224"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_parent<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">42</a></span>
+<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_parent<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">42</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">(42.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">(42.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents the global
 namespace, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">(42.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">(42.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 that has C language linkage ([dcl.link]), then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">(42.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(42.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 that has a language linkage other than C++ language linkage, then an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">(42.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(42.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a type
 that is neither a class nor enumeration type, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">(42.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(42.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 or direct base class relationship, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">(42.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(42.6)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
-<div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">43</a></span>
+<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">43</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_parent<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">44</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">44</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">(44.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(44.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member that is a direct member of an anonymous union, or an unnamed
 bit-field declared within the
 <code class="sourceCode cpp"><em>member-specification</em></code> of
 such a union, then a reflection representing the innermost enclosing
 anonymous union.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">(44.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(44.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator, then a reflection representing the corresponding enumeration
 type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">(44.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(44.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship between a class
 <code class="sourceCode cpp"><em>D</em></code> and a direct base class
 <code class="sourceCode cpp"><em>B</em></code>, then a reflection
 representing <code class="sourceCode cpp"><em>D</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">(44.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(44.4)</a></span>
 Otherwise, let <code class="sourceCode cpp"><em>E</em></code> be the
 class, function, or namespace whose class scope, function parameter
 scope, or namespace scope is, respectively, the innermost such scope
 that either is, or encloses, the target scope of a declaration of what
 is represented by <code class="sourceCode cpp">r</code>.
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">(44.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">(44.5)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is the function call
 operator of a closure type for a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
@@ -12738,71 +12754,71 @@ first <code class="sourceCode cpp">parent_of</code> will be the closure
 type, so the second <code class="sourceCode cpp">parent_of</code> is
 necessary to give the parent of that closure type.<span> — <em>end
 note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">(44.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">(44.6)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="op">^^</span><em>E</em></code>.</li>
 </ul></li>
 </ul>
 <div class="example">
 <span>[ <em>Example 4:</em> </span>
-<div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> I <span class="op">{</span> <span class="op">}</span>;</span>
-<span id="cb226-2"><a href="#cb226-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb226-3"><a href="#cb226-3" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> F <span class="op">:</span> I <span class="op">{</span></span>
-<span id="cb226-4"><a href="#cb226-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">union</span> <span class="op">{</span></span>
-<span id="cb226-5"><a href="#cb226-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> o;</span>
-<span id="cb226-6"><a href="#cb226-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
-<span id="cb226-7"><a href="#cb226-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb226-8"><a href="#cb226-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">enum</span> N <span class="op">{</span></span>
-<span id="cb226-9"><a href="#cb226-9" aria-hidden="true" tabindex="-1"></a>    A</span>
-<span id="cb226-10"><a href="#cb226-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb226-11"><a href="#cb226-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb226-12"><a href="#cb226-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb226-13"><a href="#cb226-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
-<span id="cb226-14"><a href="#cb226-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb226-15"><a href="#cb226-15" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">)</span> <span class="op">==</span> <span class="op">^^::)</span>;</span>
-<span id="cb226-16"><a href="#cb226-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(</span>bases_of<span class="op">(^^</span>F, ctx<span class="op">)[</span><span class="dv">0</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span>F<span class="op">)</span>;</span>
-<span id="cb226-17"><a href="#cb226-17" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_union_type<span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">::</span>o<span class="op">)))</span>;</span>
-<span id="cb226-18"><a href="#cb226-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">::</span>N<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>F<span class="op">)</span>;</span>
-<span id="cb226-19"><a href="#cb226-19" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">::</span>A<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>F<span class="op">::</span>N<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> I <span class="op">{</span> <span class="op">}</span>;</span>
+<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb227-3"><a href="#cb227-3" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> F <span class="op">:</span> I <span class="op">{</span></span>
+<span id="cb227-4"><a href="#cb227-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">union</span> <span class="op">{</span></span>
+<span id="cb227-5"><a href="#cb227-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> o;</span>
+<span id="cb227-6"><a href="#cb227-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
+<span id="cb227-7"><a href="#cb227-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb227-8"><a href="#cb227-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">enum</span> N <span class="op">{</span></span>
+<span id="cb227-9"><a href="#cb227-9" aria-hidden="true" tabindex="-1"></a>    A</span>
+<span id="cb227-10"><a href="#cb227-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb227-11"><a href="#cb227-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb227-12"><a href="#cb227-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb227-13"><a href="#cb227-13" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb227-14"><a href="#cb227-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb227-15"><a href="#cb227-15" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">)</span> <span class="op">==</span> <span class="op">^^::)</span>;</span>
+<span id="cb227-16"><a href="#cb227-16" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(</span>bases_of<span class="op">(^^</span>F, ctx<span class="op">)[</span><span class="dv">0</span><span class="op">])</span> <span class="op">==</span> <span class="op">^^</span>F<span class="op">)</span>;</span>
+<span id="cb227-17"><a href="#cb227-17" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_union_type<span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">::</span>o<span class="op">)))</span>;</span>
+<span id="cb227-18"><a href="#cb227-18" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">::</span>N<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>F<span class="op">)</span>;</span>
+<span id="cb227-19"><a href="#cb227-19" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>parent_of<span class="op">(^^</span>F<span class="op">::</span>A<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>F<span class="op">::</span>N<span class="op">)</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">45</a></span>
+<div class="sourceCode" id="cb228"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">46</a></span>
 <em>Returns</em>: A reflection representing the underlying entity of
 what <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 5:</em> </span>
-<div class="sourceCode" id="cb228"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
-<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
-<span id="cb228-3"><a href="#cb228-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^^int) == ^^int);</span>
-<span id="cb228-4"><a href="#cb228-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^^X) == ^^int);</span>
-<span id="cb228-5"><a href="#cb228-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^^Y) == ^^int);</span></code></pre></div>
+<div class="sourceCode" id="cb229"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
+<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a>using Y = X;</span>
+<span id="cb229-3"><a href="#cb229-3" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^^int) == ^^int);</span>
+<span id="cb229-4"><a href="#cb229-4" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^^X) == ^^int);</span>
+<span id="cb229-5"><a href="#cb229-5" aria-hidden="true" tabindex="-1"></a>static_assert(dealias(^^Y) == ^^int);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">48</a></span>
+<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">48</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
 function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb230"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">49</a></span>
+<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">49</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">50</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">50</a></span>
 <em>Returns</em>: A reflection of the primary template of the
 specialization represented by <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">51</a></span>
+<div class="sourceCode" id="cb232"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">51</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">52</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">52</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of the template arguments of the template
 specialization represented by <code class="sourceCode cpp">r</code>, in
@@ -12812,7 +12828,7 @@ its corresponding reflection
 <code class="sourceCode cpp"><em>R</em></code> is determined as
 follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(52.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(52.1)</a></span>
 If <code class="sourceCode cpp"><em>A</em></code> denotes a type or a
 type alias, then <code class="sourceCode cpp"><em>R</em></code> is a
 reflection representing the underlying entity of
@@ -12820,27 +12836,27 @@ reflection representing the underlying entity of
 </span><code class="sourceCode cpp"><em>R</em></code> always represents
 a type, never a type alias.<span> — <em>end
 note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(52.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(52.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>A</em></code> denotes a
 class template, variable template, concept, or alias template, then
 <code class="sourceCode cpp"><em>R</em></code> is a reflection
 representing <code class="sourceCode cpp"><em>A</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(52.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(52.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>A</em></code> is a constant
 template argument ([temp.arg.nontype]). Let
 <code class="sourceCode cpp"><em>P</em></code> be the corresponding
 template parameter.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(52.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(52.3.1)</a></span>
 If <code class="sourceCode cpp"><em>P</em></code> has reference type,
 then <code class="sourceCode cpp"><em>R</em></code> is a reflection
 representing the object referred to by
 <code class="sourceCode cpp"><em>A</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">(52.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">(52.3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>P</em></code> has class
 type, then <code class="sourceCode cpp"><em>R</em></code> represents the
 corresponding template parameter object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">(52.3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(52.3.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> is a
 reflection representing the value computed by
 <code class="sourceCode cpp"><em>A</em></code>.</li>
@@ -12848,27 +12864,27 @@ reflection representing the value computed by
 </ul>
 <div class="example">
 <span>[ <em>Example 6:</em> </span>
-<div class="sourceCode" id="cb232"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
-<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; struct Pair&lt;char, T&gt; { };</span>
-<span id="cb232-3"><a href="#cb232-3" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
-<span id="cb232-4"><a href="#cb232-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb232-5"><a href="#cb232-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^^Pair&lt;int&gt;) == ^^Pair);</span>
-<span id="cb232-6"><a href="#cb232-6" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^^Pair&lt;char, char&gt;) == ^^Pair);</span>
-<span id="cb232-7"><a href="#cb232-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^^Pair&lt;int&gt;).size() == 2);</span>
-<span id="cb232-8"><a href="#cb232-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^^Pair&lt;int&gt;)[0] == ^^int);</span>
-<span id="cb232-9"><a href="#cb232-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb232-10"><a href="#cb232-10" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^^PairPtr&lt;int&gt;) == ^^PairPtr);</span>
-<span id="cb232-11"><a href="#cb232-11" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^^PairPtr&lt;int&gt;).size() == 1);</span>
-<span id="cb232-12"><a href="#cb232-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb232-13"><a href="#cb232-13" aria-hidden="true" tabindex="-1"></a>struct S { };</span>
-<span id="cb232-14"><a href="#cb232-14" aria-hidden="true" tabindex="-1"></a>int i;</span>
-<span id="cb232-15"><a href="#cb232-15" aria-hidden="true" tabindex="-1"></a>template &lt;int, int&amp;, S, template &lt;class&gt; class&gt;</span>
-<span id="cb232-16"><a href="#cb232-16" aria-hidden="true" tabindex="-1"></a>struct X { };</span>
-<span id="cb232-17"><a href="#cb232-17" aria-hidden="true" tabindex="-1"></a>constexpr auto T = ^^X&lt;1, i, S{}, PairPtr&gt;;</span>
-<span id="cb232-18"><a href="#cb232-18" aria-hidden="true" tabindex="-1"></a>static_assert(is_value(template_arguments_of(T)[0]));</span>
-<span id="cb232-19"><a href="#cb232-19" aria-hidden="true" tabindex="-1"></a>static_assert(is_object(template_arguments_of(T)[1]));</span>
-<span id="cb232-20"><a href="#cb232-20" aria-hidden="true" tabindex="-1"></a>static_assert(is_object(template_arguments_of(T)[2]));</span>
-<span id="cb232-21"><a href="#cb232-21" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(T)[3] == ^^PairPtr);</span></code></pre></div>
+<div class="sourceCode" id="cb233"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a>template &lt;class T, class U=T&gt; struct Pair { };</span>
+<span id="cb233-2"><a href="#cb233-2" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; struct Pair&lt;char, T&gt; { };</span>
+<span id="cb233-3"><a href="#cb233-3" aria-hidden="true" tabindex="-1"></a>template &lt;class T&gt; using PairPtr = Pair&lt;T*&gt;;</span>
+<span id="cb233-4"><a href="#cb233-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb233-5"><a href="#cb233-5" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^^Pair&lt;int&gt;) == ^^Pair);</span>
+<span id="cb233-6"><a href="#cb233-6" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^^Pair&lt;char, char&gt;) == ^^Pair);</span>
+<span id="cb233-7"><a href="#cb233-7" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^^Pair&lt;int&gt;).size() == 2);</span>
+<span id="cb233-8"><a href="#cb233-8" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^^Pair&lt;int&gt;)[0] == ^^int);</span>
+<span id="cb233-9"><a href="#cb233-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb233-10"><a href="#cb233-10" aria-hidden="true" tabindex="-1"></a>static_assert(template_of(^^PairPtr&lt;int&gt;) == ^^PairPtr);</span>
+<span id="cb233-11"><a href="#cb233-11" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(^^PairPtr&lt;int&gt;).size() == 1);</span>
+<span id="cb233-12"><a href="#cb233-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb233-13"><a href="#cb233-13" aria-hidden="true" tabindex="-1"></a>struct S { };</span>
+<span id="cb233-14"><a href="#cb233-14" aria-hidden="true" tabindex="-1"></a>int i;</span>
+<span id="cb233-15"><a href="#cb233-15" aria-hidden="true" tabindex="-1"></a>template &lt;int, int&amp;, S, template &lt;class&gt; class&gt;</span>
+<span id="cb233-16"><a href="#cb233-16" aria-hidden="true" tabindex="-1"></a>struct X { };</span>
+<span id="cb233-17"><a href="#cb233-17" aria-hidden="true" tabindex="-1"></a>constexpr auto T = ^^X&lt;1, i, S{}, PairPtr&gt;;</span>
+<span id="cb233-18"><a href="#cb233-18" aria-hidden="true" tabindex="-1"></a>static_assert(is_value(template_arguments_of(T)[0]));</span>
+<span id="cb233-19"><a href="#cb233-19" aria-hidden="true" tabindex="-1"></a>static_assert(is_object(template_arguments_of(T)[1]));</span>
+<span id="cb233-20"><a href="#cb233-20" aria-hidden="true" tabindex="-1"></a>static_assert(is_object(template_arguments_of(T)[2]));</span>
+<span id="cb233-21"><a href="#cb233-21" aria-hidden="true" tabindex="-1"></a>static_assert(template_arguments_of(T)[3] == ^^PairPtr);</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -12879,26 +12895,26 @@ Access control context<a href="#meta.reflection.access.context-access-control-co
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">1</a></span>
 The <code class="sourceCode cpp">access_context</code> class is a
 non-aggregate type that represents a namespace, class, or function from
 which queries pertaining to access rules may be performed, as well as
 the naming class ([class.access.base]), if any.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">2</a></span>
 An <code class="sourceCode cpp">access_context</code> has an associated
 scope and naming class.</p>
-<div class="sourceCode" id="cb233"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> access_context <span class="op">{</span></span>
-<span id="cb233-2"><a href="#cb233-2" aria-hidden="true" tabindex="-1"></a>   access_context<span class="op">()</span> <span class="op">=</span> <span class="kw">delete</span>;</span>
-<span id="cb233-3"><a href="#cb233-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb233-4"><a href="#cb233-4" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> info scope<span class="op">()</span> <span class="kw">const</span>;</span>
-<span id="cb233-5"><a href="#cb233-5" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> info naming_class<span class="op">()</span> <span class="kw">const</span>;</span>
-<span id="cb233-6"><a href="#cb233-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb233-7"><a href="#cb233-7" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context current<span class="op">()</span> <span class="kw">noexcept</span>;</span>
-<span id="cb233-8"><a href="#cb233-8" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context unprivileged<span class="op">()</span> <span class="kw">noexcept</span>;</span>
-<span id="cb233-9"><a href="#cb233-9" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span>
-<span id="cb233-10"><a href="#cb233-10" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span>
-<span id="cb233-11"><a href="#cb233-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">3</a></span>
+<div class="sourceCode" id="cb234"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> access_context <span class="op">{</span></span>
+<span id="cb234-2"><a href="#cb234-2" aria-hidden="true" tabindex="-1"></a>   access_context<span class="op">()</span> <span class="op">=</span> <span class="kw">delete</span>;</span>
+<span id="cb234-3"><a href="#cb234-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb234-4"><a href="#cb234-4" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> info scope<span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb234-5"><a href="#cb234-5" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> info naming_class<span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb234-6"><a href="#cb234-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb234-7"><a href="#cb234-7" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context current<span class="op">()</span> <span class="kw">noexcept</span>;</span>
+<span id="cb234-8"><a href="#cb234-8" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context unprivileged<span class="op">()</span> <span class="kw">noexcept</span>;</span>
+<span id="cb234-9"><a href="#cb234-9" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span>
+<span id="cb234-10"><a href="#cb234-10" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span>
+<span id="cb234-11"><a href="#cb234-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">3</a></span>
 <code class="sourceCode cpp">access_context</code> is a structural type.
 Two values <code class="sourceCode cpp">ac1</code> and
 <code class="sourceCode cpp">ac2</code> of type
@@ -12908,22 +12924,22 @@ and <code class="sourceCode cpp">ac2<span class="op">.</span>scope<span class="o
 are template-argument-equivalent and <code class="sourceCode cpp">ac1<span class="op">.</span>naming_class<span class="op">()</span></code>
 and <code class="sourceCode cpp">ac2<span class="op">.</span>naming_class<span class="op">()</span></code>
 are template-argument-equivalent.</p>
-<div class="sourceCode" id="cb234"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info scope<span class="op">()</span> <span class="kw">const</span>;</span>
-<span id="cb234-2"><a href="#cb234-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info naming_class<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">4</a></span>
+<div class="sourceCode" id="cb235"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb235-1"><a href="#cb235-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info scope<span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb235-2"><a href="#cb235-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info naming_class<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">4</a></span>
 <em>Returns</em>: The
 <code class="sourceCode cpp">access_context</code>’s associated scope
 and naming class, respectively.</p>
-<div class="sourceCode" id="cb235"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb235-1"><a href="#cb235-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context current<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">5</a></span>
+<div class="sourceCode" id="cb236"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb236-1"><a href="#cb236-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context current<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">5</a></span>
 <code class="sourceCode cpp">current</code> is not an addressable
 function ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">6</a></span>
 Given a program point <code class="sourceCode cpp"><em>P</em></code>,
 let <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
 be the following program point:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(6.1)</a></span>
 If a potentially-evaluated subexpression ([intro.execution]) of a
 default member initializer
 <code class="sourceCode cpp"><em>I</em></code> for a member of a class
@@ -12931,27 +12947,27 @@ default member initializer
 appears at <code class="sourceCode cpp"><em>P</em></code>, then a point
 determined as follows:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">(6.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(6.1.1)</a></span>
 If <code class="sourceCode cpp"><em>I</em></code> is being used by an
 aggregate initialization that appears at point
 <code class="sourceCode cpp"><em>Q</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(6.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(6.1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>I</em></code> is being
 used for an initialization by an inherited constructor
 ([class.inhctor.init]), a point whose immediate scope is the class scope
 corresponding to <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(6.1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(6.1.3)</a></span>
 Otherwise, a point whose immediate scope is the function parameter scope
 corresponding to the constructor definition that is using
 <code class="sourceCode cpp"><em>I</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(6.2)</a></span>
 Otherwise, if a potentially-evaluated subexpression of a default
 argument ([dcl.fct.default]) appears at
 <code class="sourceCode cpp"><em>P</em></code>, and that default
 argument is being used by an invocation of a function ([expr.call]) that
 appears at point <code class="sourceCode cpp"><em>Q</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">(6.3)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a function parameter
 scope introduced by a declaration
@@ -12963,7 +12979,7 @@ trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
 scope is the innermost scope enclosing the locus of
 <code class="sourceCode cpp"><em>D</em></code> that is not a template
 parameter scope.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">(6.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">(6.4)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a function parameter
 scope introduced by a
@@ -12975,7 +12991,7 @@ at point <code class="sourceCode cpp"><em>Q</em></code>, and
 <code class="sourceCode cpp"><em>trailing-return-type</em></code> or the
 trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
 <code class="sourceCode cpp"><em>L</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(6.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(6.5)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a block scope and the
 innermost function parameter scope enclosing
@@ -12984,41 +13000,41 @@ innermost function parameter scope enclosing
 <code class="sourceCode cpp"><em>D</em></code> ([dcl.pre]), a point
 whose immediate scope is the scope inhabited by
 <code class="sourceCode cpp"><em>D</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(6.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(6.6)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>P</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">7</a></span>
 Given a scope <code class="sourceCode cpp"><em>S</em></code>, let <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="op">)</span></code>
 be the following scope:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(7.1)</a></span>
 If <code class="sourceCode cpp"><em>S</em></code> is a class scope or a
 namespace scope, <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">(7.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a lambda
 scope introduced by a
 <code class="sourceCode cpp"><em>lambda-expression</em></code>
 <code class="sourceCode cpp"><em>L</em></code>, the function parameter
 scope corresponding to the call operator of the closure type for
 <code class="sourceCode cpp"><em>L</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">(7.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 function parameter scope introduced by the declaration of a function,
 <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">(7.4)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="ch">&#39;)</span></code>
 where
 <code class="sourceCode cpp"><em>S</em><span class="ch">&#39;</span></code>
 is the parent scope of
 <code class="sourceCode cpp"><em>S</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">8</a></span>
 An invocation of <code class="sourceCode cpp">current</code> that
 appears at a program point
 <code class="sourceCode cpp"><em>P</em></code> is value-dependent
 ([temp.dep.contexpr]) if <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
 is enclosed by a scope corresponding to a templated entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">9</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class is the null reflection and whose scope represents the
 function, class, or namespace whose corresponding function parameter
@@ -13030,58 +13046,58 @@ the invocation of <code class="sourceCode cpp">current</code> lexically
 appears.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb236"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb236-1"><a href="#cb236-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> A <span class="op">{</span></span>
-<span id="cb236-2"><a href="#cb236-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> a <span class="op">=</span> <span class="dv">0</span>;</span>
-<span id="cb236-3"><a href="#cb236-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> A<span class="op">(</span><span class="dt">int</span> p<span class="op">)</span> <span class="op">:</span> a<span class="op">(</span>p<span class="op">)</span> <span class="op">{}</span></span>
-<span id="cb236-4"><a href="#cb236-4" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb236-5"><a href="#cb236-5" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> B <span class="op">:</span> A <span class="op">{</span></span>
-<span id="cb236-6"><a href="#cb236-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> A<span class="op">::</span>A;</span>
-<span id="cb236-7"><a href="#cb236-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> B<span class="op">(</span><span class="dt">int</span> p, <span class="dt">int</span> q<span class="op">)</span> <span class="op">:</span> A<span class="op">(</span>p <span class="op">*</span> q<span class="op">)</span> <span class="op">{}</span></span>
-<span id="cb236-8"><a href="#cb236-8" aria-hidden="true" tabindex="-1"></a>  info s <span class="op">=</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">()</span>;</span>
-<span id="cb236-9"><a href="#cb236-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb236-10"><a href="#cb236-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb236-11"><a href="#cb236-11" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Agg <span class="op">{</span></span>
-<span id="cb236-12"><a href="#cb236-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="dt">bool</span> eq<span class="op">(</span>info rhs <span class="op">=</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">())</span> <span class="op">{</span></span>
-<span id="cb236-13"><a href="#cb236-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> s <span class="op">==</span> rhs;</span>
-<span id="cb236-14"><a href="#cb236-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb236-15"><a href="#cb236-15" aria-hidden="true" tabindex="-1"></a>  info s <span class="op">=</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">()</span>;</span>
-<span id="cb236-16"><a href="#cb236-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb236-17"><a href="#cb236-17" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb236-18"><a href="#cb236-18" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> NS <span class="op">{</span></span>
-<span id="cb236-19"><a href="#cb236-19" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>Agg<span class="op">{}.</span>s <span class="op">==</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">())</span>;  <span class="co">// OK</span></span>
-<span id="cb236-20"><a href="#cb236-20" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>Agg<span class="op">{}.</span>eq<span class="op">())</span>;  <span class="co">// OK</span></span>
-<span id="cb236-21"><a href="#cb236-21" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>B<span class="op">(</span><span class="dv">1</span><span class="op">).</span>s <span class="op">==</span> <span class="op">^^</span>B<span class="op">)</span>;  <span class="co">// OK</span></span>
-<span id="cb236-22"><a href="#cb236-22" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_constructor<span class="op">(</span>B<span class="op">{</span><span class="dv">1</span>, <span class="dv">2</span><span class="op">}.</span>s<span class="op">)</span> <span class="op">&amp;&amp;</span> parent_of<span class="op">(</span>B<span class="op">{</span><span class="dv">1</span>, <span class="dv">2</span><span class="op">}.</span>s<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>B<span class="op">)</span>;  <span class="co">// OK</span></span>
-<span id="cb236-23"><a href="#cb236-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb236-24"><a href="#cb236-24" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> fn<span class="op">()</span> <span class="op">-&gt;</span> <span class="op">[:</span>is_namespace<span class="op">(</span>access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">())</span> <span class="op">?</span> <span class="op">^^</span><span class="dt">int</span> <span class="op">:</span> <span class="op">^^</span><span class="dt">bool</span><span class="op">:]</span>;</span>
-<span id="cb236-25"><a href="#cb236-25" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(^^</span>fn<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span><span class="kw">auto</span><span class="op">()-&gt;</span><span class="dt">int</span><span class="op">)</span>;  <span class="co">// OK</span></span>
-<span id="cb236-26"><a href="#cb236-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb236-27"><a href="#cb236-27" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> R<span class="op">&gt;</span></span>
-<span id="cb236-28"><a href="#cb236-28" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> TCls <span class="op">{</span></span>
-<span id="cb236-29"><a href="#cb236-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="dt">bool</span> fn<span class="op">()</span></span>
-<span id="cb236-30"><a href="#cb236-30" aria-hidden="true" tabindex="-1"></a>    <span class="kw">requires</span> <span class="op">(</span>is_type<span class="op">(</span>access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">()))</span> <span class="op">{</span></span>
-<span id="cb236-31"><a href="#cb236-31" aria-hidden="true" tabindex="-1"></a>      <span class="co">// OK, scope is &#39;TCls&lt;R&gt;&#39;.</span></span>
-<span id="cb236-32"><a href="#cb236-32" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="kw">true</span>;</span>
-<span id="cb236-33"><a href="#cb236-33" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
-<span id="cb236-34"><a href="#cb236-34" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb236-35"><a href="#cb236-35" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>TCls<span class="op">&lt;</span><span class="dv">0</span><span class="op">&gt;{}.</span>fn<span class="op">())</span>;  <span class="co">// OK</span></span>
-<span id="cb236-36"><a href="#cb236-36" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb237"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb237-1"><a href="#cb237-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> A <span class="op">{</span></span>
+<span id="cb237-2"><a href="#cb237-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> a <span class="op">=</span> <span class="dv">0</span>;</span>
+<span id="cb237-3"><a href="#cb237-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> A<span class="op">(</span><span class="dt">int</span> p<span class="op">)</span> <span class="op">:</span> a<span class="op">(</span>p<span class="op">)</span> <span class="op">{}</span></span>
+<span id="cb237-4"><a href="#cb237-4" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb237-5"><a href="#cb237-5" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> B <span class="op">:</span> A <span class="op">{</span></span>
+<span id="cb237-6"><a href="#cb237-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">using</span> A<span class="op">::</span>A;</span>
+<span id="cb237-7"><a href="#cb237-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> B<span class="op">(</span><span class="dt">int</span> p, <span class="dt">int</span> q<span class="op">)</span> <span class="op">:</span> A<span class="op">(</span>p <span class="op">*</span> q<span class="op">)</span> <span class="op">{}</span></span>
+<span id="cb237-8"><a href="#cb237-8" aria-hidden="true" tabindex="-1"></a>  info s <span class="op">=</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">()</span>;</span>
+<span id="cb237-9"><a href="#cb237-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb237-10"><a href="#cb237-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb237-11"><a href="#cb237-11" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> Agg <span class="op">{</span></span>
+<span id="cb237-12"><a href="#cb237-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="dt">bool</span> eq<span class="op">(</span>info rhs <span class="op">=</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">())</span> <span class="op">{</span></span>
+<span id="cb237-13"><a href="#cb237-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> s <span class="op">==</span> rhs;</span>
+<span id="cb237-14"><a href="#cb237-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb237-15"><a href="#cb237-15" aria-hidden="true" tabindex="-1"></a>  info s <span class="op">=</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">()</span>;</span>
+<span id="cb237-16"><a href="#cb237-16" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb237-17"><a href="#cb237-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb237-18"><a href="#cb237-18" aria-hidden="true" tabindex="-1"></a><span class="kw">namespace</span> NS <span class="op">{</span></span>
+<span id="cb237-19"><a href="#cb237-19" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>Agg<span class="op">{}.</span>s <span class="op">==</span> access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">())</span>;  <span class="co">// OK</span></span>
+<span id="cb237-20"><a href="#cb237-20" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>Agg<span class="op">{}.</span>eq<span class="op">())</span>;  <span class="co">// OK</span></span>
+<span id="cb237-21"><a href="#cb237-21" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>B<span class="op">(</span><span class="dv">1</span><span class="op">).</span>s <span class="op">==</span> <span class="op">^^</span>B<span class="op">)</span>;  <span class="co">// OK</span></span>
+<span id="cb237-22"><a href="#cb237-22" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_constructor<span class="op">(</span>B<span class="op">{</span><span class="dv">1</span>, <span class="dv">2</span><span class="op">}.</span>s<span class="op">)</span> <span class="op">&amp;&amp;</span> parent_of<span class="op">(</span>B<span class="op">{</span><span class="dv">1</span>, <span class="dv">2</span><span class="op">}.</span>s<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>B<span class="op">)</span>;  <span class="co">// OK</span></span>
+<span id="cb237-23"><a href="#cb237-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb237-24"><a href="#cb237-24" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> fn<span class="op">()</span> <span class="op">-&gt;</span> <span class="op">[:</span>is_namespace<span class="op">(</span>access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">())</span> <span class="op">?</span> <span class="op">^^</span><span class="dt">int</span> <span class="op">:</span> <span class="op">^^</span><span class="dt">bool</span><span class="op">:]</span>;</span>
+<span id="cb237-25"><a href="#cb237-25" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>type_of<span class="op">(^^</span>fn<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span><span class="kw">auto</span><span class="op">()-&gt;</span><span class="dt">int</span><span class="op">)</span>;  <span class="co">// OK</span></span>
+<span id="cb237-26"><a href="#cb237-26" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb237-27"><a href="#cb237-27" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> R<span class="op">&gt;</span></span>
+<span id="cb237-28"><a href="#cb237-28" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> TCls <span class="op">{</span></span>
+<span id="cb237-29"><a href="#cb237-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> <span class="dt">bool</span> fn<span class="op">()</span></span>
+<span id="cb237-30"><a href="#cb237-30" aria-hidden="true" tabindex="-1"></a>    <span class="kw">requires</span> <span class="op">(</span>is_type<span class="op">(</span>access_context<span class="op">::</span>current<span class="op">().</span>scope<span class="op">()))</span> <span class="op">{</span></span>
+<span id="cb237-31"><a href="#cb237-31" aria-hidden="true" tabindex="-1"></a>      <span class="co">// OK, scope is &#39;TCls&lt;R&gt;&#39;.</span></span>
+<span id="cb237-32"><a href="#cb237-32" aria-hidden="true" tabindex="-1"></a>      <span class="cf">return</span> <span class="kw">true</span>;</span>
+<span id="cb237-33"><a href="#cb237-33" aria-hidden="true" tabindex="-1"></a>    <span class="op">}</span></span>
+<span id="cb237-34"><a href="#cb237-34" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb237-35"><a href="#cb237-35" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>TCls<span class="op">&lt;</span><span class="dv">0</span><span class="op">&gt;{}.</span>fn<span class="op">())</span>;  <span class="co">// OK</span></span>
+<span id="cb237-36"><a href="#cb237-36" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb237"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb237-1"><a href="#cb237-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unprivileged<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">10</a></span>
+<div class="sourceCode" id="cb238"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb238-1"><a href="#cb238-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unprivileged<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">10</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class is the null reflection and whose scope is the global
 namespace.</p>
-<div class="sourceCode" id="cb238"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb238-1"><a href="#cb238-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">11</a></span>
+<div class="sourceCode" id="cb239"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb239-1"><a href="#cb239-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">11</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class and scope are both the null reflection.</p>
-<div class="sourceCode" id="cb239"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb239-1"><a href="#cb239-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">12</a></span>
+<div class="sourceCode" id="cb240"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb240-1"><a href="#cb240-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">cls</code> is
 either the null reflection or a reflection of a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">13</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose scope is <code class="sourceCode cpp"><span class="kw">this</span><span class="op">-&gt;</span>scope<span class="op">()</span></code>
 and whose naming class is <code class="sourceCode cpp">cls</code>.</p>
@@ -13093,45 +13109,45 @@ Member accessibility queries<a href="#meta.reflection.access.queries-member-acce
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb240"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb240-1"><a href="#cb240-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">1</a></span>
+<div class="sourceCode" id="cb241"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb241-1"><a href="#cb241-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">1</a></span>
 Let <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">(1.1)</a></span>
 If <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 the class <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">(1.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>parent_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">2</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">(2.1)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a class member
 for which <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 is an incomplete class and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">(2.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a direct base
 class relationship between a base class and an incomplete derived
 class.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">3</a></span>
 Let <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">(3.1)</a></span>
 If <code class="sourceCode cpp">ctx<span class="op">.</span>naming_class<span class="op">()</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">(4.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed bit-field
 <code class="sourceCode cpp"><em>F</em></code>, then <code class="sourceCode cpp">is_accessible<span class="op">(</span>r<sub><span class="math inline"><em>H</em></span></sub>, ctx<span class="op">)</span></code>
 where
@@ -13143,35 +13159,35 @@ with the same access as <code class="sourceCode cpp"><em>F</em></code>.
 are treated as class members for the purpose of
 <code class="sourceCode cpp">is_accessible</code>.<span> — <em>end
 note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">(4.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> does not represent a
 class member or a direct base class relationship, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">(4.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">(4.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">(4.3.1)</a></span>
 a class member that is not a (possibly indirect or variant) member of
 <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">(4.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(4.3.2)</a></span>
 a direct base class relationship such that <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 does not represent <code class="sourceCode cpp"><em>NAMING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or a (direct or indirect) base class thereof,</li>
 </ul>
 <p>then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">(4.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>
 is the null reflection, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">(4.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(4.5)</a></span>
 Otherwise, letting <code class="sourceCode cpp"><em>P</em></code> be a
 program point whose immediate scope is the function parameter scope,
 class scope, or namespace scope corresponding to the function, class, or
 namespace represented by <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">(4.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(4.5.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a direct base class
 relationship with base class
 <code class="sourceCode cpp"><em>B</em></code>, then
@@ -13180,7 +13196,7 @@ class <code class="sourceCode cpp"><em>B</em></code> of <code class="sourceCode 
 is accessible at <code class="sourceCode cpp"><em>P</em></code>
 ([class.access.base]); otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">(4.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(4.5.2)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a class
 member <code class="sourceCode cpp"><em>M</em></code>;
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -13200,36 +13216,36 @@ note</em> ]</span></p>
 </div>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb241"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb241-1"><a href="#cb241-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context fn<span class="op">()</span> <span class="op">{</span></span>
-<span id="cb241-2"><a href="#cb241-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> access_context<span class="op">::</span>current<span class="op">()</span>;</span>
-<span id="cb241-3"><a href="#cb241-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
-<span id="cb241-4"><a href="#cb241-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb241-5"><a href="#cb241-5" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> Cls <span class="op">{</span></span>
-<span id="cb241-6"><a href="#cb241-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> mem;</span>
-<span id="cb241-7"><a href="#cb241-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">friend</span> <span class="kw">consteval</span> access_context fn<span class="op">()</span>;</span>
-<span id="cb241-8"><a href="#cb241-8" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb241-9"><a href="#cb241-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^^</span>mem;</span>
-<span id="cb241-10"><a href="#cb241-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb241-11"><a href="#cb241-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb241-12"><a href="#cb241-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_accessible<span class="op">(</span>Cls<span class="op">::</span>r, fn<span class="op">()))</span>;                        <span class="co">// OK</span></span>
-<span id="cb241-13"><a href="#cb241-13" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_accessible<span class="op">(</span>Cls<span class="op">::</span>r, access_context<span class="op">::</span>current<span class="op">()))</span>;   <span class="co">// error: not accessible</span></span>
-<span id="cb241-14"><a href="#cb241-14" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_accessible<span class="op">(</span>Cls<span class="op">::</span>r, access_context<span class="op">::</span>unchecked<span class="op">()))</span>; <span class="co">// OK</span></span></code></pre></div>
+<div class="sourceCode" id="cb242"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context fn<span class="op">()</span> <span class="op">{</span></span>
+<span id="cb242-2"><a href="#cb242-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> access_context<span class="op">::</span>current<span class="op">()</span>;</span>
+<span id="cb242-3"><a href="#cb242-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span>
+<span id="cb242-4"><a href="#cb242-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-5"><a href="#cb242-5" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> Cls <span class="op">{</span></span>
+<span id="cb242-6"><a href="#cb242-6" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int</span> mem;</span>
+<span id="cb242-7"><a href="#cb242-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">friend</span> <span class="kw">consteval</span> access_context fn<span class="op">()</span>;</span>
+<span id="cb242-8"><a href="#cb242-8" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb242-9"><a href="#cb242-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">static</span> <span class="kw">constexpr</span> <span class="kw">auto</span> r <span class="op">=</span> <span class="op">^^</span>mem;</span>
+<span id="cb242-10"><a href="#cb242-10" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb242-11"><a href="#cb242-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-12"><a href="#cb242-12" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_accessible<span class="op">(</span>Cls<span class="op">::</span>r, fn<span class="op">()))</span>;                        <span class="co">// OK</span></span>
+<span id="cb242-13"><a href="#cb242-13" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_accessible<span class="op">(</span>Cls<span class="op">::</span>r, access_context<span class="op">::</span>current<span class="op">()))</span>;   <span class="co">// error: not accessible</span></span>
+<span id="cb242-14"><a href="#cb242-14" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>is_accessible<span class="op">(</span>Cls<span class="op">::</span>r, access_context<span class="op">::</span>unchecked<span class="op">()))</span>; <span class="co">// OK</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb242"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_nonstatic_data_members<span class="op">(</span></span>
-<span id="cb242-2"><a href="#cb242-2" aria-hidden="true" tabindex="-1"></a>      info r,</span>
-<span id="cb242-3"><a href="#cb242-3" aria-hidden="true" tabindex="-1"></a>      access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">5</a></span>
+<div class="sourceCode" id="cb243"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb243-1"><a href="#cb243-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_nonstatic_data_members<span class="op">(</span></span>
+<span id="cb243-2"><a href="#cb243-2" aria-hidden="true" tabindex="-1"></a>      info r,</span>
+<span id="cb243-3"><a href="#cb243-3" aria-hidden="true" tabindex="-1"></a>      access_context ctx<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">5</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(5.1)</a></span>
 <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(5.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a closure
 type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13237,11 +13253,11 @@ is <code class="sourceCode cpp"><span class="kw">false</span></code> for
 any <code class="sourceCode cpp"><em>R</em></code> in <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb243"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb243-1"><a href="#cb243-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_bases<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">7</a></span>
+<div class="sourceCode" id="cb244"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb244-1"><a href="#cb244-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_bases<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">bases_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13257,12 +13273,12 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb244"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb244-1"><a href="#cb244-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">1</a></span>
+<div class="sourceCode" id="cb245"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb245-1"><a href="#cb245-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing either a class type that is complete from
 some point in the evaluation context or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">2</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>members-of-precedes</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if
@@ -13272,31 +13288,31 @@ following the
 <code class="sourceCode cpp"><em>class-specifier</em></code> of the
 outermost class for which <code class="sourceCode cpp"><em>P</em></code>
 is in a complete-class context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> of a member
 <code class="sourceCode cpp"><em>M</em></code> of a class or namespace
 <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible</em>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">(3.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a closure type
 ([expr.prim.lambda.closure]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">(3.2)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a specialization
 of a template ([temp.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">(3.3)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a class that is not
 a closure type, then <code class="sourceCode cpp"><em>M</em></code> is a
 direct member of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.mem.general]) that is not a variant member of a nested anonymous
 union of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.union.anon]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">(3.4)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a namespace, then
 <code class="sourceCode cpp"><em>D</em></code> inhabits the namespace
 scope of <code class="sourceCode cpp"><em>Q</em></code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">(3.5)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a closure type,
 then <code class="sourceCode cpp"><em>M</em></code> is a function call
 operator or function call operator template.</li>
@@ -13304,7 +13320,7 @@ operator or function call operator template.</li>
 <p>It is implementation-defined whether declarations of other members of
 a closure type <code class="sourceCode cpp"><em>Q</em></code> are
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">4</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-representable</em>
@@ -13314,34 +13330,34 @@ declaration of <code class="sourceCode cpp"><em>M</em></code>
 members-of-precedes <code class="sourceCode cpp"><em>P</em></code> and
 <code class="sourceCode cpp"><em>M</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">(4.1)</a></span>
 a class or enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">(4.2)</a></span>
 a type alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">(4.3)</a></span>
 a primary class template, function template, primary variable template,
 alias template, or concept,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">(4.4)</a></span>
 a variable or reference,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">(4.5)</a></span>
 a function <code class="sourceCode cpp"><em>F</em></code> for which
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">(4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">(4.6)</a></span>
 the type of <code class="sourceCode cpp"><em>F</em></code> does not
 contain an undeduced placeholder type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">(4.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">(4.7)</a></span>
 the constraints (if any) of
 <code class="sourceCode cpp"><em>F</em></code> are satisfied, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">(4.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">(4.8)</a></span>
 if <code class="sourceCode cpp"><em>F</em></code> is a prospective
 destructor, <code class="sourceCode cpp"><em>F</em></code> is the
 selected destructor ([class.dtor]),</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">(4.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">(4.9)</a></span>
 a non-static data member,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">(4.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">(4.10)</a></span>
 a namespace, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">(4.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">(4.11)</a></span>
 a namespace alias.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Examples of direct
@@ -13352,18 +13368,18 @@ unscoped enumerators ([enum]), partial specializations of templates
 ([temp.spec.partial]), and closure types
 ([expr.prim.lambda.closure]).<span> — <em>end
 note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members
 <code class="sourceCode cpp"><em>M</em></code> of the entity
 <code class="sourceCode cpp"><em>Q</em></code> represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 for which</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">(5.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-representable
 from some point in the evaluation context and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">(5.2)</a></span>
 <code class="sourceCode cpp">is_accessible<span class="op">(^^</span><em>M</em>, ctx<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
@@ -13383,24 +13399,24 @@ user-declared members ([special]).<span> — <em>end
 note</em> ]</span></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb245"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb245-1"><a href="#cb245-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> B <span class="op">{}</span>;</span>
-<span id="cb245-2"><a href="#cb245-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb245-3"><a href="#cb245-3" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">:</span> B <span class="op">{</span></span>
-<span id="cb245-4"><a href="#cb245-4" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
-<span id="cb245-5"><a href="#cb245-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">class</span> I;</span>
-<span id="cb245-6"><a href="#cb245-6" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
-<span id="cb245-7"><a href="#cb245-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> m;</span>
-<span id="cb245-8"><a href="#cb245-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb245-9"><a href="#cb245-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb245-10"><a href="#cb245-10" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>members_of<span class="op">(^^</span>S, access_context<span class="op">::</span>current<span class="op">()).</span>size<span class="op">()</span> <span class="op">==</span> <span class="dv">7</span><span class="op">)</span>;    <span class="co">// 6 special members, 1 public member, does not include base</span></span>
-<span id="cb245-11"><a href="#cb245-11" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>members_of<span class="op">(^^</span>S, access_context<span class="op">::</span>unchecked<span class="op">()).</span>size<span class="op">()</span> <span class="op">==</span> <span class="dv">8</span><span class="op">)</span>;  <span class="co">// all of the above, as well a reflection representing S::I</span></span></code></pre></div>
+<div class="sourceCode" id="cb246"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb246-1"><a href="#cb246-1" aria-hidden="true" tabindex="-1"></a><span class="kw">class</span> B <span class="op">{}</span>;</span>
+<span id="cb246-2"><a href="#cb246-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb246-3"><a href="#cb246-3" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">:</span> B <span class="op">{</span></span>
+<span id="cb246-4"><a href="#cb246-4" aria-hidden="true" tabindex="-1"></a><span class="kw">private</span><span class="op">:</span></span>
+<span id="cb246-5"><a href="#cb246-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">class</span> I;</span>
+<span id="cb246-6"><a href="#cb246-6" aria-hidden="true" tabindex="-1"></a><span class="kw">public</span><span class="op">:</span></span>
+<span id="cb246-7"><a href="#cb246-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> m;</span>
+<span id="cb246-8"><a href="#cb246-8" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb246-9"><a href="#cb246-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb246-10"><a href="#cb246-10" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>members_of<span class="op">(^^</span>S, access_context<span class="op">::</span>current<span class="op">()).</span>size<span class="op">()</span> <span class="op">==</span> <span class="dv">7</span><span class="op">)</span>;    <span class="co">// 6 special members, 1 public member, does not include base</span></span>
+<span id="cb246-11"><a href="#cb246-11" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>members_of<span class="op">(^^</span>S, access_context<span class="op">::</span>unchecked<span class="op">()).</span>size<span class="op">()</span> <span class="op">==</span> <span class="dv">8</span><span class="op">)</span>;  <span class="co">// all of the above, as well a reflection representing S::I</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<div class="sourceCode" id="cb246"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb246-1"><a href="#cb246-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">6</a></span>
+<div class="sourceCode" id="cb247"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb247-1"><a href="#cb247-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 is a reflection representing a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">7</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp"><em>C</em></code> be
 the class represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -13412,32 +13428,32 @@ direct base class relationships appear in the order in which the
 corresponding base classes appear in the
 <code class="sourceCode cpp"><em>base-specifier-list</em></code> of
 <code class="sourceCode cpp"><em>C</em></code>.</p>
-<div class="sourceCode" id="cb247"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb247-1"><a href="#cb247-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">8</a></span>
+<div class="sourceCode" id="cb248"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb248-1"><a href="#cb248-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">8</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">9</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_variable<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
-<div class="sourceCode" id="cb248"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb248-1"><a href="#cb248-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">10</a></span>
+<div class="sourceCode" id="cb249"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb249-1"><a href="#cb249-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_nonstatic_data_member<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
-<div class="sourceCode" id="cb249"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb249-1"><a href="#cb249-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">12</a></span>
+<div class="sourceCode" id="cb250"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb250-1"><a href="#cb250-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">is_enumerable_type<span class="op">(</span>type_enum<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">13</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
@@ -13450,30 +13466,30 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb250"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb250-1"><a href="#cb250-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> member_offset <span class="op">{</span></span>
-<span id="cb250-2"><a href="#cb250-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">ptrdiff_t</span> bytes;</span>
-<span id="cb250-3"><a href="#cb250-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">ptrdiff_t</span> bits;</span>
-<span id="cb250-4"><a href="#cb250-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> total_bits<span class="op">()</span> <span class="kw">const</span>;</span>
-<span id="cb250-5"><a href="#cb250-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> <span class="kw">operator</span><span class="op">&lt;=&gt;(</span><span class="kw">const</span> member_offset<span class="op">&amp;)</span> <span class="kw">const</span> <span class="op">=</span> <span class="cf">default</span>;</span>
-<span id="cb250-6"><a href="#cb250-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
-<span id="cb250-7"><a href="#cb250-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb250-8"><a href="#cb250-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">1</a></span>
+<div class="sourceCode" id="cb251"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb251-1"><a href="#cb251-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> member_offset <span class="op">{</span></span>
+<span id="cb251-2"><a href="#cb251-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">ptrdiff_t</span> bytes;</span>
+<span id="cb251-3"><a href="#cb251-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">ptrdiff_t</span> bits;</span>
+<span id="cb251-4"><a href="#cb251-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> total_bits<span class="op">()</span> <span class="kw">const</span>;</span>
+<span id="cb251-5"><a href="#cb251-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">auto</span> <span class="kw">operator</span><span class="op">&lt;=&gt;(</span><span class="kw">const</span> member_offset<span class="op">&amp;)</span> <span class="kw">const</span> <span class="op">=</span> <span class="cf">default</span>;</span>
+<span id="cb251-6"><a href="#cb251-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
+<span id="cb251-7"><a href="#cb251-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb251-8"><a href="#cb251-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
-<div class="sourceCode" id="cb251"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb251-1"><a href="#cb251-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">2</a></span>
+<div class="sourceCode" id="cb252"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb252-1"><a href="#cb252-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or direct base class
 relationship other than a virtual base class of an abstract class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the offset in bits
 from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
-<div class="sourceCode" id="cb252"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb252-1"><a href="#cb252-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">5</a></span>
+<div class="sourceCode" id="cb253"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb253-1"><a href="#cb253-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member that is not a bit-field, direct base class
@@ -13486,7 +13502,7 @@ relationship, or data member description
 where <code class="sourceCode cpp"><em>W</em></code> is not ⊥. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>, a data member
@@ -13507,35 +13523,35 @@ that <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op"
 If <code class="sourceCode cpp">b</code> represents a direct base class
 relationship of an empty base class, then <code class="sourceCode cpp">size_of<span class="op">(</span>b<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb253"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb253-1"><a href="#cb253-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">7</a></span>
+<div class="sourceCode" id="cb254"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb254-1"><a href="#cb254-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing a type, object, variable of non-reference
 type, non-static data member that is not a bit-field, direct base class
 relationship, or data member description. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">(8.1)</a></span>
 If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp"><em>T</em></code>, then
 the alignment requirement for the layout-associated type
 ([class.mem.general]) for a non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a variable or object, then the alignment requirement of the
 variable or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">(8.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">(8.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">(8.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>TR</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13548,8 +13564,8 @@ where the corresponding subobject of
 <code class="sourceCode cpp"><em>TR</em></code> would have type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
 </ul>
-<div class="sourceCode" id="cb254"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb254-1"><a href="#cb254-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">9</a></span>
+<div class="sourceCode" id="cb255"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, unnamed bit-field, direct base class
@@ -13557,15 +13573,15 @@ relationship, or data member description. If <code class="sourceCode cpp">dealia
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">10</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(10.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member that is a bit-field or an unnamed bit-field with width
 <code class="sourceCode cpp"><em>W</em></code>, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">(10.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13574,7 +13590,7 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>NUA</em></code>) ([class.mem.general])
 and <code class="sourceCode cpp"><em>W</em></code> is not ⊥, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">(10.3)</a></span>
 Otherwise, <code class="sourceCode cpp">CHAR_BIT <span class="op">*</span> size_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
 </div>
@@ -13585,25 +13601,25 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when its type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
-<div class="sourceCode" id="cb255"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb255-2"><a href="#cb255-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">3</a></span>
+<div class="sourceCode" id="cb256"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb256-1"><a href="#cb256-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb256-2"><a href="#cb256-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">(4.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a variable or object of
 type <code class="sourceCode cpp">U</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">(4.2)</a></span>
 <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, and
 <span class="note"><span>[ <em>Note 2:</em> </span>The intent is to
@@ -13611,31 +13627,31 @@ allow only qualification conversions from
 <code class="sourceCode cpp">U</code> to
 <code class="sourceCode cpp">T</code>.<span> — <em>end
 note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">(4.3)</a></span>
 if <code class="sourceCode cpp">r</code> represents a variable, then
 either that variable is usable in constant expressions or its lifetime
 began within the core constant expression currently under
 evaluation.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">5</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 object <code class="sourceCode cpp"><em>O</em></code>, then a reference
 to <code class="sourceCode cpp"><em>O</em></code>. Otherwise, a
 reference to the object declared, or referred to, by the variable
 represented by <code class="sourceCode cpp">r</code>.</p>
-<div class="sourceCode" id="cb256"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb256-1"><a href="#cb256-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb256-2"><a href="#cb256-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">6</a></span>
+<div class="sourceCode" id="cb257"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb257-1"><a href="#cb257-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb257-2"><a href="#cb257-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">(6.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-static data
 member with type <code class="sourceCode cpp">X</code>, that is not a
 bit-field, that is a direct member of a class
 <code class="sourceCode cpp">C</code> and
 <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">X C<span class="op">::*</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">(6.2)</a></span>
 <code class="sourceCode cpp">r</code> represents an implicit object
 member function with type <code class="sourceCode cpp">F</code> or
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>
@@ -13643,7 +13659,7 @@ that is a direct member of a class <code class="sourceCode cpp">C</code>
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>;
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">(6.3)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-member function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -13651,57 +13667,57 @@ type <code class="sourceCode cpp">F</code> or
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">7</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a pointer type, then a
 pointer value pointing to the function represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">(7.2)</a></span>
 Otherwise, a pointer-to-member value designating the non-static data
 member or function represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
-<div class="sourceCode" id="cb257"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb257-1"><a href="#cb257-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb257-2"><a href="#cb257-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-value</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">8</a></span>
+<div class="sourceCode" id="cb258"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb258-1"><a href="#cb258-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb258-2"><a href="#cb258-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-value</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value that
 <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are similar types ([conv.qual]),
 and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value that <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">10</a></span>
 <em>Returns</em>: The value that <code class="sourceCode cpp">r</code>
 represents, converted to <code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb258"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb258-1"><a href="#cb258-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
-<span id="cb258-2"><a href="#cb258-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">11</a></span>
+<div class="sourceCode" id="cb259"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb259-1"><a href="#cb259-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
+<span id="cb259-2"><a href="#cb259-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">11</a></span>
 <em>Effects</em>: Equivalent to:</p>
-<div class="sourceCode" id="cb259"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb259-1"><a href="#cb259-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_reference_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb259-2"><a href="#cb259-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</span>
-<span id="cb259-3"><a href="#cb259-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>is_nonstatic_data_member<span class="op">(</span>r<span class="op">)</span> <span class="op">||</span> is_function<span class="op">(</span>r<span class="op">))</span> <span class="op">{</span></span>
-<span id="cb259-4"><a href="#cb259-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</span>
-<span id="cb259-5"><a href="#cb259-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb259-6"><a href="#cb259-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span>;</span>
-<span id="cb259-7"><a href="#cb259-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb260"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb260-1"><a href="#cb260-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_reference_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb260-2"><a href="#cb260-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-ref</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</span>
+<span id="cb260-3"><a href="#cb260-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="cf">if</span> <span class="op">(</span>is_nonstatic_data_member<span class="op">(</span>r<span class="op">)</span> <span class="op">||</span> is_function<span class="op">(</span>r<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb260-4"><a href="#cb260-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-member-or-function</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>r<span class="op">)</span>;</span>
+<span id="cb260-5"><a href="#cb260-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb260-6"><a href="#cb260-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>extract-value</em><span class="op">&lt;</span>T<span class="op">&gt;(</span>value_of<span class="op">(</span>r<span class="op">))</span>;</span>
+<span id="cb260-7"><a href="#cb260-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -13710,55 +13726,55 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb260"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb260-1"><a href="#cb260-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
-<span id="cb260-2"><a href="#cb260-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
-<span id="cb260-3"><a href="#cb260-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb260-4"><a href="#cb260-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
-<span id="cb260-5"><a href="#cb260-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb261"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb261-1"><a href="#cb261-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb261-2"><a href="#cb261-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">1</a></span>
+<div class="sourceCode" id="cb261"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb261-1"><a href="#cb261-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> R<span class="op">&gt;</span></span>
+<span id="cb261-2"><a href="#cb261-2" aria-hidden="true" tabindex="-1"></a><span class="kw">concept</span> reflection_range <span class="op">=</span></span>
+<span id="cb261-3"><a href="#cb261-3" aria-hidden="true" tabindex="-1"></a>  ranges<span class="op">::</span>input_range<span class="op">&lt;</span>R<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb261-4"><a href="#cb261-4" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>ranges<span class="op">::</span>range_value_t<span class="op">&lt;</span>R<span class="op">&gt;</span>, info<span class="op">&gt;</span> <span class="op">&amp;&amp;</span></span>
+<span id="cb261-5"><a href="#cb261-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb262"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb262-1"><a href="#cb262-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb262-2"><a href="#cb262-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the reflections
 held by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 is a valid <em>template-id</em> ([temp.names]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">4</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If forming <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 leads to a failure outside of the immediate context, the program is
 ill-formed.<span> — <em>end note</em> ]</span></span></p>
-<div class="sourceCode" id="cb262"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb262-1"><a href="#cb262-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb262-2"><a href="#cb262-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">5</a></span>
+<div class="sourceCode" id="cb263"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb263-1"><a href="#cb263-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb263-2"><a href="#cb263-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the reflections
 held by the elements of
 <code class="sourceCode cpp">arguments</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^^</span>Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">8</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The specialization
 <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 is only instantiated if needed.<span> — <em>end
 note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">9</a></span>
 <span class="note"><span>[ <em>Note 3:</em> </span>If forming <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 leads to a failure outside of the immediate context, the program is
 ill-formed.<span> — <em>end note</em> ]</span></span></p>
@@ -13770,7 +13786,7 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">1</a></span>
 An object <code class="sourceCode cpp"><em>O</em></code> of type
 <code class="sourceCode cpp"><em>T</em></code> is
 <em>meta-reflectable</em> if an lvalue expression denoting
@@ -13778,54 +13794,80 @@ An object <code class="sourceCode cpp"><em>O</em></code> of type
 constant template argument for a constant template parameter of type
 <code class="sourceCode cpp"><em>T</em><span class="op">&amp;</span></code>
 ([temp.arg.nontype]).</p>
-<div class="sourceCode" id="cb263"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb263-1"><a href="#cb263-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb263-2"><a href="#cb263-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">2</a></span>
-<em>Mandates</em>: <code class="sourceCode cpp">T</code> is a copy
-constructible, structural type that is neither a reference type nor an
-array type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">3</a></span>
-Let <code class="sourceCode cpp"><em>V</em></code> be the value computed
-by an lvalue-to-rvalue conversion applied to
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">2</a></span>
+The following are defined for exposition only to aid in the
+specification of <code class="sourceCode cpp">reflect_value</code>:</p>
+<div class="sourceCode" id="cb264"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb264-2"><a href="#cb264-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info <em>reflect-value-scalar</em><span class="op">(</span>T expr<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p>Let <code class="sourceCode cpp"><em>V</em></code> be the value
+computed by an lvalue-to-rvalue conversion applied to
 <code class="sourceCode cpp">expr</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">3</a></span>
+<em>Constant When</em>: <code class="sourceCode cpp"><em>V</em></code>
+satisfies the constraints for for a value computed by a prvalue constant
+expression ([expr.const]) and, if
+<code class="sourceCode cpp"><em>V</em></code> has pointer type, then it
+is not a pointer to an object that is not meta-reflectable.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">4</a></span>
+<em>Returns</em>: A reflection of a value of type
+<code class="sourceCode cpp"><em>T</em></code> associated with the
+computed value <code class="sourceCode cpp"><em>V</em></code>.</p>
+<div class="sourceCode" id="cb265"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb265-2"><a href="#cb265-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info <em>reflect-value-class</em><span class="op">(</span>T <span class="kw">const</span><span class="op">&amp;</span> expr<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">5</a></span>
+<em>Mandates</em>: <code class="sourceCode cpp">T</code> is copy
+constructible and structural ([temp.param]).</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">6</a></span>
+Let <code class="sourceCode cpp"><em>O</em></code> be a template
+parameter object ([temp.param]) copy-initialized from
+<code class="sourceCode cpp">expr</code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">7</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">(4.1)</a></span>
-<code class="sourceCode cpp"><em>V</em></code> satisfies the constraints
-for a value computed by a prvalue constant expression
-([expr.const]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(7.1)</a></span>
+<code class="sourceCode cpp"><em>O</em></code> satisfies the constraints
+for a constant expression ([expr.const]),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">(7.2)</a></span>
 no constituent reference of
-<code class="sourceCode cpp"><em>V</em></code> refers to an object that
+<code class="sourceCode cpp"><em>O</em></code> refers to an object that
 is not meta-reflectable, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">(4.3)</a></span>
-no constituent value of <code class="sourceCode cpp"><em>V</em></code>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">(7.3)</a></span>
+no constituent value of <code class="sourceCode cpp"><em>O</em></code>
 of pointer type is a pointer to an object that is not
 meta-reflectable.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">5</a></span>
-<em>Returns</em>: A reflection of
-<code class="sourceCode cpp"><em>V</em></code>. The type of the
-represented value is the cv-unqualified version of
-<code class="sourceCode cpp">T</code>.</p>
-<div class="sourceCode" id="cb264"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb264-2"><a href="#cb264-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">8</a></span>
+<em>Returns</em>: A reflection of a value of type
+<code class="sourceCode cpp">T</code> associated with the template
+parameter object <code class="sourceCode cpp"><em>O</em></code>.</p>
+<div class="sourceCode" id="cb266"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb266-1"><a href="#cb266-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb266-2"><a href="#cb266-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_value<span class="op">(</span><span class="kw">const</span> T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><em>Effects</em>: Equivalent to:</p>
+<div class="sourceCode" id="cb267"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb267-1"><a href="#cb267-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>is_class_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
+<span id="cb267-2"><a href="#cb267-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>reflect-value-class</em><span class="op">(</span>expr<span class="op">)</span>;</span>
+<span id="cb267-3"><a href="#cb267-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb267-4"><a href="#cb267-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">return</span> <em>reflect-value-scalar</em><span class="op">(</span>expr<span class="op">)</span>;</span>
+<span id="cb267-5"><a href="#cb267-5" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<p><span class="note"><span>[ <em>Note 1:</em> </span>Array-to-pointer
+and function-to-function-pointer decay occur.<span> — <em>end
+note</em> ]</span></span></p>
+<div class="sourceCode" id="cb268"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb268-1"><a href="#cb268-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb268-2"><a href="#cb268-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">9</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is not a
 function type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code>
 designates a meta-reflectable object.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">11</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
-<div class="sourceCode" id="cb265"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
-<span id="cb265-2"><a href="#cb265-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> fn<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">9</a></span>
+<div class="sourceCode" id="cb269"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb269-1"><a href="#cb269-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
+<span id="cb269-2"><a href="#cb269-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> fn<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">12</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">13</a></span>
 <em>Returns</em>: A reflection of the function designated by
 <code class="sourceCode cpp">fn</code>.</p>
 </div>
@@ -13836,36 +13878,36 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb266"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb266-1"><a href="#cb266-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> data_member_options <span class="op">{</span></span>
-<span id="cb266-2"><a href="#cb266-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> <em>name-type</em> <span class="op">{</span> <span class="co">// exposition only</span></span>
-<span id="cb266-3"><a href="#cb266-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb266-4"><a href="#cb266-4" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
-<span id="cb266-5"><a href="#cb266-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb266-6"><a href="#cb266-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb266-7"><a href="#cb266-7" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
-<span id="cb266-8"><a href="#cb266-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb266-9"><a href="#cb266-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
-<span id="cb266-10"><a href="#cb266-10" aria-hidden="true" tabindex="-1"></a>    variant<span class="op">&lt;</span>u8string, string<span class="op">&gt;</span> <em>contents</em>;    <span class="co">// exposition only</span></span>
-<span id="cb266-11"><a href="#cb266-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
-<span id="cb266-12"><a href="#cb266-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb266-13"><a href="#cb266-13" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><em>name-type</em><span class="op">&gt;</span> name;</span>
-<span id="cb266-14"><a href="#cb266-14" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> alignment;</span>
-<span id="cb266-15"><a href="#cb266-15" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> bit_width;</span>
-<span id="cb266-16"><a href="#cb266-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
-<span id="cb266-17"><a href="#cb266-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">1</a></span>
+<div class="sourceCode" id="cb270"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb270-1"><a href="#cb270-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> data_member_options <span class="op">{</span></span>
+<span id="cb270-2"><a href="#cb270-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">struct</span> <em>name-type</em> <span class="op">{</span> <span class="co">// exposition only</span></span>
+<span id="cb270-3"><a href="#cb270-3" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb270-4"><a href="#cb270-4" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
+<span id="cb270-5"><a href="#cb270-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb270-6"><a href="#cb270-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb270-7"><a href="#cb270-7" aria-hidden="true" tabindex="-1"></a>      <span class="kw">consteval</span> <em>name-type</em><span class="op">(</span>T <span class="op">&amp;&amp;)</span>;</span>
+<span id="cb270-8"><a href="#cb270-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb270-9"><a href="#cb270-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">private</span><span class="op">:</span></span>
+<span id="cb270-10"><a href="#cb270-10" aria-hidden="true" tabindex="-1"></a>    variant<span class="op">&lt;</span>u8string, string<span class="op">&gt;</span> <em>contents</em>;    <span class="co">// exposition only</span></span>
+<span id="cb270-11"><a href="#cb270-11" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span>;</span>
+<span id="cb270-12"><a href="#cb270-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb270-13"><a href="#cb270-13" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><em>name-type</em><span class="op">&gt;</span> name;</span>
+<span id="cb270-14"><a href="#cb270-14" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> alignment;</span>
+<span id="cb270-15"><a href="#cb270-15" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> bit_width;</span>
+<span id="cb270-16"><a href="#cb270-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
+<span id="cb270-17"><a href="#cb270-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">data_member_options<span class="op">::</span><em>name-type</em></code>
 are consteval-only types ([basic.types.general]), and are not structural
 types ([temp.param]).</p>
-<div class="sourceCode" id="cb267"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb267-1"><a href="#cb267-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
-<span id="cb267-2"><a href="#cb267-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">2</a></span>
+<div class="sourceCode" id="cb271"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb271-1"><a href="#cb271-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
+<span id="cb271-2"><a href="#cb271-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
-<div class="sourceCode" id="cb268"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb268-1"><a href="#cb268-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
-<span id="cb268-2"><a href="#cb268-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">3</a></span>
+<div class="sourceCode" id="cb272"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb272-1"><a href="#cb272-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
+<span id="cb272-2"><a href="#cb272-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="note">
@@ -13879,71 +13921,71 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 <code class="sourceCode cpp">u8string</code>, etc.) equally well.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb269"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb269-1"><a href="#cb269-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
-<span id="cb269-2"><a href="#cb269-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb273"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb273-1"><a href="#cb273-1" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem1 <span class="op">=</span> data_member_spec<span class="op">(^^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">&quot;ordinary_literal_encoding&quot;</span><span class="op">})</span>;</span>
+<span id="cb273-2"><a href="#cb273-2" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> mem2 <span class="op">=</span> data_member_spec<span class="op">(^^</span><span class="dt">int</span>, <span class="op">{.</span>name<span class="op">=</span><span class="st">u8&quot;utf8_encoding&quot;</span><span class="op">})</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<div class="sourceCode" id="cb270"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb270-1"><a href="#cb270-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
-<span id="cb270-2"><a href="#cb270-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">4</a></span>
+<div class="sourceCode" id="cb274"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb274-1"><a href="#cb274-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
+<span id="cb274-2"><a href="#cb274-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp">cv <em>T</em></code>
 where <code class="sourceCode cpp"><em>T</em></code> is either an object
 type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier when interpreted with the ordinary literal
 encoding;</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">(4.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">(4.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">(4.4.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">(4.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">(4.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">(4.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">(4.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">(4.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">(4.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em></code> equals
 <code class="sourceCode cpp"><span class="dv">0</span></code> then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value; and</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13952,31 +13994,31 @@ contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type represented
 by <code class="sourceCode cpp">delias<span class="op">(</span>type<span class="op">)</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 or ⊥ if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 does not contain a value, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">6</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>; it can also be
@@ -13985,16 +14027,16 @@ queried by certain other functions in
 (e.g., <code class="sourceCode cpp">type_of</code>,
 <code class="sourceCode cpp">identifier_of</code>).<span> — <em>end
 note</em> ]</span></span></p>
-<div class="sourceCode" id="cb271"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb271-1"><a href="#cb271-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">7</a></span>
+<div class="sourceCode" id="cb275"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb275-1"><a href="#cb275-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
 description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<div class="sourceCode" id="cb272"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb272-1"><a href="#cb272-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb272-2"><a href="#cb272-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">8</a></span>
+<div class="sourceCode" id="cb276"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb276-1"><a href="#cb276-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb276-2"><a href="#cb276-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">8</a></span>
 <em>Constant When</em>: Letting
 <code class="sourceCode cpp"><em>C</em></code> be the class represented
 by <code class="sourceCode cpp">class_type</code> and
@@ -14002,24 +14044,24 @@ by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><em>K</em></code><sup>th</sup> reflection
 value in <code class="sourceCode cpp">mdescrs</code>,</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">(8.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">(8.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context; <span class="note"><span>[ <em>Note
 3:</em> </span><code class="sourceCode cpp"><em>C</em></code> can be a
 class template specialization for which there is a reachable definition
 of the primary class template. In this case, an explicit specialization
 is injected.<span> — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">(8.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">(8.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>;</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">(8.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">(8.3)</a></span>
 <code class="sourceCode cpp">is_complete_type<span class="op">(</span>type_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">))</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>; and</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">(8.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">(8.4)</a></span>
 for every pair
 (<code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>) where
@@ -14028,11 +14070,11 @@ for every pair
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 then either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">(8.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">(8.4.1)</a></span>
 <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">!=</span> u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">(8.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">(8.4.2)</a></span>
 <code class="sourceCode cpp">u8identifier_of<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span> <span class="op">==</span> <span class="st">u8&quot;_&quot;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 <span class="note"><span>[ <em>Note 4:</em> </span>Every provided
@@ -14040,7 +14082,7 @@ identifier is unique or <code class="sourceCode cpp"><span class="st">&quot;_&qu
 — <em>end note</em> ]</span></span></li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">9</a></span>
 Let
 {<code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub>k</sub></code>}
 be a sequence of reflections and
@@ -14051,28 +14093,28 @@ values such that <code class="sourceCode cpp">data_member_spec<span class="op">(
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>k</em></span></sub></code> in
 <code class="sourceCode cpp">mdescrs</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 provides a definition for <code class="sourceCode cpp"><em>C</em></code>
 with properties as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">(10.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">(10.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the core constant expression currently under
 evaluation.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization,
 that is not a local class, of a templated class
 <code class="sourceCode cpp"><em>T</em></code>; then
 <code class="sourceCode cpp"><em>D</em></code> is an explicit
 specialization of
 <code class="sourceCode cpp"><em>T</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">(10.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">(10.4)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a public
 non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>. For every
@@ -14083,27 +14125,27 @@ the declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> precedes the
 declaration of
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">(10.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">(10.5)</a></span>
 A non-static data member or unnamed bit-field corresponding to each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(10.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">(10.5.1)</a></span>
 It has the type represented by
 <code class="sourceCode cpp"><span class="math inline"><em>t</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">(10.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">(10.5.2)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, it
 is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">(10.5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">(10.5.3)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>bit_width</code>
 contains a value, it is declared as a bit-field whose width is that
 value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">(10.5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">(10.5.4)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment</code>
 contains a value, it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code> <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(*</span><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>alignment<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">(10.5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">(10.5.5)</a></span>
 If <code class="sourceCode cpp"><span class="math inline"><em>o</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">.</span>name</code>
 does not contain a value, it is an unnamed bit-field. Otherwise, it is a
 non-static data member with an identifier determined by the character
@@ -14111,7 +14153,7 @@ sequence encoded by <code class="sourceCode cpp">u8identifier_of<span class="op"
 in UTF-8.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -14121,10 +14163,10 @@ Unary type traits<a href="#meta.reflection.unary-unary-type-traits" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">1</a></span>
 Subclause [meta.reflection.unary] contains consteval functions that may
 be used to query the properties of a type at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">2</a></span>
 For each function taking an argument of type
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>
 whose name contains <code class="sourceCode cpp">type</code>, a call to
@@ -14143,43 +14185,43 @@ Primary type categories<a href="#meta.reflection.unary.cat-primary-type-categori
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp"><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.2 <a href="https://wg21.link/meta.unary.cat">[meta.unary.cat]</a></span>.</p>
-<div class="sourceCode" id="cb273"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb273-1"><a href="#cb273-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-2"><a href="#cb273-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-3"><a href="#cb273-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-4"><a href="#cb273-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-5"><a href="#cb273-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-6"><a href="#cb273-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-7"><a href="#cb273-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-8"><a href="#cb273-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-9"><a href="#cb273-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-10"><a href="#cb273-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-11"><a href="#cb273-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-12"><a href="#cb273-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-13"><a href="#cb273-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-14"><a href="#cb273-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb273-15"><a href="#cb273-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">2</a></span></p>
+<div class="sourceCode" id="cb277"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb277-1"><a href="#cb277-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_void_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-2"><a href="#cb277-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_null_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-3"><a href="#cb277-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_integral_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-4"><a href="#cb277-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_floating_point_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-5"><a href="#cb277-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-6"><a href="#cb277-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-7"><a href="#cb277-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-8"><a href="#cb277-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-9"><a href="#cb277-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_object_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-10"><a href="#cb277-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_function_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-11"><a href="#cb277-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-12"><a href="#cb277-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_union_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-13"><a href="#cb277-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_class_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-14"><a href="#cb277-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb277-15"><a href="#cb277-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reflection_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb274"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb274-1"><a href="#cb274-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
-<span id="cb274-2"><a href="#cb274-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
-<span id="cb274-3"><a href="#cb274-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
-<span id="cb274-4"><a href="#cb274-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^^is_void_v, {type}));</span>
-<span id="cb274-5"><a href="#cb274-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb274-6"><a href="#cb274-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
-<span id="cb274-7"><a href="#cb274-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
-<span id="cb274-8"><a href="#cb274-8" aria-hidden="true" tabindex="-1"></a>    return type == ^^void</span>
-<span id="cb274-9"><a href="#cb274-9" aria-hidden="true" tabindex="-1"></a>        || type == ^^const void</span>
-<span id="cb274-10"><a href="#cb274-10" aria-hidden="true" tabindex="-1"></a>        || type == ^^volatile void</span>
-<span id="cb274-11"><a href="#cb274-11" aria-hidden="true" tabindex="-1"></a>        || type == ^^const volatile void;</span>
-<span id="cb274-12"><a href="#cb274-12" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb274-13"><a href="#cb274-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb278"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb278-1"><a href="#cb278-1" aria-hidden="true" tabindex="-1"></a>namespace std::meta {</span>
+<span id="cb278-2"><a href="#cb278-2" aria-hidden="true" tabindex="-1"></a>  consteval bool is_void_type(info type) {</span>
+<span id="cb278-3"><a href="#cb278-3" aria-hidden="true" tabindex="-1"></a>    // one example implementation</span>
+<span id="cb278-4"><a href="#cb278-4" aria-hidden="true" tabindex="-1"></a>    return extract&lt;bool&gt;(substitute(^^is_void_v, {type}));</span>
+<span id="cb278-5"><a href="#cb278-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb278-6"><a href="#cb278-6" aria-hidden="true" tabindex="-1"></a>    // another example implementation</span>
+<span id="cb278-7"><a href="#cb278-7" aria-hidden="true" tabindex="-1"></a>    type = dealias(type);</span>
+<span id="cb278-8"><a href="#cb278-8" aria-hidden="true" tabindex="-1"></a>    return type == ^^void</span>
+<span id="cb278-9"><a href="#cb278-9" aria-hidden="true" tabindex="-1"></a>        || type == ^^const void</span>
+<span id="cb278-10"><a href="#cb278-10" aria-hidden="true" tabindex="-1"></a>        || type == ^^volatile void</span>
+<span id="cb278-11"><a href="#cb278-11" aria-hidden="true" tabindex="-1"></a>        || type == ^^const volatile void;</span>
+<span id="cb278-12"><a href="#cb278-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb278-13"><a href="#cb278-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -14190,19 +14232,19 @@ Composite type categories<a href="#meta.reflection.unary.comp-composite-type-cat
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type</code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>TRAIT</em>_type<span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding unary type trait <code class="sourceCode cpp"><em>TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.3 <a href="https://wg21.link/meta.unary.comp">[meta.unary.comp]</a></span>.</p>
-<div class="sourceCode" id="cb275"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb275-1"><a href="#cb275-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb275-2"><a href="#cb275-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb275-3"><a href="#cb275-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb275-4"><a href="#cb275-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb275-5"><a href="#cb275-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb275-6"><a href="#cb275-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb275-7"><a href="#cb275-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb279"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb279-1"><a href="#cb279-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_reference_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb279-2"><a href="#cb279-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_arithmetic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb279-3"><a href="#cb279-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_fundamental_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb279-4"><a href="#cb279-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb279-5"><a href="#cb279-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scalar_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb279-6"><a href="#cb279-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_compound_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb279-7"><a href="#cb279-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_member_pointer_type<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14211,7 +14253,7 @@ Type properties<a href="#meta.reflection.unary.prop-type-properties" class="self
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
@@ -14220,7 +14262,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em>_type</code>
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TYPE</em></code>
@@ -14229,7 +14271,7 @@ defined in this subclause with type <code class="sourceCode cpp"><span class="dt
 or <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14239,74 +14281,74 @@ each function template <code class="sourceCode cpp">meta<span class="op">::</spa
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-TRAIT</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type property <code class="sourceCode cpp"><em>VARIADIC-TRAIT</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.5.4 <a href="https://wg21.link/meta.unary.prop">[meta.unary.prop]</a></span>.</p>
-<div class="sourceCode" id="cb276"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb276-1"><a href="#cb276-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-2"><a href="#cb276-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-3"><a href="#cb276-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-4"><a href="#cb276-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-5"><a href="#cb276-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_replaceable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-6"><a href="#cb276-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-7"><a href="#cb276-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-8"><a href="#cb276-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-9"><a href="#cb276-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-10"><a href="#cb276-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-11"><a href="#cb276-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-12"><a href="#cb276-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_consteval_only_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-13"><a href="#cb276-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-14"><a href="#cb276-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-15"><a href="#cb276-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-16"><a href="#cb276-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-17"><a href="#cb276-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-18"><a href="#cb276-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-19"><a href="#cb276-19" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb276-20"><a href="#cb276-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb276-21"><a href="#cb276-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-22"><a href="#cb276-22" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-23"><a href="#cb276-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-24"><a href="#cb276-24" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-25"><a href="#cb276-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb276-26"><a href="#cb276-26" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-27"><a href="#cb276-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-28"><a href="#cb276-28" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-29"><a href="#cb276-29" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb276-30"><a href="#cb276-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-31"><a href="#cb276-31" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-32"><a href="#cb276-32" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-33"><a href="#cb276-33" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-34"><a href="#cb276-34" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb276-35"><a href="#cb276-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb276-36"><a href="#cb276-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-37"><a href="#cb276-37" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-38"><a href="#cb276-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-39"><a href="#cb276-39" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-40"><a href="#cb276-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb276-41"><a href="#cb276-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-42"><a href="#cb276-42" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-43"><a href="#cb276-43" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-44"><a href="#cb276-44" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-45"><a href="#cb276-45" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb276-46"><a href="#cb276-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb276-47"><a href="#cb276-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-48"><a href="#cb276-48" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-49"><a href="#cb276-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-50"><a href="#cb276-50" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-51"><a href="#cb276-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb276-52"><a href="#cb276-52" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-53"><a href="#cb276-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-54"><a href="#cb276-54" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-55"><a href="#cb276-55" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb276-56"><a href="#cb276-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-57"><a href="#cb276-57" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-58"><a href="#cb276-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-59"><a href="#cb276-59" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-60"><a href="#cb276-60" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-61"><a href="#cb276-61" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-62"><a href="#cb276-62" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-63"><a href="#cb276-63" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-64"><a href="#cb276-64" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-65"><a href="#cb276-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb276-66"><a href="#cb276-66" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb276-67"><a href="#cb276-67" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
-<span id="cb276-68"><a href="#cb276-68" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb280"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb280-1"><a href="#cb280-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-2"><a href="#cb280-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-3"><a href="#cb280-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copyable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-4"><a href="#cb280-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-5"><a href="#cb280-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_replaceable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-6"><a href="#cb280-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_standard_layout_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-7"><a href="#cb280-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_empty_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-8"><a href="#cb280-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_polymorphic_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-9"><a href="#cb280-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_abstract_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-10"><a href="#cb280-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-11"><a href="#cb280-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_aggregate_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-12"><a href="#cb280-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_consteval_only_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-13"><a href="#cb280-13" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_signed_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-14"><a href="#cb280-14" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unsigned_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-15"><a href="#cb280-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-16"><a href="#cb280-16" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_unbounded_array_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-17"><a href="#cb280-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_scoped_enum_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-18"><a href="#cb280-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-19"><a href="#cb280-19" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb280-20"><a href="#cb280-20" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb280-21"><a href="#cb280-21" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-22"><a href="#cb280-22" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-23"><a href="#cb280-23" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-24"><a href="#cb280-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-25"><a href="#cb280-25" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb280-26"><a href="#cb280-26" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-27"><a href="#cb280-27" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-28"><a href="#cb280-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-29"><a href="#cb280-29" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb280-30"><a href="#cb280-30" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-31"><a href="#cb280-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-32"><a href="#cb280-32" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-33"><a href="#cb280-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-34"><a href="#cb280-34" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb280-35"><a href="#cb280-35" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb280-36"><a href="#cb280-36" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-37"><a href="#cb280-37" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-38"><a href="#cb280-38" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-39"><a href="#cb280-39" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-40"><a href="#cb280-40" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb280-41"><a href="#cb280-41" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-42"><a href="#cb280-42" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-43"><a href="#cb280-43" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_trivially_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-44"><a href="#cb280-44" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-45"><a href="#cb280-45" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb280-46"><a href="#cb280-46" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_constructible_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb280-47"><a href="#cb280-47" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_default_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-48"><a href="#cb280-48" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-49"><a href="#cb280-49" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_constructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-50"><a href="#cb280-50" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-51"><a href="#cb280-51" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_assignable_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb280-52"><a href="#cb280-52" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_copy_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-53"><a href="#cb280-53" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_move_assignable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-54"><a href="#cb280-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-55"><a href="#cb280-55" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_with_type<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb280-56"><a href="#cb280-56" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_swappable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-57"><a href="#cb280-57" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-58"><a href="#cb280-58" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_destructible_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-59"><a href="#cb280-59" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_relocatable_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-60"><a href="#cb280-60" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-61"><a href="#cb280-61" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_implicit_lifetime_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-62"><a href="#cb280-62" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-63"><a href="#cb280-63" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_virtual_destructor<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-64"><a href="#cb280-64" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-65"><a href="#cb280-65" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_unique_object_representations<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb280-66"><a href="#cb280-66" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-67"><a href="#cb280-67" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_constructs_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span>
+<span id="cb280-68"><a href="#cb280-68" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> reference_converts_from_temporary<span class="op">(</span>info type_dst, info type_src<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14315,13 +14357,13 @@ Type property queries<a href="#meta.reflection.unary.prop.query-type-property-qu
 <div class="std">
 <blockquote>
 <div class="addu">
-<div class="sourceCode" id="cb277"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb277-1"><a href="#cb277-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">1</a></span>
+<div class="sourceCode" id="cb281"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb281-1"><a href="#cb281-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">1</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.</p>
-<div class="sourceCode" id="cb278"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb278-1"><a href="#cb278-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">2</a></span>
+<div class="sourceCode" id="cb282"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb282-1"><a href="#cb282-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">2</a></span>
 <em>Effects</em>: Equivalent to <code class="sourceCode cpp"><span class="cf">return</span> extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span>;</code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
@@ -14335,17 +14377,17 @@ relations<a href="#meta.reflection.rel-type-relations" class="self-link"></a></h
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">1</a></span>
 The consteval functions specified in this subclause may be used to query
 relationships between types at compile time.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">2</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type</code>
 defined in this subclause with type <code class="sourceCode cpp"><span class="dt">bool</span><span class="op">(</span>meta<span class="op">::</span>info, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>REL</em>_type<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>REL</em>_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14355,7 +14397,7 @@ each binary function template <code class="sourceCode cpp">meta<span class="op">
 <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-REL</em>_type<span class="op">(^^</span>T, r<span class="op">)</span></code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>VARIADIC-REL</em>_v<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">4</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">R</code>, pack of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14365,24 +14407,24 @@ each ternary function template <code class="sourceCode cpp">meta<span class="op"
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-REL-R</em><span class="op">(^^</span>R, <span class="op">^^</span>T, r<span class="op">)</span>_type</code>
 equals the value of the corresponding type relation <code class="sourceCode cpp"><em>VARIADIC-REL-R</em>_v<span class="op">&lt;</span>R, T, U<span class="op">...&gt;</span></code>
 as specified in <span>21.3.7 <a href="https://wg21.link/meta.rel">[meta.rel]</a></span>.</p>
-<div class="sourceCode" id="cb279"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb279-1"><a href="#cb279-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb279-2"><a href="#cb279-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb279-3"><a href="#cb279-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb279-4"><a href="#cb279-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb279-5"><a href="#cb279-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
-<span id="cb279-6"><a href="#cb279-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
-<span id="cb279-7"><a href="#cb279-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
-<span id="cb279-8"><a href="#cb279-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb279-9"><a href="#cb279-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb279-10"><a href="#cb279-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb279-11"><a href="#cb279-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb279-12"><a href="#cb279-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb279-13"><a href="#cb279-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb279-14"><a href="#cb279-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb279-15"><a href="#cb279-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb279-16"><a href="#cb279-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb279-17"><a href="#cb279-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">5</a></span>
+<div class="sourceCode" id="cb283"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb283-1"><a href="#cb283-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_same_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb283-2"><a href="#cb283-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb283-3"><a href="#cb283-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb283-4"><a href="#cb283-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb283-5"><a href="#cb283-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_convertible_type<span class="op">(</span>info type_src, info type_dst<span class="op">)</span>;</span>
+<span id="cb283-6"><a href="#cb283-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_layout_compatible_type<span class="op">(</span>info type1, info type2<span class="op">)</span>;</span>
+<span id="cb283-7"><a href="#cb283-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pointer_interconvertible_base_of_type<span class="op">(</span>info type_base, info type_derived<span class="op">)</span>;</span>
+<span id="cb283-8"><a href="#cb283-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb283-9"><a href="#cb283-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb283-10"><a href="#cb283-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb283-11"><a href="#cb283-11" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb283-12"><a href="#cb283-12" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb283-13"><a href="#cb283-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb283-14"><a href="#cb283-14" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb283-15"><a href="#cb283-15" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_type<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb283-16"><a href="#cb283-16" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb283-17"><a href="#cb283-17" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nothrow_invocable_r_type<span class="op">(</span>info type_result, info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">5</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -14404,7 +14446,7 @@ Transformations between types<a href="#meta.reflection.trans-transformations-bet
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">1</a></span>
 Subclause [meta.reflection.trans] contains consteval functions that may
 be used to transform one type to another following some predefined
 rule.</p>
@@ -14416,19 +14458,19 @@ Const-volatile modifications<a href="#meta.reflection.trans.cv-const-volatile-mo
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.2 <a href="https://wg21.link/meta.trans.cv">[meta.trans.cv]</a></span>.</p>
-<div class="sourceCode" id="cb280"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb280-1"><a href="#cb280-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-2"><a href="#cb280-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-3"><a href="#cb280-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-4"><a href="#cb280-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-5"><a href="#cb280-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb280-6"><a href="#cb280-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb284"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb284-1"><a href="#cb284-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb284-2"><a href="#cb284-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb284-3"><a href="#cb284-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cv<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb284-4"><a href="#cb284-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_const<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb284-5"><a href="#cb284-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_volatile<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb284-6"><a href="#cb284-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_cv<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14437,16 +14479,16 @@ Reference modifications<a href="#meta.reflection.trans.ref-reference-modificatio
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.3 <a href="https://wg21.link/meta.trans.ref">[meta.trans.ref]</a></span>.</p>
-<div class="sourceCode" id="cb281"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb281-1"><a href="#cb281-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb281-2"><a href="#cb281-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb281-3"><a href="#cb281-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb285"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb285-1"><a href="#cb285-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb285-2"><a href="#cb285-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_lvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb285-3"><a href="#cb285-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_rvalue_reference<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14455,15 +14497,15 @@ Sign modifications<a href="#meta.reflection.trans.sign-sign-modifications" class
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.4 <a href="https://wg21.link/meta.trans.sign">[meta.trans.sign]</a></span>.</p>
-<div class="sourceCode" id="cb282"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb282-1"><a href="#cb282-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb282-2"><a href="#cb282-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb286"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb286-1"><a href="#cb286-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_signed<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb286-2"><a href="#cb286-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info make_unsigned<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14472,15 +14514,15 @@ Array modifications<a href="#meta.reflection.trans.arr-array-modifications" clas
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.5 <a href="https://wg21.link/meta.trans.arr">[meta.trans.arr]</a></span>.</p>
-<div class="sourceCode" id="cb283"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb283-1"><a href="#cb283-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb283-2"><a href="#cb283-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb287"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb287-1"><a href="#cb287-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_extent<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb287-2"><a href="#cb287-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_all_extents<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14489,15 +14531,15 @@ Pointer modifications<a href="#meta.reflection.trans.ptr-pointer-modifications" 
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.6 <a href="https://wg21.link/meta.trans.ptr">[meta.trans.ptr]</a></span>.</p>
-<div class="sourceCode" id="cb284"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb284-1"><a href="#cb284-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb284-2"><a href="#cb284-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb288"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb288-1"><a href="#cb288-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_pointer<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb288-2"><a href="#cb288-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info add_pointer<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14516,7 +14558,7 @@ class template intended to be specialized and not directly invoked.
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em></code>
@@ -14524,7 +14566,7 @@ defined in this subclause with type <code class="sourceCode cpp">meta<span class
 <code class="sourceCode cpp">meta<span class="op">::</span><em>MOD</em><span class="op">(^^</span>T<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>MOD</em>_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">2</a></span>
 For any pack of types or type aliases
 <code class="sourceCode cpp">T<span class="op">...</span></code> and
 range <code class="sourceCode cpp">r</code> such that <code class="sourceCode cpp">ranges<span class="op">::</span>equal<span class="op">(</span>r, vector<span class="op">{^^</span>T<span class="op">...})</span></code>
@@ -14533,7 +14575,7 @@ each unary function template <code class="sourceCode cpp">meta<span class="op">:
 defined in this subclause, <code class="sourceCode cpp">meta<span class="op">::</span><em>VARIADIC-MOD</em><span class="op">(</span>r<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp"><em>VARIADIC-MOD</em>_t<span class="op">&lt;</span>T<span class="op">...&gt;</span></code>
 as specified in <span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">3</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, pack
 of types or type aliases
 <code class="sourceCode cpp">U<span class="op">...</span></code>, and
@@ -14542,29 +14584,29 @@ is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span>invoke_result<span class="op">(^^</span>T, r<span class="op">)</span></code>
 returns the reflection of the corresponding type denoted by <code class="sourceCode cpp">invoke_result_t<span class="op">&lt;</span>T, U<span class="op">...&gt;</span></code>
 (<span>21.3.8.7 <a href="https://wg21.link/meta.trans.other">[meta.trans.other]</a></span>).</p>
-<div class="sourceCode" id="cb285"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb285-1"><a href="#cb285-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb285-2"><a href="#cb285-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb285-3"><a href="#cb285-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb285-4"><a href="#cb285-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb285-5"><a href="#cb285-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb285-6"><a href="#cb285-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb285-7"><a href="#cb285-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb285-8"><a href="#cb285-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
-<span id="cb285-9"><a href="#cb285-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
-<span id="cb285-10"><a href="#cb285-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb285-11"><a href="#cb285-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">4</a></span></p>
+<div class="sourceCode" id="cb289"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb289-1"><a href="#cb289-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info remove_cvref<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb289-2"><a href="#cb289-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info decay<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb289-3"><a href="#cb289-3" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb289-4"><a href="#cb289-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_type<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb289-5"><a href="#cb289-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb289-6"><a href="#cb289-6" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info common_reference<span class="op">(</span>R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb289-7"><a href="#cb289-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info underlying_type<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb289-8"><a href="#cb289-8" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
+<span id="cb289-9"><a href="#cb289-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
+<span id="cb289-10"><a href="#cb289-10" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb289-11"><a href="#cb289-11" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">4</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb286"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb286-1"><a href="#cb286-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
-<span id="cb286-2"><a href="#cb286-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb286-3"><a href="#cb286-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
-<span id="cb286-4"><a href="#cb286-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
-<span id="cb286-5"><a href="#cb286-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
-<span id="cb286-6"><a href="#cb286-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
-<span id="cb286-7"><a href="#cb286-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
-<span id="cb286-8"><a href="#cb286-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
-<span id="cb286-9"><a href="#cb286-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb290"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb290-1"><a href="#cb290-1" aria-hidden="true" tabindex="-1"></a><span class="co">// example implementation</span></span>
+<span id="cb290-2"><a href="#cb290-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb290-3"><a href="#cb290-3" aria-hidden="true" tabindex="-1"></a>  type <span class="op">=</span> dealias<span class="op">(</span>type<span class="op">)</span>;</span>
+<span id="cb290-4"><a href="#cb290-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>has_template_arguments<span class="op">(</span>type<span class="op">)</span> <span class="op">&amp;&amp;</span> template_of<span class="op">(</span>type<span class="op">)</span> <span class="op">==</span> <span class="op">^^</span>reference_wrapper<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb290-5"><a href="#cb290-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> add_lvalue_reference<span class="op">(</span>template_arguments_of<span class="op">(</span>type<span class="op">)[</span><span class="dv">0</span><span class="op">])</span>;</span>
+<span id="cb290-6"><a href="#cb290-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span> <span class="cf">else</span> <span class="op">{</span></span>
+<span id="cb290-7"><a href="#cb290-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">return</span> type;</span>
+<span id="cb290-8"><a href="#cb290-8" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb290-9"><a href="#cb290-9" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -14579,32 +14621,32 @@ acceptance of <span class="citation" data-cites="P2830R10"><a href="https://wg21
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">1</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code>, for
 each function <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp"><span class="dt">size_t</span><span class="op">(</span>meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>UNARY-TRAIT</em><span class="op">(^^</span>T<span class="op">)</span></code>
 equals the value of the corresponding property <code class="sourceCode cpp"><em>UNARY-TRAIT</em>_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">2</a></span>
 For any type or type alias <code class="sourceCode cpp">T</code> and
 value <code class="sourceCode cpp">I</code>, for each function <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em></code>
 defined in this subclause with the type <code class="sourceCode cpp">info<span class="op">(</span><span class="dt">size_t</span>, meta<span class="op">::</span>info<span class="op">)</span></code>,
 <code class="sourceCode cpp">meta<span class="op">::</span><em>BINARY-TRAIT</em><span class="op">(</span>I, <span class="op">^^</span>T<span class="op">)</span></code>
 returns a reflection representing the type denoted by <code class="sourceCode cpp"><em>BINARY-TRAIT</em>_t<span class="op">&lt;</span>I, T<span class="op">&gt;</span></code>
 as defined in <span>22.4 <a href="https://wg21.link/tuple">[tuple]</a></span> or <span>22.6 <a href="https://wg21.link/variant">[variant]</a></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">3</a></span>
 For any types or type aliases <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code>, <code class="sourceCode cpp">meta<span class="op">::</span>type_order<span class="op">(^^</span>T, <span class="op">^^</span>U<span class="op">)</span></code>
 equals the value of <code class="sourceCode cpp">type_order_v<span class="op">&lt;</span>T, U<span class="op">&gt;</span></code>
 as defined in <span>17.12 <a href="https://wg21.link/cmp">[cmp]</a></span>.</p>
-<div class="sourceCode" id="cb287"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb287-1"><a href="#cb287-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb287-2"><a href="#cb287-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb287-3"><a href="#cb287-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb287-4"><a href="#cb287-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
-<span id="cb287-5"><a href="#cb287-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
-<span id="cb287-6"><a href="#cb287-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb287-7"><a href="#cb287-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> strong_ordering type_order<span class="op">(</span>info a, info b<span class="op">)</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb291"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb291-1"><a href="#cb291-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb291-2"><a href="#cb291-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb291-3"><a href="#cb291-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb291-4"><a href="#cb291-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span>
+<span id="cb291-5"><a href="#cb291-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span>
+<span id="cb291-6"><a href="#cb291-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb291-7"><a href="#cb291-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> strong_ordering type_order<span class="op">(</span>info a, info b<span class="op">)</span>;</span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14618,33 +14660,33 @@ in <span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, w
 as a mandates:</p>
 <div class="std">
 <blockquote>
-<div class="sourceCode" id="cb288"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb288-1"><a href="#cb288-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> To, <span class="kw">class</span> From<span class="op">&gt;</span></span>
-<span id="cb288-2"><a href="#cb288-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> To bit_cast<span class="op">(</span><span class="kw">const</span> From<span class="op">&amp;</span> from<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">1</a></span>
+<div class="sourceCode" id="cb292"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb292-1"><a href="#cb292-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> To, <span class="kw">class</span> From<span class="op">&gt;</span></span>
+<span id="cb292-2"><a href="#cb292-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> To bit_cast<span class="op">(</span><span class="kw">const</span> From<span class="op">&amp;</span> from<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">1</a></span>
 <em>Constraints</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">(1.1)</a></span>
 <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>To<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span>From<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_777" id="pnum_777">(1.2)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>To<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_778" id="pnum_778">(1.3)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>From<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
 </ul>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_779" id="pnum_779">*</a></span>
 <em>Mandates</em>: Neither <code class="sourceCode cpp">To</code> nor
 <code class="sourceCode cpp">From</code> are consteval-only types
 ([expr.const]).</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_780" id="pnum_780">2</a></span>
 <em>Returns</em>: […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_781" id="pnum_781">3</a></span>
 <span class="rm" style="color: #bf0303"><del><em>Remarks</em></del></span> <span class="addu"><em>Constant When</em></span>: <span class="rm" style="color: #bf0303"><del>This function is constexpr if and only
 if</del></span> <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -14652,23 +14694,23 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_782" id="pnum_782">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_783" id="pnum_783">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_784" id="pnum_784">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_785" id="pnum_785">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_786" id="pnum_786">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
@@ -14689,9 +14731,9 @@ contains two consecutive
 be ill-formed in this revision of C++.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
-<div class="sourceCode" id="cb289"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb289-1"><a href="#cb289-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> C <span class="op">{</span> <span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span><span class="op">)</span>; <span class="op">}</span>;</span>
-<span id="cb289-2"><a href="#cb289-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span> <span class="op">(</span>C<span class="op">::*</span>p<span class="op">)(</span><span class="dt">int</span><span class="op">)</span>, C<span class="op">)</span>;</span>
-<span id="cb289-3"><a href="#cb289-3" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> i <span class="op">=</span> <span class="op">&amp;</span>C<span class="op">::</span><span class="kw">operator</span><span class="op">^^</span>C<span class="op">{}</span>; <span class="co">// ill-formed; previously well-formed</span></span></code></pre></div>
+<div class="sourceCode" id="cb293"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb293-1"><a href="#cb293-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> C <span class="op">{</span> <span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span><span class="op">)</span>; <span class="op">}</span>;</span>
+<span id="cb293-2"><a href="#cb293-2" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> <span class="kw">operator</span><span class="op">^(</span><span class="dt">int</span> <span class="op">(</span>C<span class="op">::*</span>p<span class="op">)(</span><span class="dt">int</span><span class="op">)</span>, C<span class="op">)</span>;</span>
+<span id="cb293-3"><a href="#cb293-3" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> i <span class="op">=</span> <span class="op">&amp;</span>C<span class="op">::</span><span class="kw">operator</span><span class="op">^^</span>C<span class="op">{}</span>; <span class="co">// ill-formed; previously well-formed</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </blockquote>
@@ -14728,10 +14770,10 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb290"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb290-1"><a href="#cb290-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
-<span id="cb290-2"><a href="#cb290-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
-<span id="cb290-3"><a href="#cb290-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
-<span id="cb290-4"><a href="#cb290-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2025XXL</span></span></code></pre></div>
+<div class="sourceCode" id="cb294"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb294-1"><a href="#cb294-1" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_coroutine 201902L</span>
+<span id="cb294-2"><a href="#cb294-2" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_destroying_delete 201806L</span>
+<span id="cb294-3"><a href="#cb294-3" aria-hidden="true" tabindex="-1"></a>  __cpp_impl_three_way_comparison 201907L</span>
+<span id="cb294-4"><a href="#cb294-4" aria-hidden="true" tabindex="-1"></a><span class="va">+ __cpp_impl_reflection 2025XXL</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14739,7 +14781,7 @@ makes sense to provide one?</p>
 <div class="std">
 <blockquote>
 <div>
-<div class="sourceCode" id="cb291"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb291-1"><a href="#cb291-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2025XXL // also in &lt;meta&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb295"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb295-1"><a href="#cb295-1" aria-hidden="true" tabindex="-1"></a><span class="va">+ #define __cpp_lib_reflection 2025XXL // also in &lt;meta&gt;</span></span></code></pre></div>
 </div>
 </blockquote>
 </div>
@@ -14751,7 +14793,7 @@ shown to be necessary. The following changes were confirmed by EWG
 during the Hagenberg 2025 meeting.</p>
 <p>One small change was needed to the reflection operator.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_787" id="pnum_787">1</a></span>
 Application of the
 <code class="sourceCode cpp"><span class="op">^^</span></code> operator
 to a non-type template parameter
@@ -14780,7 +14822,7 @@ as appropriate.</li>
 <p>A few changes were needed to “consteval-only types” to ensure that
 objects of such types cannot reach runtime.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_788" id="pnum_788">2</a></span>
 Relaxed linkage restrictions on objects of consteval-only types
 <ul>
 <li><strong>P2996R4</strong>: Rigid rules prevented objects of
@@ -14798,7 +14840,7 @@ imported across TUs and modules without issue.
 <li>Try it with <a href="https://godbolt.org/z/Y8cdd9sGo">Clang</a>.</li>
 </ul></li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_789" id="pnum_789">3</a></span>
 Immediate-escalation of expressions of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Every expression of consteval-only type
@@ -14808,7 +14850,7 @@ to persist to runtime (e.g., passing a reference to a <code class="sourceCode cp
 to a runtime function).</li>
 <li>Fully implemented; try it with Clang <a href="https://godbolt.org/z/5sfe7vdzE">here</a> and <a href="https://godbolt.org/z/T3MY1Yqo4">here</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">4</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_790" id="pnum_790">4</a></span>
 Immediate-escalation of non-constexpr variables of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Immediate-escalating functions containing
@@ -14819,7 +14861,7 @@ of consteval-only type (for which an expression does not necessarily
 appear) from reaching runtime.</li>
 <li>Fully implemented; try it with <a href="https://godbolt.org/z/3asrnK13G">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_791" id="pnum_791">5</a></span>
 No “erasure” of consteval-only-ness from results of constant
 expressions.
 <ul>
@@ -14838,7 +14880,7 @@ seen <a href="https://godbolt.org/z/E4faezfr3">here</a>).</li>
 </ul>
 <p>Two changes were needed for splicers.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_792" id="pnum_792">6</a></span>
 A slight syntactic change is needed for template splicers.
 <ul>
 <li><strong>P2994R4</strong>:
@@ -14859,7 +14901,7 @@ were supposed to work.</li>
 </ul></li>
 <li>Try it on godbolt with <a href="https://godbolt.org/z/GKj5of839">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">7</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_793" id="pnum_793">7</a></span>
 Reflections of concepts cannot be spliced.
 <ul>
 <li><strong>P2996R4</strong>: Concepts could be spliced within both
@@ -14882,7 +14924,7 @@ after P2996R4. When the evaluation of an expression calls
 evaluation produces an <em>injected declaration</em> of the completed
 type (try it on <a href="https://godbolt.org/z/PTeb9qqcW">godbolt</a>).</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_777" id="pnum_777">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_794" id="pnum_794">1</a></span>
 Recent revisions lock down the context from which
 <code class="sourceCode cpp">define_aggregate</code> can be called.
 <ul>
@@ -14901,7 +14943,7 @@ for code injection due to e.g., template instantiation behavior,
 immediate-escalating expression behavior, etc.</li>
 <li>Fully implemented with Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_778" id="pnum_778">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_795" id="pnum_795">2</a></span>
 The scope that a given expression can inject a declaration <em>into</em>
 has been constrained.
 <ul>
@@ -14916,7 +14958,7 @@ use <code class="sourceCode cpp">define_aggregate</code> to observe
 failed substitutions, overload resolution order, etc.</li>
 <li>Fully implemented in Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_779" id="pnum_779">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_796" id="pnum_796">3</a></span>
 Strengthening order of evaluation for core constant expressions removes
 the need for more IFNDR.
 <ul>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -3786,31 +3786,40 @@ Add a new paragraph at the end of [basic.types.general]{.sref} as follows:
 Add new paragraphs before the last paragraph of [basic.fundamental]{.sref} as follows:
 
 ::: std
+[16]{.pnum} The types denoted by `$cv$ std​::​nullptr_t` are distinct types. [...]
+
 ::: addu
 
-[17 - 1]{.pnum} A value of type `std::meta::info` is called a _reflection_. There exists a unique _null reflection_; every other reflection is a representation of
+[x]{.pnum} A value of type `std::meta::info` is called a _reflection_. There exists a unique _null reflection_; every other reflection is a representation of
 
-* a value of structural type ([temp.param]),
-* an object with static storage duration ([basic.stc]),
-* a variable ([basic.pre]),
-* a structured binding ([dcl.struct.bind]),
-* a function ([dcl.fct]),
-* an enumerator ([dcl.enum]),
-* a type alias ([dcl.typedef]),
-* a type ([basic.types]),
-* a class member ([class.mem]),
-* an unnamed bit-field ([class.bit]),
-* a primary class template ([temp.pre]),
-* a function template ([temp.pre]),
-* a primary variable template ([temp.pre]),
-* an alias template ([temp.alias]),
-* a concept ([temp.concept]),
-* a namespace alias ([namespace.alias]),
-* a namespace ([basic.namespace.general]),
-* a direct base class relationship ([class.derived.general]), or
-* a data member description ([class.mem.general]).
+* [x.#]{.pnum} a value (see below) of structural type ([temp.param]),
+* [x.#]{.pnum} an object with static storage duration ([basic.stc]),
+* [x.#]{.pnum} a variable ([basic.pre]),
+* [x.#]{.pnum} a structured binding ([dcl.struct.bind]),
+* [x.#]{.pnum} a function ([dcl.fct]),
+* [x.#]{.pnum} an enumerator ([dcl.enum]),
+* [x.#]{.pnum} a type alias ([dcl.typedef]),
+* [x.#]{.pnum} a type ([basic.types]),
+* [x.#]{.pnum} a class member ([class.mem]),
+* [x.#]{.pnum} an unnamed bit-field ([class.bit]),
+* [x.#]{.pnum} a primary class template ([temp.pre]),
+* [x.#]{.pnum} a function template ([temp.pre]),
+* [x.#]{.pnum} a primary variable template ([temp.pre]),
+* [x.#]{.pnum} an alias template ([temp.alias]),
+* [x.#]{.pnum} a concept ([temp.concept]),
+* [x.#]{.pnum} a namespace alias ([namespace.alias]),
+* [x.#]{.pnum} a namespace ([basic.namespace.general]),
+* [x.#]{.pnum} a direct base class relationship ([class.derived.general]), or
+* [x.#]{.pnum} a data member description ([class.mem.general]).
 
 A reflection is said to _represent_ the corresponding construct.
+
+A reflection of a value of type `T` is associated with
+
+* [x.#]{.pnum} if `T` is a scalar type, then a computed value of type `T`, or
+* [x.#]{.pnum} if `T` is a class type, then a template parameter object ([temp.param]) of type `T`.
+
+[A reflection of a value can be produced by library functions such as `std::meta::value_of` and `std::meta::reflect_value`]{.note}
 
 ::: example
 ```cpp
@@ -3864,11 +3873,13 @@ constexpr auto r18 = std::meta::data_member_spec(^^int, {.name="member"});
 
 :::
 
-[17 - 2]{.pnum} *Recommended practice*: Implementations should not represent other constructs specified in this document, such as partial template specializations, attributes, placeholder types, statements, or expressions, as values of type `std::meta::info`.
+[y]{.pnum} *Recommended practice*: Implementations should not represent other constructs specified in this document, such as partial template specializations, attributes, placeholder types, statements, or expressions, as values of type `std::meta::info`.
 
-[17 - 3]{.pnum} [Future revisions of this document can specify semantics for reflections representing any such constructs.]{.note}
+[z]{.pnum} [Future revisions of this document can specify semantics for reflections representing any such constructs.]{.note}
 
 :::
+
+[17]{.pnum} The types described in this subclause are called *fundamental types*.
 :::
 
 ### [intro.execution]{.sref} Sequential execution {-}
@@ -4191,7 +4202,11 @@ auto g = typename [:^^int:](42);
 
   [The type of a `$splice-expression$` designating a variable or structured binding of reference type will be adjusted to a non-reference type ([expr.type]{.sref}).]{.note}
 
-* [#.#]{.pnum} Otherwise, if `$S$` is a value or an enumerator, the expression is a prvalue that computes `$S$` and whose type is the same as that of `$S$`.
+* [#.#]{.pnum} Otherwise, if `$S$` is a value or an enumerator, the expression is a prvalue whose type is the same of `$S$` and whose value is determined as follows:
+
+  * [#.#.#]{.pnum} if `$S$` is an enumerator, then the value is the value of the enumerator;
+  * [#.#.#]{.pnum} otherwise, if `$S$` is a value of scalar type, then the value is `$S$`'s associated value;
+  * [#.#.#]{.pnum} otherwise (if `$S$` is a value of class type), then the value is the result of the lvalue-to-rvalue conversion applied to `$S$`'s associated template parameter object.
 
 * [#.#]{.pnum} Otherwise, the expression is ill-formed.
 
@@ -6820,26 +6835,20 @@ static_assert(object_of(^^x) == object_of(^^y)); // OK, because y is a reference
 consteval info value_of(info r);
 ```
 
-[#]{.pnum} Let `$Q$` be
+[#]{.pnum} Let `$R$` be a constant expression of type `info` such that `$R$ == r` is `true`.
 
-* [#.#]{.pnum} If `r` represents a reference, then the object referred to by that reference.
-* [#.#]{.pnum} Otherwise, if `r` represents any other variable, then the object declared by that variable.
-* [#.#]{.pnum} Otherwise, the construct represented by `r`.
+[#]{.pnum} *Constant When*: `[: $R$ :]` is a valid `$splice-expression$` ([expr.prim.splice]).
 
-[#]{.pnum} *Constant When*: `$Q$` is
+[#]{.pnum} *Effects*: Equivalent to:
 
-* [#.#]{.pnum} a value,
-* [#.#]{.pnum} an enumerator, or
-* [#.#]{.pnum} an object such that
-  * [#.#.#]{.pnum} the lifetime of `$Q$` has not ended,
-  * [#.#.#]{.pnum} the type of `$Q$` is a structural type ([temp.param]) that is copyable, and
-  * [#.#.#]{.pnum} either `$Q$` is usable in constant expressions from some point in the evaluation context or the lifetime of `$Q$` began within the core constant expression currently under evaluation ([expr.const]).
+```cpp
+if (is_value(r)) {
+  return r;
+} else {
+  return reflect_value([: $R$ :]);
+}
+```
 
-[#]{.pnum} *Returns*:
-
-* [#.#]{.pnum} If `$Q$` is an object `o`, then a reflection of the value held by `o`. The reflected value has the type represented by `type_of(o)`, with the cv-qualifiers removed if this is a scalar type.
-* [#.#]{.pnum} Otherwise, if `$Q$` is an enumerator, then a reflection of the value of the enumerator. The reflected value has the type represented by `type_of(r)` with the cv-qualifiers removed.
-* [#.#]{.pnum} Otherwise, `r`.
 
 ::: example
 ```cpp
@@ -7724,22 +7733,52 @@ consteval info substitute(info templ, R&& arguments);
 ::: addu
 [#]{.pnum} An object `$O$` of type `$T$` is *meta-reflectable* if an lvalue expression denoting `$O$` is suitable for use as a constant template argument for a constant template parameter of type `$T$&` ([temp.arg.nontype]).
 
+[#]{.pnum} The following are defined for exposition only to aid in the specification of `reflect_value`:
+
+```cpp
+template <typename T>
+  consteval info $reflect-value-scalar$(T expr); // exposition only
+```
+
+Let `$V$` be the value computed by an lvalue-to-rvalue conversion applied to `expr`.
+
+[#]{.pnum} *Constant When*: `$V$` satisfies the constraints for for a value computed by a prvalue constant expression ([expr.const]) and, if `$V$` has pointer type, then it is not a pointer to an object that is not meta-reflectable.
+
+[#]{.pnum} *Returns*: A reflection of a value of type `$T$` associated with the computed value `$V$`.
+
+```cpp
+template <typename T>
+  consteval info $reflect-value-class$(T const& expr); // exposition only
+```
+
+[#]{.pnum} *Mandates*: `T` is copy constructible and structural ([temp.param]).
+
+[#]{.pnum} Let `$O$` be a template parameter object ([temp.param]) copy-initialized from `expr`.
+
+[#]{.pnum} *Constant When*:
+
+* [#.#]{.pnum} `$O$` satisfies the constraints for a constant expression ([expr.const]),
+* [#.#]{.pnum} no constituent reference of `$O$` refers to an object that is not meta-reflectable, and
+* [#.#]{.pnum} no constituent value of `$O$` of pointer type is a pointer to an object that is not meta-reflectable.
+
+[#]{.pnum} *Returns*: A reflection of a value of type `T` associated with the template parameter object `$O$`.
+
 ```cpp
 template <typename T>
   consteval info reflect_value(const T& expr);
 ```
 
-[#]{.pnum} *Mandates*: `T` is a copy constructible, structural type that is neither a reference type nor an array type.
+*Effects*: Equivalent to:
 
-[#]{.pnum} Let `$V$` be the value computed by an lvalue-to-rvalue conversion applied to `expr`.
+```cpp
+if (is_class_type(^^T)) {
+  return $reflect-value-class$(expr);
+} else {
+  return $reflect-value-scalar$(expr);
+}
+```
 
-[#]{.pnum} *Constant When*:
-
-* [#.#]{.pnum} `$V$` satisfies the constraints for a value computed by a prvalue constant expression ([expr.const]),
-* [#.#]{.pnum} no constituent reference of `$V$` refers to an object that is not meta-reflectable, and
-* [#.#]{.pnum} no constituent value of `$V$` of pointer type is a pointer to an object that is not meta-reflectable.
-
-[#]{.pnum} *Returns*: A reflection of `$V$`. The type of the represented value is the cv-unqualified version of `T`.
+[Array-to-pointer and function-to-function-pointer decay occur.]{.note}
 
 ```cpp
 template <typename T>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -31,6 +31,8 @@ Since [@P2996R11]:
 * core wording updates
   * better specify interaction between spliced function calls and overload resolution; integrate fix to [@CWG2701]
   * disallow reflection of local parameters introduced by `$requires-expression$`s
+  * change "naming class" to "designating class" and define for `$splice-expression$`s
+  * clarified value reflection model and the interaction between `reflect_value`, `value_of`, and splicing.
 * library wording updates
   * improve specification of `access_context::current()` (including examples)
   * `size_of(r)` is no longer constant if `r` is a bit-field
@@ -3816,7 +3818,7 @@ A reflection is said to _represent_ the corresponding construct.
 
 A reflection of a value of type `T` is associated with
 
-* [x.#]{.pnum} if `T` is a scalar type, then a computed value of type `T`, or
+* [x.#]{.pnum} if `T` is a scalar type, then a value of type `T`, or
 * [x.#]{.pnum} if `T` is a class type, then a template parameter object ([temp.param]) of type `T`.
 
 [A reflection of a value can be produced by library functions such as `std::meta::value_of` and `std::meta::reflect_value`]{.note}
@@ -4202,7 +4204,7 @@ auto g = typename [:^^int:](42);
 
   [The type of a `$splice-expression$` designating a variable or structured binding of reference type will be adjusted to a non-reference type ([expr.type]{.sref}).]{.note}
 
-* [#.#]{.pnum} Otherwise, if `$S$` is a value or an enumerator, the expression is a prvalue whose type is the same of `$S$` and whose value is determined as follows:
+* [#.#]{.pnum} Otherwise, if `$S$` is a value or an enumerator, the expression is a prvalue whose type is the same as that of `$S$` and whose value is determined as follows:
 
   * [#.#.#]{.pnum} if `$S$` is an enumerator, then the value is the value of the enumerator;
   * [#.#.#]{.pnum} otherwise, if `$S$` is a value of scalar type, then the value is `$S$`'s associated value;
@@ -4220,9 +4222,7 @@ auto g = typename [:^^int:](42);
 
 * [#.#]{.pnum} Otherwise, the expression is ill-formed.
 
-[Access checking of class members occurs during lookup, and therefore does not pertain to splicing.]{.note}
-
-[#]{.pnum} While performing overload resolution to determine the entity referred to by a `$splice-expression$`, the best viable function is _designated in a manner exempt from access rules_.
+[Class members designated by `$splice-expression$`s are accessible from any point ([class.access.base]). A class member access expression whose right operand is a `$splice-expression$` is ill-formed if the left operand (considered as a pointer) cannot be implicitly converted to a pointer to the designating class of the right operand.]{.note}
 
 :::
 :::
@@ -4273,7 +4273,7 @@ Modify paragraph 4 to account for splices in member access expressions:
 
 :::
 
-Adjust the language in paragraphs 6-9 to account for `$splice-expression$`s. Explicitly add a fallback to paragraph 7 that makes other cases ill-formed.
+Adjust the language in paragraphs 6-9 to account for `$splice-expression$`s. Explicitly add a fallback to paragraph 7 that makes other cases ill-formed. Update the term "naming class" to "designated class" in paragraph 8.
 
 ::: std
 
@@ -4283,7 +4283,7 @@ Adjust the language in paragraphs 6-9 to account for `$splice-expression$`s. Exp
 
 [6]{.pnum} If `E2` [is]{.rm} [designates]{.addu} a bit-field, `E1.E2` is a bit-field. [...]
 
-[7]{.pnum} If `E2` [designates an entity that]{.addu} is declared to have type "reference to `T`", then `E1.E2` is an lvalue of type `T`. [If]{.rm} [In that case, if]{.addu} `E2` [is]{.rm} [designates]{.addu} a static data member, `E1.E2` designates the object or function to which the reference is bound, otherwise `E1.E2` designates the object or function to which the corresponding reference member of `E1` is bound. Otherwise, one of the following rules applies.
+[#]{.pnum} If `E2` [designates an entity that]{.addu} is declared to have type "reference to `T`", then `E1.E2` is an lvalue of type `T`. [If]{.rm} [In that case, if]{.addu} `E2` [is]{.rm} [designates]{.addu} a static data member, `E1.E2` designates the object or function to which the reference is bound, otherwise `E1.E2` designates the object or function to which the corresponding reference member of `E1` is bound. Otherwise, one of the following rules applies.
 
 * [#.#]{.pnum} If `E2` [is]{.rm} [designates]{.addu} a static data member and the type of `E2` is `T`, then `E1.E2` is an lvalue; [...]
 * [#.#]{.pnum} [Otherwise, if]{.addu} [If]{.rm} `E2` [is]{.rm} [designates]{.addu} a non-static data member and the type of `E1` is "_cq1_ _vq1_ `X`", and the type of `E2` is "_cq2 vq2_ `T`", [...]. If [the entity designated by]{.addu} `E2` is declared to be a `mutable` member, then the type of `E1.E2` is "_vq12_ `T`". If [the entity designated by]{.addu} `E2` is not declared to be a `mutable` member, then the type of `E1.E2` is "_cq12_ _vq12_ `T`".
@@ -4296,9 +4296,9 @@ Adjust the language in paragraphs 6-9 to account for `$splice-expression$`s. Exp
 
 * [[#.#]{.pnum} Otherwise, the program is ill-formed.]{.addu}
 
-[8]{.pnum} If `E2` [is]{.rm} [designates]{.addu} a non-static member, the program is ill-formed if the class of which `E2` [is directly]{.rm} [designates]{.addu} a member is an ambiguous base ([class.member.lookup]{.sref}) of the naming class ([class.access.base]{.sref}) of `E2`.
+[#]{.pnum} If `E2` [is]{.rm} [designates]{.addu} a non-static member, the program is ill-formed if the class of which `E2` [is directly]{.rm} [designates]{.addu} a [direct]{.addu} member is an ambiguous base ([class.member.lookup]{.sref}) of the [naming]{.rm} [designating]{.addu} class ([class.access.base]{.sref}) of `E2`.
 
-[9]{.pnum} If [the entity designated by]{.addu} `E2` is a non-static member and the result of `E1` is an object whose type is not similar ([conv.qual]) to the type of `E1`, the behavior is undefined.
+[#]{.pnum} If [the entity designated by]{.addu} `E2` is a non-static member and the result of `E1` is an object whose type is not similar ([conv.qual]) to the type of `E1`, the behavior is undefined.
 
 :::
 
@@ -5330,6 +5330,38 @@ Prefer "type alias" rather than `$typedef-name$` in the note that follows paragr
 [Because access control applies to the declarations named, if access control is applied to a [`$typedef-name$`]{.rm} [type alias]{.addu}, only the accessibility of the typedef or alias declaration itself is considered. The accessibility of the [entity referred to by the `$typedef-name$`]{.rm} [underlying entity]{.addu} is not considered.]{.note3}
 :::
 
+### [class.access.base]{.sref} Accessibility of base classes and base class members {-}
+
+Update paragraph 5 to handle `$splice-expression$`s, and to make more clear that the "naming class" (renamed "designating class" here) is a property of the expression. State explicitly that members designated through `$splice-expression$`s are accessible.
+
+::: std
+[5]{.pnum} [...]
+
+[The access to a member is affected by the class in which the member is named. This naming class is the]{.rm} [An expression `E` that designates a member `m` has a _designating class_ that affects the access to `m`. This designating class is either]{.addu}
+
+- [[#.#]{.pnum} the innermost class of which `m` is directly a member if `E` is a `$splice-expression$` or]{.addu}
+- [#.#]{.pnum} [the]{.addu} class in whose scope lookup performed a search that found [`m`]{.addu} [the member]{.rm} [otherwise]{.addu}.
+
+[This class can be explicit, e.g., when a `$qualified-id$` is used, or implicit, e.g., when a class member access operator ([expr.ref]) is used (including cases where an implicit "`this->`" was added). If both a class member access operator and a `$qualified-id$` are used to [name]{.rm} [designate]{.addu} the member (as in `p->T::m`), the class [naming]{.rm} [designating]{.addu} the member is the class denoted by the `$nested-name-specifier$` of the `$qualified-id$` (that is, `T`).]{.note3}
+
+A member `m` is accessible at the point `$R$` when [named]{.rm} [designated]{.addu} in class `N` if
+
+- [#.#]{.pnum} `m` as a member of `N` is public, or
+- [#.#]{.pnum} `m` as a member of `N` is private, and `$R$` occurs in a direct member or friend of class `$N$`, or
+- [#.#]{.pnum} `m` as a member of `N` is protected, and `$R$` occurs in a direct member or friend of class `$N$`, or in a member of a class `P` derived from `N`, where `m` as a member of `P` is public, private, or protected, or
+- [[#.#]{.pnum} `m` is designated by a `$splice-expression$`, or]{.addu}
+- [#.#]{.pnum} there exists a base class `B` of `N` that is accessible at `$R$`, and `m` is accessible at `$R$` when [named]{.rm} [designated]{.addu} in class `B`.
+:::
+
+Update paragraph 6, and the note which follows, to use the term "designated class":
+
+::: std
+[6]{.pnum} If a class member access operator, including an implicit "`this->`", is used to access a non-static data member or non-static member function, the reference is ill-formed if the left operand (considered as a pointer in the "`.`" case) cannot be implicitly converted to a pointer to the [naming]{.rm} [designating]{.addu} class of the right operand.
+
+[This requirement is in addition to the requirement that the member be accessible as [named]{.rm} [designated]{.addu}.]{.note}
+
+:::
+
 ### [over.pre]{.sref} Preamble {-}
 
 Add a note explaining the expressions that form overload sets after paragraph 2.
@@ -5338,17 +5370,6 @@ Add a note explaining the expressions that form overload sets after paragraph 2.
 [2]{.pnum} When a function is named [or designated]{.addu} in a call, which function declaration is being referenced and the validity of the call are determined by comparing the types of the arguments at the point of use with the types of the parameters in the declarations in the overload set. This function selection process is called _overload resolution_ and is defined in [over.match].
 
   [[Overload sets are formed by `$id-expression$`s naming functions and function templates and by `$splice-expression$`s designating entities of the same kinds.]{.note}]{.addu}
-
-:::
-
-### [over.match.general]{.sref} General {-}
-
-Modify paragraphs 3 and 4 to clarify that access rules do not apply in all contexts.
-
-::: std
-[3]{.pnum} If a best viable function exists and is unique, overload resolution succeeds and produces it as the result. Otherwise overload resolution fails and the invocation is ill-formed. When overload resolution succeeds, and the best viable function is [not]{.rm} [neither designated in a manner exempt from access rules ([expr.prim.splice]) nor]{.addu} accessible in the context in which it is used, the program is ill-formed.
-
-[4]{.pnum} Overload resolution results in a _usable candidate_ if overload resolution succeeds and the selected candidate is either not a function ([over.built]{.sref}), or is a function that is not deleted and is [either designated in a manner exempt from access rules or is]{.addu} accessible from the context in which overload resolution was performed.
 
 :::
 
@@ -5707,10 +5728,11 @@ is introduced.
 
 ### [temp.arg.template]{.sref} Template template arguments {-}
 
-Extend [temp.arg.template]{.sref}/1 to cover splice template arguments:
+Extend paragraph 1 to cover splice template arguments:
 
 ::: std
 [1]{.pnum} A `$template-argument$` for a template template parameter shall [either]{.addu} be the name of a template [or a `$splice-template-argument$`]{.addu}. For a `$type-tt-parameter$`, the name [or `$splice-template-argument$`]{.addu} shall [denote]{.rm} [designate]{.addu} a class template or alias template. For a `$variable-tt-parameter$`, the name [or `$splice-template-argument$`]{.addu} shall [denote]{.rm} [designate]{.addu} a variable template. For a `$concept-tt-parameter$`, the name [or `$splice-template-argument$`]{.addu} shall [denote]{.rm} [designate]{.addu} a concept. Only primary templates are considered when matching the template argument with the corresponding parameter; partial specializations are not considered even if their parameter lists match that of the template template parameter.
+
 :::
 
 ### [temp.type]{.sref} Type equivalence {-}
@@ -6839,7 +6861,7 @@ consteval info value_of(info r);
 
 [#]{.pnum} *Constant When*: `[: $R$ :]` is a valid `$splice-expression$` ([expr.prim.splice]).
 
-[#]{.pnum} *Effects*: Equivalent to:
+[#]{.pnum} *Effects*:  Equivalent to:
 
 ```cpp
 if (is_value(r)) {
@@ -7383,7 +7405,7 @@ consteval bool is_accessible(info r, access_context ctx);
 * [#.#]{.pnum} `r` does not represent a class member for which `$PARENT-CLS$(r)` is an incomplete class and
 * [#.#]{.pnum} `r` does not represent a direct base class relationship between a base class and an incomplete derived class.
 
-[#]{.pnum} Let `$NAMING-CLS$(r, ctx)` be:
+[#]{.pnum} Let `$DESIGNATING-CLS$(r, ctx)` be:
 
 * [#.#]{.pnum} If `ctx.naming_class()` represents a class `$C$`, then `$C$`.
 * [#.#]{.pnum} Otherwise, `$PARENT-CLS$(r)`.
@@ -7393,15 +7415,15 @@ consteval bool is_accessible(info r, access_context ctx);
 * [#.#]{.pnum} If `r` represents an unnamed bit-field `$F$`, then `is_accessible(r@~$H$~@, ctx)` where `r@~$H$~@` represents a hypothetical non-static data member of the class represented by `$PARENT-CLS$(r)` with the same access as `$F$`. [Unnamed bit-fields are treated as class members for the purpose of `is_accessible`.]{.note}
 * [#.#]{.pnum} Otherwise, if `r` does not represent a class member or a direct base class relationship, then `true`.
 * [#.#]{.pnum} Otherwise, if `r` represents
-  * [#.#.#]{.pnum} a class member that is not a (possibly indirect or variant) member of `$NAMING-CLS$(r, ctx)` or
-  * [#.#.#]{.pnum} a direct base class relationship such that `parent_of(r)` does not represent `$NAMING-CLS$(r, ctx)` or a (direct or indirect) base class thereof,
+  * [#.#.#]{.pnum} a class member that is not a (possibly indirect or variant) member of `$DESIGNATING-CLS$(r, ctx)` or
+  * [#.#.#]{.pnum} a direct base class relationship such that `parent_of(r)` does not represent `$DESIGNATING-CLS$(r, ctx)` or a (direct or indirect) base class thereof,
 
   then `false`.
 * [#.#]{.pnum} Otherwise, if `ctx.scope()` is the null reflection, then `true`.
 
 * [#.#]{.pnum} Otherwise, letting `$P$` be a program point whose immediate scope is the function parameter scope, class scope, or namespace scope corresponding to the function, class, or namespace represented by `ctx.scope()`:
-  * [#.#.#]{.pnum} If `r` represents a direct base class relationship with base class `$B$`, then `true` if base class `$B$` of `$NAMING-CLASS$(r, ctx)` is accessible at `$P$` ([class.access.base]); otherwise, `false`.
-  * [#.#.#]{.pnum} Otherwise, `r` represents a class member `$M$`; `true` if `$M$` is accessible at `$P$` when named in `$NAMING-CLS$(r, ctx)` ([class.access.base]). Otherwise, `false`.
+  * [#.#.#]{.pnum} If `r` represents a direct base class relationship with base class `$B$`, then `true` if base class `$B$` of `$DESIGNATING-CLS$(r, ctx)` is accessible at `$P$` ([class.access.base]); otherwise, `false`.
+  * [#.#.#]{.pnum} Otherwise, `r` represents a class member `$M$`; `true` if `$M$` is accessible at `$P$` when designated in `$DESIGNATING-CLS$(r, ctx)` ([class.access.base]). Otherwise, `false`.
 
 ::: note
 The definitions of when a class member or base class is accessible from a point `$P$` do not consider whether a declaration of that entity is reachable from `$P$`.
@@ -7706,7 +7728,7 @@ consteval bool can_substitute(info templ, R&& arguments);
 
 [#]{.pnum} Let `Z` be the template represented by `templ` and let `Args...` be a sequence of prvalue constant expressions that compute the reflections held by the elements of `arguments`.
 
-[#]{.pnum} *Returns*: `true` if `Z<[:Args:]...>` is a valid *template-id* ([temp.names]). Otherwise, `false`.
+[#]{.pnum} *Returns*: `true` if `Z<[:Args:]...>` is a valid `$template-id$` ([temp.names]) that does not name a function whose type contains an undeduced placeholder type. Otherwise, `false`.
 
 [#]{.pnum} [If forming `Z<[:Args:]...>` leads to a failure outside of the immediate context, the program is ill-formed.]{.note}
 
@@ -7721,9 +7743,27 @@ consteval info substitute(info templ, R&& arguments);
 
 [#]{.pnum} *Returns*: `^^Z<[:Args:]...>`.
 
-[#]{.pnum} [The specialization `Z<[:Args:]...>` is only instantiated if needed.]{.note}
-
 [#]{.pnum} [If forming `Z<[:Args:]...>` leads to a failure outside of the immediate context, the program is ill-formed.]{.note}
+
+::: example
+```cpp
+template <typename T>
+auto fn1();
+
+static_assert(!can_substitute(^^fn1, {^^int}));  // OK
+constexpr info r1 = substitute(^^fn1, {^^int});
+  // error: fn<int> contains an undeduced placeholder type
+
+template <typename T>
+auto fn2() {
+  static_assert(^^T != ^^int); // static assertion failed during instantiation of fn<int>
+  return 0;
+}
+
+constexpr bool r2 = can_substitute(^^fn2, {^^int});
+  // error: instantiation of body of fn<int> is needed to deduce return type
+```
+:::
 :::
 :::
 
@@ -7742,7 +7782,7 @@ template <typename T>
 
 Let `$V$` be the value computed by an lvalue-to-rvalue conversion applied to `expr`.
 
-[#]{.pnum} *Constant When*: `$V$` satisfies the constraints for for a value computed by a prvalue constant expression ([expr.const]) and, if `$V$` has pointer type, then it is not a pointer to an object that is not meta-reflectable.
+[#]{.pnum} *Constant When*: `$V$` satisfies the constraints for the result of a prvalue constant expression ([expr.const]) and, if `$V$` is a pointer to an object, then that object is meta-reflectable.
 
 [#]{.pnum} *Returns*: A reflection of a value of type `$T$` associated with the computed value `$V$`.
 
@@ -7753,15 +7793,14 @@ template <typename T>
 
 [#]{.pnum} *Mandates*: `T` is copy constructible and structural ([temp.param]).
 
-[#]{.pnum} Let `$O$` be a template parameter object ([temp.param]) copy-initialized from `expr`.
+[#]{.pnum} Let `$O$` be an object copy-initialized from `expr`.
 
 [#]{.pnum} *Constant When*:
 
-* [#.#]{.pnum} `$O$` satisfies the constraints for a constant expression ([expr.const]),
-* [#.#]{.pnum} no constituent reference of `$O$` refers to an object that is not meta-reflectable, and
-* [#.#]{.pnum} no constituent value of `$O$` of pointer type is a pointer to an object that is not meta-reflectable.
+* [#.#]{.pnum} `$O$` satisfies the constraints for the result of a glvalue constant expression ([expr.const]),
+* [#.#]{.pnum} every object referred to by a constituent reference of `$O$`, or pointed to by a constituent pointer value of `$O$`, is meta-reflectable.
 
-[#]{.pnum} *Returns*: A reflection of a value of type `T` associated with the template parameter object `$O$`.
+[#]{.pnum} *Returns*: A reflection of a value of type `T` associated with a template parameter object that is template-argument-equivalent to `$O$`.
 
 ```cpp
 template <typename T>
@@ -7847,8 +7886,10 @@ The class `$name-type$` allows the function `data_member_spec` to accept an ordi
 
 ::: example
 ```cpp
-constexpr auto mem1 = data_member_spec(^^int, {.name="ordinary_literal_encoding"});
-constexpr auto mem2 = data_member_spec(^^int, {.name=u8"utf8_encoding"});
+consteval void fn() {
+  data_member_options o1 = {.name="ordinary_literal_encoding"};
+  data_member_options o2 = {.name=u8"utf8_encoding"};
+}
 ```
 :::
 


### PR DESCRIPTION
- Rename "naming class" to "designating class"; handle for _splice-expressions_
- `can_substitute` is false when the substitution forms a function whose type contains an undeduced placeholder type
- Add an example to `substitute` of when the definition gets instantiated
- Use `data_member_options` explicitly instead of leaning on `data_member_spec` in the example for `data_member_options::name_type`.