### PR TITLE
Module and P3687 updates.

### DIFF
--- a/2996_reflection/d2996r13.html
+++ b/2996_reflection/d2996r13.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="mpark/wg21" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <meta name="dcterms.date" content="2025-06-07" />
+  <meta name="dcterms.date" content="2025-06-11" />
   <title>Reflection for C++26</title>
   <style>
       code{white-space: pre-wrap;}
@@ -576,7 +576,7 @@ background-color: #ffff00;
   </tr>
   <tr>
     <td>Date:</td>
-    <td>2025-06-07</td>
+    <td>2025-06-11</td>
   </tr>
   <tr>
     <td style="vertical-align:top">Project:</td>
@@ -762,10 +762,10 @@ definitions<span></span></a></li>
 <li><a href="#lex.phases-phases-of-translation" id="toc-lex.phases-phases-of-translation"><span>5.2
 <span>[lex.phases]</span></span> Phases of
 translation<span></span></a></li>
-<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.5
+<li><a href="#lex.pptoken-preprocessing-tokens" id="toc-lex.pptoken-preprocessing-tokens"><span>5.4
 <span>[lex.pptoken]</span></span> Preprocessing
 tokens<span></span></a></li>
-<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.8
+<li><a href="#lex.operators-operators-and-punctuators" id="toc-lex.operators-operators-and-punctuators"><span>5.12
 <span>[lex.operators]</span></span> Operators and
 punctuators<span></span></a></li>
 <li><a href="#basic.pre-preamble" id="toc-basic.pre-preamble"><span>6.1
@@ -807,18 +807,18 @@ dependence<span></span></a></li>
 <li><a href="#expr.prim-primary-expressions" id="toc-expr.prim-primary-expressions"><span>7.5
 <span>[expr.prim]</span></span> Primary
 expressions<span></span></a></li>
-<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.5.1
+<li><a href="#expr.prim.id.general-general" id="toc-expr.prim.id.general-general"><span>7.5.4.1
 <span>[expr.prim.id.general]</span></span> General<span></span></a></li>
-<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.5.2
+<li><a href="#expr.prim.id.unqual-unqualified-names" id="toc-expr.prim.id.unqual-unqualified-names"><span>7.5.4.2
 <span>[expr.prim.id.unqual]</span></span> Unqualified
 names<span></span></a></li>
-<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.5.3
+<li><a href="#expr.prim.id.qual-qualified-names" id="toc-expr.prim.id.qual-qualified-names"><span>7.5.4.3
 <span>[expr.prim.id.qual]</span></span> Qualified
 names<span></span></a></li>
-<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.6.2
+<li><a href="#expr.prim.lambda.closure-closure-types" id="toc-expr.prim.lambda.closure-closure-types"><span>7.5.5.2
 <span>[expr.prim.lambda.closure]</span></span> Closure
 types<span></span></a></li>
-<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span>7.5.8.3
+<li><a href="#expr.prim.req.type-type-requirements" id="toc-expr.prim.req.type-type-requirements"><span>7.5.7.3
 <span>[expr.prim.req.type]</span></span> Type
 requirements<span></span></a></li>
 <li><a href="#expr.prim.splice-expression-splicing" id="toc-expr.prim.splice-expression-splicing">7.5.8* [expr.prim.splice]
@@ -865,31 +865,31 @@ Functions<span></span></a></li>
 <li><a href="#dcl.fct.default-default-arguments" id="toc-dcl.fct.default-default-arguments"><span>9.3.4.7
 <span>[dcl.fct.default]</span></span> Default
 arguments<span></span></a></li>
-<li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.5.1
+<li><a href="#dcl.init.general-initializers-general" id="toc-dcl.init.general-initializers-general"><span>9.4.1
 <span>[dcl.init.general]</span></span> Initializers
 (General)<span></span></a></li>
-<li><a href="#dcl.fct.def.general-function-definitions" id="toc-dcl.fct.def.general-function-definitions"><span>9.6.1
+<li><a href="#dcl.fct.def.general-function-definitions" id="toc-dcl.fct.def.general-function-definitions"><span>9.5.1
 <span>[dcl.fct.def.general]</span></span> Function
 definitions<span></span></a></li>
-<li><a href="#dcl.fct.def.delete-deleted-definitions" id="toc-dcl.fct.def.delete-deleted-definitions"><span>9.6.3
+<li><a href="#dcl.fct.def.delete-deleted-definitions" id="toc-dcl.fct.def.delete-deleted-definitions"><span>9.5.3
 <span>[dcl.fct.def.delete]</span></span> Deleted
 definitions<span></span></a></li>
-<li><a href="#enum.udecl-the-using-enum-declaration" id="toc-enum.udecl-the-using-enum-declaration"><span>9.8.2
+<li><a href="#enum.udecl-the-using-enum-declaration" id="toc-enum.udecl-the-using-enum-declaration"><span>9.7.2
 <span>[enum.udecl]</span></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
 declaration<span></span></a></li>
-<li><a href="#namespace.alias-namespace-alias" id="toc-namespace.alias-namespace-alias"><span>9.9.3
+<li><a href="#namespace.alias-namespace-alias" id="toc-namespace.alias-namespace-alias"><span>9.8.3
 <span>[namespace.alias]</span></span> Namespace
 alias<span></span></a></li>
-<li><a href="#namespace.udir-using-namespace-directive" id="toc-namespace.udir-using-namespace-directive"><span>9.9.4
+<li><a href="#namespace.udir-using-namespace-directive" id="toc-namespace.udir-using-namespace-directive"><span>9.8.4
 <span>[namespace.udir]</span></span> Using namespace
 directive<span></span></a></li>
-<li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.13.1
+<li><a href="#dcl.attr.grammar-attribute-syntax-and-semantics" id="toc-dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1
 <span>[dcl.attr.grammar]</span></span> Attribute syntax and
 semantics<span></span></a></li>
-<li><a href="#dcl.attr.deprecated-deprecated-attribute" id="toc-dcl.attr.deprecated-deprecated-attribute"><span>9.13.4
+<li><a href="#dcl.attr.deprecated-deprecated-attribute" id="toc-dcl.attr.deprecated-deprecated-attribute"><span>9.12.5
 <span>[dcl.attr.deprecated]</span></span> Deprecated
 attribute<span></span></a></li>
-<li><a href="#dcl.attr.unused-maybe-unused-attribute" id="toc-dcl.attr.unused-maybe-unused-attribute"><span>9.13.8
+<li><a href="#dcl.attr.unused-maybe-unused-attribute" id="toc-dcl.attr.unused-maybe-unused-attribute"><span>9.12.9
 <span>[dcl.attr.unused]</span></span> Maybe unused
 attribute<span></span></a></li>
 <li><a href="#module.interface-module-interface" id="toc-module.interface-module-interface"><span>10.2
@@ -1028,7 +1028,7 @@ Expression result reflection<span></span></a></li>
 Reflection class definition generation<span></span></a></li>
 <li><a href="#meta.reflection.traits-reflection-type-traits" id="toc-meta.reflection.traits-reflection-type-traits">[meta.reflection.traits]
 Reflection type traits<span></span></a></li>
-<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.11.3
+<li><a href="#bit.cast-function-template-bit_cast" id="toc-bit.cast-function-template-bit_cast"><span>22.15.3
 <span>[bit.cast]</span></span> Function template
 <code class="sourceCode cpp">bit_cast</code><span></span></a></li>
 <li><a href="#diff.cpp23-annex-c-informative-compatibility" id="toc-diff.cpp23-annex-c-informative-compatibility"><span>C.1
@@ -1045,14 +1045,22 @@ Hagenberg<span></span></a></li>
 </div>
 <h1 data-number="1" style="border-bottom:1px solid #cccccc" id="revision-history"><span class="header-section-number">1</span>
 Revision History<a href="#revision-history" class="self-link"></a></h1>
-<p>Since <span class="citation" data-cites="P2996R12"><a href="https://wg21.link/p2996r12" role="doc-biblioref">[P2996R12]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R12">[<a href="https://wg21.link/p2996r12" role="doc-biblioref">P2996R12</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
 <li>handle members of static anonymous unions / integrate suggested fix
-for <span class="citation" data-cites="CWG3026"><a href="https://cplusplus.github.io/CWG/issues/3026.html" role="doc-biblioref">[CWG3026]</a></span></li>
-<li>removed splice template arguments, following EWG poll for <span class="title"><span class="citation" data-cites="P3687R0"><a href="https://wg21.link/p3687r0" role="doc-biblioref">[P3687R0] (Final
-Adjustments to C++26 Reflection)</a></span></span></li>
+for <span class="citation" data-cites="CWG3026">[<a href="https://cplusplus.github.io/CWG/issues/3026.html" role="doc-biblioref">CWG3026</a>]</span></li>
+<li>integrate EWG updates from <span class="title"><span class="citation" data-cites="P3687R0">[<a href="https://wg21.link/p3687r0" role="doc-biblioref">P3687R0</a>]</span></span>
+<ul>
+<li>removed splice template arguments</li>
+<li>unparenthesized
+<code class="sourceCode cpp"><em>splice-expression</em></code>s are
+ill-formed when used as template arguments</li>
+<li><code class="sourceCode cpp"><em>reflect-expression</em></code>s are
+ill-formed when the operand names a
+<code class="sourceCode cpp"><em>using-declarator</em></code></li>
+</ul></li>
 </ul></li>
 <li>library wording updates
 <ul>
@@ -1060,12 +1068,12 @@ Adjustments to C++26 Reflection)</a></span></span></li>
 <code class="sourceCode cpp">reflect_constant</code>/<code class="sourceCode cpp">reflect_object</code>/<code class="sourceCode cpp">reflect_function</code></li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R11"><a href="https://wg21.link/p2996r11" role="doc-biblioref">[P2996R11]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R11">[<a href="https://wg21.link/p2996r11" role="doc-biblioref">P2996R11</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
 <li>better specify interaction between spliced function calls and
-overload resolution; integrate fix to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span></li>
+overload resolution; integrate fix to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span></li>
 <li>disallow reflection of local parameters introduced by
 <code class="sourceCode cpp"><em>requires-expression</em></code>s</li>
 <li>change “naming class” to “designating class” and define for
@@ -1086,7 +1094,7 @@ bit-field</li>
 pointer from an array</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R10"><a href="https://wg21.link/p2996r10" role="doc-biblioref">[P2996R10]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R10">[<a href="https://wg21.link/p2996r10" role="doc-biblioref">P2996R10</a>]</span>:</p>
 <ul>
 <li>replaced <code class="sourceCode cpp">has_complete_definition</code>
 function with more narrow
@@ -1120,8 +1128,7 @@ immediate functions</li>
 enumerators called from within the containing
 <code class="sourceCode cpp"><em>enum-specifier</em></code></li>
 <li>minor editing and phrasing updates to address CWG feedback</li>
-<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13"><a href="https://wg21.link/p2786r13" role="doc-biblioref">[P2786R13] (Trivial Relocatability For
-C++26)</a></span></span></li>
+<li>added type traits from <span class="title"><span class="citation" data-cites="P2786R13">[<a href="https://wg21.link/p2786r13" role="doc-biblioref">P2786R13</a>]</span></span></li>
 <li>in response to CWG feedback: added
 <code class="sourceCode cpp">has_c_language_linkage</code>,
 <code class="sourceCode cpp">has_parent</code>,
@@ -1135,13 +1142,13 @@ members to <code class="sourceCode cpp">access_context</code></li>
 <code class="sourceCode cpp">members_of</code></li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R9"><a href="https://wg21.link/p2996r9" role="doc-biblioref">[P2996R9]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R9">[<a href="https://wg21.link/p2996r9" role="doc-biblioref">P2996R9</a>]</span>:</p>
 <ul>
 <li>core wording updates
 <ul>
-<li>merge <span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1] (Consteval blocks)</a></span></span> into
-P2996. Replace the category of “plainly constant-evaluated expressions”
-with consteval blocks.</li>
+<li>merge <span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span> into P2996. Replace the
+category of “plainly constant-evaluated expressions” with consteval
+blocks.</li>
 <li>make the [expr.const] “scope rule” for injected declarations more
 rigorous; disallow escape from function parameter scopes</li>
 <li>revise [expr.reflect] grammar according to CWG feedback</li>
@@ -1149,7 +1156,7 @@ rigorous; disallow escape from function parameter scopes</li>
 arguments</li>
 <li>bring notes and examples into line with current definitions</li>
 <li>rebase [expr.const] onto latest from working draft (in particular,
-integrate changes from <span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+integrate changes from <span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>prefer “core constant expressions” to “manifestly constant-evaluated
 expression” in several places</li>
 <li>producing an injected declaration from a non-plainly
@@ -1167,14 +1174,14 @@ lieu of “core constant expression”)</li>
 <li>avoid referring to “permitted results of constant expressions” in
 wording for <code class="sourceCode cpp">reflect_value</code> and
 <code class="sourceCode cpp">reflect_object</code> (term was retired by
-<span class="citation" data-cites="P2686R5"><a href="https://wg21.link/p2686r5" role="doc-biblioref">[P2686R5]</a></span>)</li>
+<span class="citation" data-cites="P2686R5">[<a href="https://wg21.link/p2686r5" role="doc-biblioref">P2686R5</a>]</span>)</li>
 <li>template specializations and non-static data members of closure
 types are not <em>members-of-representable</em></li>
-<li>integrated <span class="title"><span class="citation" data-cites="P3547R1"><a href="https://wg21.link/p3547r1" role="doc-biblioref">[P3547R1] (Modeling Access Control With
-Reflection)</a></span></span> following its approval in (L)EWG.</li>
+<li>integrated <span class="title"><span class="citation" data-cites="P3547R1">[<a href="https://wg21.link/p3547r1" role="doc-biblioref">P3547R1</a>]</span></span> following its approval
+in (L)EWG.</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R8"><a href="https://wg21.link/p2996r8" role="doc-biblioref">[P2996R8]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R8">[<a href="https://wg21.link/p2996r8" role="doc-biblioref">P2996R8</a>]</span>:</p>
 <ul>
 <li>ensure <code class="sourceCode cpp">value_of</code> and
 <code class="sourceCode cpp">extract</code> are usable with reflections
@@ -1227,12 +1234,12 @@ complete-class contexts; rename to “<em>members-of-precedes</em>”</li>
 </ul></li>
 <li>fleshed out revision history for R8</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R7"><a href="https://wg21.link/p2996r7" role="doc-biblioref">[P2996R7]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R7">[<a href="https://wg21.link/p2996r7" role="doc-biblioref">P2996R7</a>]</span>:</p>
 <ul>
 <li>changed reflection operator from
 <code class="sourceCode cpp"><span class="op">^</span></code> to
 <code class="sourceCode cpp"><span class="op">^^</span></code> following
-adoption of <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span></li>
+adoption of <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span></li>
 <li>renamed <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>operator_symbol_of</code>
 to <code class="sourceCode cpp"><span class="op">(</span>u8<span class="op">)</span>symbol_of</code></li>
 <li>renamed some <code class="sourceCode cpp">operators</code>
@@ -1321,7 +1328,7 @@ base class relationship</em> to assist with specification of
 in [temp.arg.general]</li>
 </ul></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R6"><a href="https://wg21.link/p2996r6" role="doc-biblioref">[P2996R6]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R6">[<a href="https://wg21.link/p2996r6" role="doc-biblioref">P2996R6</a>]</span>:</p>
 <ul>
 <li>removed the <code class="sourceCode cpp">accessible_members</code>
 family of functions</li>
@@ -1340,7 +1347,7 @@ functions, tweaked enumerator names in <code class="sourceCode cpp">std<span cla
 completeness with
 <code class="sourceCode cpp">is_user_provided</code></li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R5"><a href="https://wg21.link/p2996r5" role="doc-biblioref">[P2996R5]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R5">[<a href="https://wg21.link/p2996r5" role="doc-biblioref">P2996R5</a>]</span>:</p>
 <ul>
 <li>fixed broken “Emulating typeful reflection” example.</li>
 <li>removed linkage restrictions on objects of consteval-only type that
@@ -1361,7 +1368,7 @@ Aliases”</a> section.</li>
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
 <li>removed <code class="sourceCode cpp">subobjects_of</code> and
 <code class="sourceCode cpp">accessible_subobjects_of</code> (will be
-reintroduced by <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>).</li>
+reintroduced by <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>).</li>
 <li>specified constraints for
 <code class="sourceCode cpp">enumerators_of</code> in terms of
 <code class="sourceCode cpp">has_complete_definition</code>.</li>
@@ -1383,7 +1390,7 @@ with core language terminology.</li>
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” over “alias
 of a type” in formal wording.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span>:</p>
 <ul>
 <li>removed filters from query functions</li>
 <li>cleaned up accessibility interface, removed
@@ -1425,7 +1432,7 @@ comparison among reflections returned by it.</li>
 <code class="sourceCode cpp">is_complete_type</code></li>
 <li>Many wording updates in response to feedback from CWG.</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R3"><a href="https://wg21.link/p2996r3" role="doc-biblioref">[P2996R3]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R3">[<a href="https://wg21.link/p2996r3" role="doc-biblioref">P2996R3</a>]</span>:</p>
 <ul>
 <li>changes to name functions to improve Unicode-friendliness; added
 <code class="sourceCode cpp">u8name_of</code>,
@@ -1451,7 +1458,7 @@ object; added <code class="sourceCode cpp">object_of</code>
 metafunction</li>
 <li>more wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R2"><a href="https://wg21.link/p2996r2" role="doc-biblioref">[P2996R2]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R2">[<a href="https://wg21.link/p2996r2" role="doc-biblioref">P2996R2</a>]</span>:</p>
 <ul>
 <li>many wording changes, additions, and improvements</li>
 <li>elaborated on equivalence among reflections and linkage of templated
@@ -1492,8 +1499,8 @@ functions, not member function templates</li>
 text</a></li>
 <li>added a section discussing ODR concerns</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R1"><a href="https://wg21.link/p2996r1" role="doc-biblioref">[P2996R1]</a></span>, several changes to the
-overall library API:</p>
+<p>Since <span class="citation" data-cites="P2996R1">[<a href="https://wg21.link/p2996r1" role="doc-biblioref">P2996R1</a>]</span>, several changes to the overall
+library API:</p>
 <ul>
 <li>added <code class="sourceCode cpp">qualified_name_of</code> (to
 partner with <code class="sourceCode cpp">name_of</code>)</li>
@@ -1517,7 +1524,7 @@ reflection</a>.</li>
 freestanding.</li>
 <li>adding lots of wording</li>
 </ul>
-<p>Since <span class="citation" data-cites="P2996R0"><a href="https://wg21.link/p2996r0" role="doc-biblioref">[P2996R0]</a></span>:</p>
+<p>Since <span class="citation" data-cites="P2996R0">[<a href="https://wg21.link/p2996r0" role="doc-biblioref">P2996R0</a>]</span>:</p>
 <ul>
 <li>added links to Compiler Explorer demonstrating just about all of the
 examples</li>
@@ -1536,7 +1543,7 @@ for exceptions (removing invalid reflections)</li>
 Introduction<a href="#introduction" class="self-link"></a></h1>
 <p>This is a proposal for a reduced initial set of features to support
 static reflection in C++. Specifically, we are mostly proposing a subset
-of features suggested in <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>:</p>
+of features suggested in <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>:</p>
 <ul>
 <li>the representation of program elements via constant-expressions
 producing <em>reflection values</em> — <em>reflections</em> for short —
@@ -1562,7 +1569,7 @@ and compile-time metaprogramming are concerned. Instead, we expect it
 will be a useful core around which more powerful features will be added
 incrementally over time. In particular, we believe that most or all the
 remaining features explored in P1240R2 and that code injection (along
-the lines described in <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>) are desirable directions to
+the lines described in <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>) are desirable directions to
 pursue.</p>
 <p>Our choice to start with something smaller is primarily motivated by
 the belief that that improves the chances of these facilities making it
@@ -1576,7 +1583,7 @@ predicates (such as <code class="sourceCode cpp">is_class_v</code>) in
 reflection computations.</p>
 <p>One addition does stand out, however: We have added metafunctions
 that permit the synthesis of simple struct and union types. While it is
-not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0"><a href="https://wg21.link/p2237r0" role="doc-biblioref">[P2237R0]</a></span>), it can be remarkably
+not nearly as powerful as generalized code injection (see <span class="citation" data-cites="P2237R0">[<a href="https://wg21.link/p2237r0" role="doc-biblioref">P2237R0</a>]</span>), it can be remarkably
 effective in practice.</p>
 <h2 data-number="2.2" id="why-a-single-opaque-reflection-type"><span class="header-section-number">2.2</span> Why a single opaque reflection
 type?<a href="#why-a-single-opaque-reflection-type" class="self-link"></a></h2>
@@ -1722,17 +1729,9 @@ rely on these features, and it is possible to do without them - but it
 would greatly help the usability experience if those could be adopted as
 well:</p>
 <ul>
-<li><span class="title"><span class="citation" data-cites="P1306R2"><a href="https://wg21.link/p1306r2" role="doc-biblioref">[P1306R2]
-(Expansion statements)</a></span></span></li>
-<li><span class="title"><span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]
-(Consteval blocks)</a></span></span></li>
-<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7"><a href="https://wg21.link/p0784r7" role="doc-biblioref">[P0784R7] (More
-constexpr containers)</a></span></span>, <span class="title"><span class="citation" data-cites="P1974R0"><a href="https://wg21.link/p1974r0" role="doc-biblioref">[P1974R0]
-(Non-transient constexpr allocation using propconst)</a></span></span>,
-<span class="title"><span class="citation" data-cites="P2670R1"><a href="https://wg21.link/p2670r1" role="doc-biblioref">[P2670R1]
-(Non-transient constexpr allocation)</a></span></span>, <span class="title"><span class="citation" data-cites="P3554R0"><a href="https://wg21.link/p3554r0" role="doc-biblioref">[P3554R0]
-(Non-transient allocation with vector and
-basic_string)</a></span></span></li>
+<li><span class="title"><span class="citation" data-cites="P1306R2">[<a href="https://wg21.link/p1306r2" role="doc-biblioref">P1306R2</a>]</span></span></li>
+<li><span class="title"><span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span></span></li>
+<li>non-transient constexpr allocation – <span class="title"><span class="citation" data-cites="P0784R7">[<a href="https://wg21.link/p0784r7" role="doc-biblioref">P0784R7</a>]</span></span>, <span class="title"><span class="citation" data-cites="P1974R0">[<a href="https://wg21.link/p1974r0" role="doc-biblioref">P1974R0</a>]</span></span>, <span class="title"><span class="citation" data-cites="P2670R1">[<a href="https://wg21.link/p2670r1" role="doc-biblioref">P2670R1</a>]</span></span>, <span class="title"><span class="citation" data-cites="P3554R0">[<a href="https://wg21.link/p3554r0" role="doc-biblioref">P3554R0</a>]</span></span></li>
 </ul>
 <h2 data-number="3.1" id="back-and-forth"><span class="header-section-number">3.1</span> Back-And-Forth<a href="#back-and-forth" class="self-link"></a></h2>
 <p>Our first example is not meant to be compelling but to show how to go
@@ -2310,7 +2309,7 @@ initialize members of a defined union using a splicer, as in:</p>
 </blockquote>
 </div>
 <p>Arguably, the answer should be yes - this would be consistent with
-how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1"><a href="https://wg21.link/p3293r1" role="doc-biblioref">[P3293R1]</a></span>.</p>
+how other accesses work. This is instead proposed in <span class="citation" data-cites="P3293R1">[<a href="https://wg21.link/p3293r1" role="doc-biblioref">P3293R1</a>]</span>.</p>
 <p>On Compiler Explorer: <a href="https://godbolt.org/z/W74qxqnhf">EDG</a>, <a href="https://godbolt.org/z/eqj6e3Tjr">Clang</a>.</p>
 <h2 data-number="3.10" id="struct-to-struct-of-arrays"><span class="header-section-number">3.10</span> Struct to Struct of Arrays<a href="#struct-to-struct-of-arrays" class="self-link"></a></h2>
 <div class="std">
@@ -2602,7 +2601,7 @@ requires writing
 since this isn’t a type-only context.</p>
 <h2 data-number="3.13" id="implementing-member-wise-hash_append"><span class="header-section-number">3.13</span> Implementing member-wise
 <code class="sourceCode cpp">hash_append</code><a href="#implementing-member-wise-hash_append" class="self-link"></a></h2>
-<p>Based on the <span class="citation" data-cites="N3980"><a href="https://wg21.link/n3980" role="doc-biblioref">[N3980]</a></span>
+<p>Based on the <span class="citation" data-cites="N3980">[<a href="https://wg21.link/n3980" role="doc-biblioref">N3980</a>]</span>
 API:</p>
 <div class="std">
 <blockquote>
@@ -2618,12 +2617,12 @@ API:</p>
 <p>Of course, any production-ready
 <code class="sourceCode cpp">hash_append</code> would include a facility
 for classes to opt members in and out of participation in hashing.
-Annotations as proposed by <span class="title"><span class="citation" data-cites="P3394R2"><a href="https://wg21.link/p3394r2" role="doc-biblioref">[P3394R2] (Annotations for
-Reflection)</a></span></span> provides just such a mechanism.</p>
+Annotations as proposed by <span class="title"><span class="citation" data-cites="P3394R2">[<a href="https://wg21.link/p3394r2" role="doc-biblioref">P3394R2</a>]</span></span> provides just such a
+mechanism.</p>
 <h2 data-number="3.14" id="converting-a-struct-to-a-tuple"><span class="header-section-number">3.14</span> Converting a Struct to a
 Tuple<a href="#converting-a-struct-to-a-tuple" class="self-link"></a></h2>
-<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R10"><a href="https://wg21.link/p1061r10" role="doc-biblioref">[P1061R10]</a></span>, but can also be written
-using <code class="sourceCode cpp">std<span class="op">::</span>make_index_sequence</code>:</p>
+<p>This approach requires allowing packs in structured bindings <span class="citation" data-cites="P1061R10">[<a href="https://wg21.link/p1061r10" role="doc-biblioref">P1061R10</a>]</span>, but can also be written using
+<code class="sourceCode cpp">std<span class="op">::</span>make_index_sequence</code>:</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb31"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
@@ -2977,10 +2976,10 @@ metafunction can also be used to map a reflection of an object to a
 reflection of its value.</p>
 <h3 data-number="4.1.1" id="syntax-discussion"><span class="header-section-number">4.1.1</span> Syntax discussion<a href="#syntax-discussion" class="self-link"></a></h3>
 <p>The original TS landed on <code class="sourceCode cpp"><span class="cf">reflexpr</span><span class="op">(...)</span></code>
-as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that syntax as well.
-As more examples were discussed, it became clear that that syntax was
-both (a) too “heavy” and (b) insufficiently distinct from a function
-call. SG7 eventually agreed upon the prefix
+as the syntax to reflect source constructs and <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that syntax as well. As
+more examples were discussed, it became clear that that syntax was both
+(a) too “heavy” and (b) insufficiently distinct from a function call.
+SG7 eventually agreed upon the prefix
 <code class="sourceCode cpp"><span class="op">^</span></code> operator.
 The “upward arrow” interpretation of the caret matches the “lift” or
 “raise” verbs that are sometimes used to describe the reflection
@@ -3011,8 +3010,8 @@ lifting, <code class="sourceCode cpp">\</code> and
 syntax.</p>
 <p>In Wrocław 2024, SG7 and EWG voted to adopt
 <code class="sourceCode cpp"><span class="op">^^</span></code> as the
-new reflection operator (as proposed by <span class="citation" data-cites="P3381R0"><a href="https://wg21.link/p3381r0" role="doc-biblioref">[P3381R0]</a></span>). The R8 revision of this
-paper integrates that change.</p>
+new reflection operator (as proposed by <span class="citation" data-cites="P3381R0">[<a href="https://wg21.link/p3381r0" role="doc-biblioref">P3381R0</a>]</span>). The R8 revision of this paper
+integrates that change.</p>
 <h2 data-number="4.2" id="splicers"><span class="header-section-number">4.2</span> Splicers
 (<code class="sourceCode cpp"><span class="op">[:</span></code>…<code class="sourceCode cpp"><span class="op">:]</span></code>)<a href="#splicers" class="self-link"></a></h2>
 <p>A reflection can be “spliced” into source code using one of several
@@ -3263,8 +3262,8 @@ extension in a future paper.</p>
 (described in more detail below). However, there are many cases where we
 don’t have a single reflection, we have a range of reflections - and we
 want to splice them all in one go. For that, the predecessor to this
-paper, <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span>, proposed an additional form
-of splicer: a range splicer.</p>
+paper, <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span>, proposed an additional form of
+splicer: a range splicer.</p>
 <p>Construct the <a href="#converting-a-struct-to-a-tuple">struct-to-tuple</a> example from
 above. It was demonstrated using a single splice, but it would be
 simpler if we had a range splice:</p>
@@ -3350,7 +3349,7 @@ Which is enough for a tolerable implementation:</p>
 <h3 data-number="4.2.4" id="syntax-discussion-1"><span class="header-section-number">4.2.4</span> Syntax discussion<a href="#syntax-discussion-1" class="self-link"></a></h3>
 <p>Early discussions of splice-like constructs (related to the TS
 design) considered using <code class="sourceCode cpp"><span class="cf">unreflexpr</span><span class="op">(...)</span></code>
-for that purpose. <span class="citation" data-cites="P1240R0"><a href="https://wg21.link/p1240r0" role="doc-biblioref">[P1240R0]</a></span> adopted that option for
+for that purpose. <span class="citation" data-cites="P1240R0">[<a href="https://wg21.link/p1240r0" role="doc-biblioref">P1240R0</a>]</span> adopted that option for
 <em>expression</em> splicing, observing that a single splicing syntax
 could not viably be parsed (some disambiguation is needed to distinguish
 types and templates). SG-7 eventually agreed to adopt the <code class="sourceCode cpp"><span class="op">[:</span> <span class="op">...</span> <span class="op">:]</span></code>
@@ -3431,7 +3430,7 @@ document templates:</p>
 need syntax for in the future:</p>
 <ul>
 <li>code injection (of whatever form), and</li>
-<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1"><a href="https://wg21.link/p1887r1" role="doc-biblioref">[P1887R1]</a></span> suggested
+<li>annotations (reflectable attributes, as values. <span class="citation" data-cites="P1887R1">[<a href="https://wg21.link/p1887r1" role="doc-biblioref">P1887R1</a>]</span> suggested
 <code class="sourceCode cpp"><span class="op">+</span></code> as an
 annotation introducer, but
 <code class="sourceCode cpp"><span class="op">+</span></code> can begin
@@ -3698,9 +3697,8 @@ because these are <code class="sourceCode cpp">std<span class="op">::</span>meta
 must be a constant. Because it’s not here
 (<code class="sourceCode cpp">__first</code> and
 <code class="sourceCode cpp">__last</code> are just function
-parameters), that triggers the immediate-escalation machinery from <span class="title"><span class="citation" data-cites="P2564R3"><a href="https://wg21.link/p2564r3" role="doc-biblioref">[P2564R3]
-(consteval needs to propagate up)</a></span></span> (before that paper,
-it would have been ill-formed on the spot). But because
+parameters), that triggers the immediate-escalation machinery from <span class="title"><span class="citation" data-cites="P2564R3">[<a href="https://wg21.link/p2564r3" role="doc-biblioref">P2564R3</a>]</span></span> (before that paper, it
+would have been ill-formed on the spot). But because
 <code class="sourceCode cpp">__introsort</code> is not
 <code class="sourceCode cpp"><span class="kw">constexpr</span></code>,
 propagation fails at that point, and the program is ill-formed.</p>
@@ -3803,7 +3801,7 @@ example:</p>
 </div>
 <p>Hence this proposal also introduces constraints on constant
 evaluation as follows…</p>
-<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1"><a href="https://wg21.link/p3289r1" role="doc-biblioref">[P3289R1]</a></span>) have the property that their
+<p>First, consteval blocks (from <span class="citation" data-cites="P3289R1">[<a href="https://wg21.link/p3289r1" role="doc-biblioref">P3289R1</a>]</span>) have the property that their
 evaluation must occur and must succeed in a valid C++ program. We
 require that a programmer can count on those evaluations occurring
 exactly once and completing at translation time.</p>
@@ -3814,9 +3812,8 @@ source constructs lexically following them.</p>
 <p>Those constraints are mostly intuitive, but they are a significant
 change to the underlying principles of the current standard in this
 respect.</p>
-<p><span class="title"><span class="citation" data-cites="P2758R4"><a href="https://wg21.link/p2758r4" role="doc-biblioref">[P2758R4]
-(Emitting messages at compile time)</a></span></span> also has to deal
-with side effects during constant evaluation. However, those effects
+<p><span class="title"><span class="citation" data-cites="P2758R4">[<a href="https://wg21.link/p2758r4" role="doc-biblioref">P2758R4</a>]</span></span> also has to deal with
+side effects during constant evaluation. However, those effects
 (“output”) are of a slightly different nature in the sense that they can
 be buffered until a manifestly constant-evaluated expression/conversion
 has completed. “Buffering” a class type completion is not practical
@@ -3895,7 +3892,7 @@ constant expressions (we would of course still keep the requirement that
 the constraint is a
 <code class="sourceCode cpp"><span class="dt">bool</span></code>).</p></li>
 </ul>
-<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1"><a href="https://wg21.link/p3068r1" role="doc-biblioref">[P3068R1]</a></span> has proposed the introduction
+<p>Since the R2 revision of this paper, <span class="citation" data-cites="P3068R1">[<a href="https://wg21.link/p3068r1" role="doc-biblioref">P3068R1</a>]</span> has proposed the introduction
 of constexpr exceptions. The proposal addresses hurdles like compiler
 modes that disable exception support, and a Clang-based implementation
 is underway. We believe this to be the most desirable error-handling
@@ -4255,14 +4252,14 @@ translated to a different presentation (as in (2)).</p></li>
 to evaluate if the identifier cannot be represented in the ordinary
 literal encoding.</p>
 <h3 data-number="4.4.6" id="reflecting-names"><span class="header-section-number">4.4.6</span> Reflecting names<a href="#reflecting-names" class="self-link"></a></h3>
-<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2"><a href="https://wg21.link/p1240r2" role="doc-biblioref">[P1240R2]</a></span>) included a metafunction
-called <code class="sourceCode cpp">name_of</code>, which we defined to
-return a <code class="sourceCode cpp">string_view</code> containing the
-“name” of the reflected entity. As the paper evolved, it became
-necessary to sharpen the specification of what this “name” contains.
-Subsequent revisions (beginning with P2996R2, presented in Tokyo)
-specified that <code class="sourceCode cpp">name_of</code> returns the
-unqualified name, whereas a new
+<p>Earlier revisions of this proposal (and its predecessor, <span class="citation" data-cites="P1240R2">[<a href="https://wg21.link/p1240r2" role="doc-biblioref">P1240R2</a>]</span>) included a metafunction called
+<code class="sourceCode cpp">name_of</code>, which we defined to return
+a <code class="sourceCode cpp">string_view</code> containing the “name”
+of the reflected entity. As the paper evolved, it became necessary to
+sharpen the specification of what this “name” contains. Subsequent
+revisions (beginning with P2996R2, presented in Tokyo) specified that
+<code class="sourceCode cpp">name_of</code> returns the unqualified
+name, whereas a new
 <code class="sourceCode cpp">qualified_name_of</code> would give the
 fully qualified name.</p>
 <p>Most would agree that <code class="sourceCode cpp">qualified_name_of<span class="op">(^^</span><span class="dt">size_t</span><span class="op">)</span></code>
@@ -4650,9 +4647,9 @@ side-effect.</p>
 <code class="sourceCode cpp">define_aggregate</code> can be used, we are
 not aware of any motivating use cases for P2996 that are harmed. Worth
 mentioning, however: the rule has more dire implications for other code
-injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2"><a href="https://wg21.link/p3294r2" role="doc-biblioref">[P3294R2]</a></span> (“<em>Code Injection With
-Token Sequences</em>”). With this rule as it is, it becomes impossible
-for e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
+injection papers being considered by WG21, most notably <span class="citation" data-cites="P3294R2">[<a href="https://wg21.link/p3294r2" role="doc-biblioref">P3294R2</a>]</span> (“<em>Code Injection With Token
+Sequences</em>”). With this rule as it is, it becomes impossible for
+e.g., the instantiation of a class template specialization <code class="sourceCode cpp">TCls<span class="op">&lt;</span>Foo<span class="op">&gt;</span></code>
 to produce an injected declaration of <code class="sourceCode cpp">std<span class="op">::</span>formatter<span class="op">&lt;</span>TCls<span class="op">&lt;</span>Foo<span class="op">&gt;&gt;</span></code>
 (since the target scope would be the global namespace).</p>
 <p>In this context, we do believe that relaxations of the rule can be
@@ -4674,8 +4671,7 @@ implementations<a href="#freestanding-implementations" class="self-link"></a></h
 return a
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>
 value. Unfortunately, that means that they are currently not usable in a
-freestanding environment, but <span class="title"><span class="citation" data-cites="P3295R0"><a href="https://wg21.link/p3295r0" role="doc-biblioref">[P3295R0] (Freestanding constexpr containers and
-constexpr exception types)</a></span></span> currently proposes
+freestanding environment, but <span class="title"><span class="citation" data-cites="P3295R0">[<a href="https://wg21.link/p3295r0" role="doc-biblioref">P3295R0</a>]</span></span> currently proposes
 freestanding
 <code class="sourceCode cpp">std<span class="op">::</span>vector</code>,
 <code class="sourceCode cpp">std<span class="op">::</span>string</code>,
@@ -5600,7 +5596,7 @@ complete definition of <code class="sourceCode cpp">T</code>, and they
 both afterwards <code class="sourceCode cpp"><span class="pp">#include </span><span class="im">&quot;cls.h&quot;</span></code>,
 the result will be an ODR violation.</p>
 <p>Additional papers are already in flight proposing additional
-metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2"><a href="https://wg21.link/p3096r2" role="doc-biblioref">[P3096R2]</a></span> proposes the
+metafunctions that pose similar dangers. For instance, <span class="citation" data-cites="P3096R2">[<a href="https://wg21.link/p3096r2" role="doc-biblioref">P3096R2</a>]</span> proposes the
 <code class="sourceCode cpp">parameters_of</code> metafunction. This
 feature is important for generating language bindings (e.g., Python,
 JavaScript), but since parameter names can differ between declarations,
@@ -5664,7 +5660,7 @@ follows:</p>
 <div class="std">
 <blockquote>
 <p><span class="marginalizedparent"><a class="marginalized" href="#pnum_6" id="pnum_6">7-8</a></span>
-Each preprocessing token is converted into a token (<span>5.10 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). Whitespace
+Each preprocessing token is converted into a token (<span>5.6 <a href="https://wg21.link/lex.token">[lex.token]</a></span>). Whitespace
 characters separating tokens are no longer significant. The resulting
 tokens constitute a <em>translation unit</em> and are syntactically and
 semantically analyzed as a
@@ -5787,7 +5783,7 @@ image which contains information needed for execution in its execution
 environment.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.5
+<h3 class="unnumbered" id="lex.pptoken-preprocessing-tokens"><span>5.4
 <a href="https://wg21.link/lex.pptoken">[lex.pptoken]</a></span>
 Preprocessing tokens<a href="#lex.pptoken-preprocessing-tokens" class="self-link"></a></h3>
 <p>Add a bullet after bullet (4.2):</p>
@@ -5833,11 +5829,11 @@ note</em> ]</span></span></span></p></li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
+<h3 class="unnumbered" id="lex.operators-operators-and-punctuators"><span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span>
 Operators and punctuators<a href="#lex.operators-operators-and-punctuators" class="self-link"></a></h3>
 <p>Change the grammar for
 <code class="sourceCode cpp"><em>operator-or-punctuator</em></code> in
-paragraph 1 of <span>5.8 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
+paragraph 1 of <span>5.12 <a href="https://wg21.link/lex.operators">[lex.operators]</a></span> to
 include the reflection operator and the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>
 delimiters:</p>
@@ -6015,7 +6011,7 @@ follows:</p>
 <ul>
 <li><span class="marginalizedparent"><a class="marginalized" href="#pnum_30" id="pnum_30">(3.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is an
-<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.5
+<code class="sourceCode cpp"><em>id-expression</em></code> (<span>7.5.4
 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>)
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code>
@@ -6174,7 +6170,7 @@ TU-local to different translation units are never considered equivalent
 General<a href="#basic.scope.scope-general" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 introduction of a “host scope” in paragraph 2 is part of the resolution
-to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Define the “host scope” of a declaration in paragraph 2:</p>
 <div class="std">
 <blockquote>
@@ -6419,18 +6415,18 @@ A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>names</em> an entity <code class="sourceCode cpp"><em>E</em></code>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(13.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_65" id="pnum_65">(13.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> contains a
 <code class="sourceCode cpp"><em>lambda-expression</em></code> whose
-closure type is <code class="sourceCode cpp"><em>E</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(13.*)</a></span>
+closure type is <code class="sourceCode cpp"><em>E</em></code>,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_66" id="pnum_66">(13.*)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code>
 contains a
 <code class="sourceCode cpp"><em>reflect-expression</em></code> or a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> that,
 respectively, represents or designates
-<code class="sourceCode cpp"><em>E</em></code>,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(13.2)</a></span>
+<code class="sourceCode cpp"><em>E</em></code>,</span></p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_67" id="pnum_67">(13.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not a function or
 function template and <code class="sourceCode cpp"><em>D</em></code>
 contains an <code class="sourceCode cpp"><em>id-expression</em></code>,
@@ -6438,15 +6434,83 @@ contains an <code class="sourceCode cpp"><em>id-expression</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>template-name</em></code>, or
 <code class="sourceCode cpp"><em>concept-name</em></code> denoting
-<code class="sourceCode cpp"><em>E</em></code>, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(13.3)</a></span>
+<code class="sourceCode cpp"><em>E</em></code>, or</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_68" id="pnum_68">(13.3)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is a function or function
 template and <code class="sourceCode cpp"><em>D</em></code> contains an
 expression that names <code class="sourceCode cpp"><em>E</em></code>
 ([basic.def.odr]) or an
 <code class="sourceCode cpp"><em>id-expression</em></code> that refers
 to a set of overloads that contains
-<code class="sourceCode cpp"><em>E</em></code>.</li>
+<code class="sourceCode cpp"><em>E</em></code>.</p>
+<p><span class="note7"><span>[ <em>Note 7:</em> </span>Non-dependent
+names in an instantiated declaration do not refer to a set of overload
+([temp.res]).<span> — <em>end note</em> ]</span></span></p></li>
+</ul>
+</blockquote>
+</div>
+<p><span class="draftnote" style="color: #01796F">[ Drafting note: No
+changes are proposed to paragraphs 14-15, but they are reproduced below
+for ease of reference. ]</span></p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">14</a></span>
+A declaration is an <em>exposure</em> if it either names a TU-local
+entity (defined below), ignoring</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">(14.1)</a></span>
+the <code class="sourceCode cpp"><em>function-body</em></code> for a
+non-inline function or function template (but not the deduced return
+type for a (possibly instantiated) definition of a function with a
+declared return type that uses a placeholder ytpe
+([dcl.spec.auto])),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(14.2)</a></span>
+the <code class="sourceCode cpp"><em>initializer</em></code> for a
+variable or variable template (but not the variable’s type),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">(14.3)</a></span>
+friend declarations in a class definition, and</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">(14.4)</a></span>
+any reference to a non-volatile const object or reference with internal
+or no linkage initialized with a constant expression that is not an
+odr-use ([basic.def.odr]),</li>
+</ul>
+<p>or defines a constexpr variable initialized to a TU-local value
+(defined below).</p>
+<p><span class="note8"><span>[ <em>Note 8:</em> </span>An inline
+function template can be an exposure even though certain explicit
+specializations of it would be usable in other translation units.<span>
+— <em>end note</em> ]</span></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">15</a></span>
+An entity is <em>TU-local</em> if it is</p>
+<ul>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(15.1)</a></span>
+a type, function, variable, or template that</p>
+<ul>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(15.1.1)</a></span>
+has a name with internal linkage, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(15.1.2)</a></span>
+does not have a name with linkage and is declared, or introduced by a
+<code class="sourceCode cpp"><em>lambda-expression</em></code>, within
+the definition of a TU-local entity,</li>
+</ul></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">(15.2)</a></span>
+a type with no name that is defined outside a
+<code class="sourceCode cpp"><em>class-specifier</em></code>, function
+body, or <code class="sourceCode cpp"><em>initializer</em></code> or is
+introduced by a
+<code class="sourceCode cpp"><em>defining-type-specifier</em></code>
+that is used to declare only TU-local entities,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">(15.3)</a></span>
+a specialization of a TU-local template,</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">(15.4)</a></span>
+a specialization of a template with any TU-local template arguments,
+or</p></li>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">(15.5)</a></span>
+a specialization of a template whose (possibly instantiated) declaration
+is an exposure.</p>
+<p><span class="note9"><span>[ <em>Note 9:</em> </span>A specialization
+can be produced by implicit or explicit instantiation.<span> — <em>end
+note</em> ]</span></span></p></li>
 </ul>
 </blockquote>
 </div>
@@ -6454,46 +6518,43 @@ to a set of overloads that contains
 below addition of “value or object of a TU-local type” is in part a
 drive-by fix to make sure that enumerators in a TU-local enumeration are
 also TU-local ]</span></p>
-<p>Extend the definition of <em>TU-local</em> values and objects in p16
-to include reflections:</p>
+<p>Extend the definition of <em>TU-local</em> values and objects in
+paragraph 16 to include reflections:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_69" id="pnum_69">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">16</a></span>
 A value or object is <em>TU-local</em> if</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_70" id="pnum_70">(16.0)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">(16.0)</a></span>
 it is of TU-local type,</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_71" id="pnum_71">(16.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">(16.1)</a></span>
 it is, or is a pointer to, a TU-local function or the object associated
 with a TU-local variable, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_72" id="pnum_72">(16.1+)</a></span>
-it is a reflection representing either
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">(16.1+)</a></span>
+it is a reflection that represents either
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_73" id="pnum_73">(16.1+.1)</a></span>
-an entity that is either TU-local or introduced by an exposure, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_74" id="pnum_74">(16.1+.2)</a></span>
-a value, or object that is TU-local, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_75" id="pnum_75">(16.1+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">(16.1+.1)</a></span>
+an entity, value, or object, that is TU-local, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(16.1+.2)</a></span>
 a direct base class relationship ([class.derived.general]) for which the
-base class or the derived class is either TU-local or introduced by an
-exposure, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_76" id="pnum_76">(16.1+.4)</a></span>
+base class or the derived class is TU-local, or</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(16.1+.3)</a></span>
 a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
 <code class="sourceCode cpp"><em>A</em></code>,
 <code class="sourceCode cpp"><em>W</em></code>,
 <code class="sourceCode cpp"><em>NUA</em></code>) ([class.mem.general])
-for which <code class="sourceCode cpp"><em>T</em></code> is either
-TU-local or introduced by an exposure, or</li>
+for which <code class="sourceCode cpp"><em>T</em></code> is TU-local,
+or</li>
 </ul></li>
 </ul>
 </div>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_77" id="pnum_77">(16.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(16.2)</a></span>
 it is an object of class or array type and any of its subobjects or any
 of the objects or functions to which its non-static data members of
 reference type refer is TU-local and is usable in constant
@@ -6503,6 +6564,26 @@ expressions.</li>
 units are never considered equivalent.</span></p>
 </blockquote>
 </div>
+<p><span class="draftnote" style="color: #01796F">[ Drafting note: No
+changes are proposed to paragraphs 17-18, but they are reproduced below
+for ease of reference. ]</span></p>
+<div class="std">
+<blockquote>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">17</a></span>
+If a (possibly instantiated) declaration of, or a deduction guide for, a
+non-TU-local entity in a module interface unit (outside the
+<code class="sourceCode cpp"><em>private-module-fragment</em></code>, if
+any) or module partition ([module.unit]) is an exposure, the program is
+ill-formed. Such a declaration in any other context is deprecated
+([depr.local]).</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">18</a></span>
+If a declaration that appears in one translation unit names a TU-local
+entity declared in another translation unit that is not a header unit,
+the program is ill-formed. A declaration instantiated for a template
+specialization ([temp.spec]) appears at the point of instantiation of
+the specialization ([temp.point]).make</p>
+</blockquote>
+</div>
 <p>Add examples demonstrating the above rules to the example in
 paragraph 19:</p>
 <div class="std">
@@ -6510,15 +6591,25 @@ paragraph 19:</p>
 <div class="example4">
 <p><span>[ <em>Example 4:</em> </span>Translation unit #1:</p>
 <div class="sourceCode" id="cb121"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a><span class="kw">export</span> <span class="kw">module</span> A;</span>
-<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a><span class="op">[...]</span></span>
-<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="dt">void</span> h<span class="op">(</span><span class="kw">auto</span> x<span class="op">)</span> <span class="op">{</span> adl<span class="op">(</span>x<span class="op">)</span>; <span class="op">}</span>  <span class="co">// OK, but certain specializations are exposures</span></span>
-<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">using</span> Alias <span class="op">=</span> <span class="dt">int</span>;</code></span></span>
-<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> R<span class="op">&gt;</span> <span class="kw">struct</span> T <span class="op">{}</span>;</code></span></span>
-<span id="cb121-8"><a href="#cb121-8" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">static</span> <span class="kw">constexpr</span> <span class="kw">auto</span> r1 <span class="op">=</span> <span class="op">^^</span>Alias;  <span class="co">// OK, value is TU-local but so is r1</span></code></span></span>
-<span id="cb121-9"><a href="#cb121-9" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">constexpr</span> <span class="kw">auto</span> r2 <span class="op">=</span> <span class="op">^^</span>Alias;         <span class="co">// error: value is TU-local but r2 is not</span></code></span></span>
-<span id="cb121-10"><a href="#cb121-10" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">export</span> T<span class="op">&lt;^^</span>Alias<span class="op">&gt;</span> t;                 <span class="co">// error: ^^Alias is a TU-local value</span></code></span></span></code></pre></div>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="dt">void</span> f<span class="op">()</span> <span class="op">{}</span></span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="dt">void</span> it<span class="op">()</span> <span class="op">{</span> f<span class="op">()</span>; <span class="op">}</span>          <span class="co">// error: is an exposure of f</span></span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">inline</span> <span class="dt">void</span> its<span class="op">()</span> <span class="op">{</span> f<span class="op">()</span>; <span class="op">}</span>  <span class="co">// OK</span></span>
+<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> <span class="dt">void</span> g<span class="op">()</span> <span class="op">{</span> its<span class="op">()</span>; <span class="op">}</span>  <span class="co">// OK</span></span>
+<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="dt">void</span> g<span class="op">&lt;</span><span class="dv">0</span><span class="op">&gt;()</span>;</span>
+<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-8"><a href="#cb121-8" aria-hidden="true" tabindex="-1"></a><span class="op">[...]</span></span>
+<span id="cb121-9"><a href="#cb121-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-10"><a href="#cb121-10" aria-hidden="true" tabindex="-1"></a><span class="kw">inline</span> <span class="dt">void</span> h<span class="op">(</span><span class="kw">auto</span> x<span class="op">)</span> <span class="op">{</span> adl<span class="op">(</span>x<span class="op">)</span>; <span class="op">}</span>  <span class="co">// OK, but certain specializations are exposures</span></span>
+<span id="cb121-11"><a href="#cb121-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-12"><a href="#cb121-12" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">constexpr</span> <span class="kw">auto</span> r1 <span class="op">=</span> <span class="op">^^</span>g<span class="op">&lt;</span><span class="dv">0</span><span class="op">&gt;</span>;  <span class="co">// OK</span></code></span></span>
+<span id="cb121-13"><a href="#cb121-13" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">namespace</span> N2 <span class="op">{</span></code></span></span>
+<span id="cb121-14"><a href="#cb121-14" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">static</span> <span class="kw">constexpr</span> <span class="kw">auto</span> r2 <span class="op">=</span> <span class="op">^^</span>g<span class="op">&lt;</span><span class="dv">1</span><span class="op">&gt;</span>;  <span class="co">// OK, r2 is TU-local</span></code></span></span>
+<span id="cb121-15"><a href="#cb121-15" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="op">}</span></code></span></span>
+<span id="cb121-16"><a href="#cb121-16" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">constexpr</span> <span class="kw">auto</span> r3 <span class="op">=</span> <span class="op">^^</span>r2;         <span class="co">// error: r3 is an exposure</span></code></span></span>
+<span id="cb121-17"><a href="#cb121-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-18"><a href="#cb121-18" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">constexpr</span> <span class="kw">auto</span> ctx <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>access_context<span class="op">::</span>current<span class="op">()</span>;</code></span></span>
+<span id="cb121-19"><a href="#cb121-19" aria-hidden="true" tabindex="-1"></a><span class="addu"><code class="sourceCode cpp"><span class="kw">constexpr</span> <span class="kw">auto</span> r4 <span class="op">=</span> std<span class="op">::</span>meta<span class="op">::</span>members_of<span class="op">(^^</span>N2, ctx<span class="op">)</span>;</code></span></span>
+<span id="cb121-20"><a href="#cb121-20" aria-hidden="true" tabindex="-1"></a><span class="addu">  <code class="sourceCode cpp"><span class="co">// error: r4 is an exposure because initializer computes a TU-local value</span></code></span></span></code></pre></div>
 <p>Translation unit #2:</p>
 <div class="sourceCode" id="cb122"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="kw">module</span> A;</span>
 <span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a><span class="op">[...]</span></span></code></pre></div>
@@ -6532,7 +6623,7 @@ General<a href="#basic.types.general-general" class="self-link"></a></h3>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_78" id="pnum_78">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">9</a></span>
 Arithmetic types (<span>6.8.2 <a href="https://wg21.link/basic.fundamental">[basic.fundamental]</a></span>),
 enumeration types, pointer types, pointer-to-member types (<span>6.8.4
 <a href="https://wg21.link/basic.compound">[basic.compound]</a></span>),
@@ -6547,18 +6638,18 @@ as follows:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_79" id="pnum_79">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">12</a></span>
 A type is <em>consteval-only</em> if it is either <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or a type compounded from a consteval-only type ([basic.compound]).
 Every object of consteval-only type shall be</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_80" id="pnum_80">(12.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(12.1)</a></span>
 the object associated with a constexpr variable or a subobject
 thereof,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_81" id="pnum_81">(12.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(12.2)</a></span>
 a template parameter object (<span>13.2 <a href="https://wg21.link/temp.param">[temp.param]</a></span>) or a
 subobject thereof, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_82" id="pnum_82">(12.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(12.3)</a></span>
 an object whose lifetime begins and ends during the evaluation of a core
 constant expression.</li>
 </ul>
@@ -6571,52 +6662,52 @@ Fundamental types<a href="#basic.fundamental-fundamental-types" class="self-link
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_83" id="pnum_83">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">16</a></span>
 The types denoted by <code class="sourceCode cpp"><em>cv</em> std​<span class="op">::</span>​nullptr_t</code>
 are distinct types. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_84" id="pnum_84">x</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">x</a></span>
 A value of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 is called a <em>reflection</em>. There exists a unique <em>null
 reflection</em>; every other reflection is a representation of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_85" id="pnum_85">(x.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(x.1)</a></span>
 a value of scalar type ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_86" id="pnum_86">(x.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(x.2)</a></span>
 an object with static storage duration ([basic.stc]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_87" id="pnum_87">(x.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(x.3)</a></span>
 a variable ([basic.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_88" id="pnum_88">(x.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(x.4)</a></span>
 a structured binding ([dcl.struct.bind]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_89" id="pnum_89">(x.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(x.5)</a></span>
 a function ([dcl.fct]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_90" id="pnum_90">(x.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">(x.6)</a></span>
 an enumerator ([dcl.enum]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_91" id="pnum_91">(x.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">(x.7)</a></span>
 a type alias ([dcl.typedef]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_92" id="pnum_92">(x.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">(x.8)</a></span>
 a type ([basic.types]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_93" id="pnum_93">(x.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">(x.9)</a></span>
 a class member ([class.mem]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_94" id="pnum_94">(x.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">(x.10)</a></span>
 an unnamed bit-field ([class.bit]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_95" id="pnum_95">(x.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(x.11)</a></span>
 a primary class template ([temp.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_96" id="pnum_96">(x.12)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(x.12)</a></span>
 a function template ([temp.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_97" id="pnum_97">(x.13)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">(x.13)</a></span>
 a primary variable template ([temp.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_98" id="pnum_98">(x.14)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">(x.14)</a></span>
 an alias template ([temp.alias]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_99" id="pnum_99">(x.15)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(x.15)</a></span>
 a concept ([temp.concept]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_100" id="pnum_100">(x.16)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(x.16)</a></span>
 a namespace alias ([namespace.alias]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_101" id="pnum_101">(x.17)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(x.17)</a></span>
 a namespace ([basic.namespace.general]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_102" id="pnum_102">(x.18)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(x.18)</a></span>
 a direct base class relationship ([class.derived.general]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_103" id="pnum_103">(x.19)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">(x.19)</a></span>
 a data member description ([class.mem.general]).</li>
 </ul>
 <p>A reflection is said to <em>represent</em> the corresponding
@@ -6675,17 +6766,17 @@ and <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="o
 <span id="cb123-46"><a href="#cb123-46" aria-hidden="true" tabindex="-1"></a>    <span class="co">// represents a data member description</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_104" id="pnum_104">y</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">y</a></span>
 <em>Recommended practice</em>: Implementations should not represent
 other constructs specified in this document, such as partial template
 specializations, attributes, placeholder types, statements, or
 expressions, as values of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_105" id="pnum_105">z</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">z</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>Future revisions of
 this document can specify semantics for reflections representing any
 such constructs.<span> — <em>end note</em> ]</span></span></p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_106" id="pnum_106">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">17</a></span>
 The types described in this subclause are called <em>fundamental
 types</em>.</p>
 </blockquote>
@@ -6696,7 +6787,7 @@ Sequential execution<a href="#intro.execution-sequential-execution" class="self-
 declaration).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_107" id="pnum_107">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">7</a></span>
 Reading an object designated by a
 <code class="sourceCode cpp"><span class="kw">volatile</span></code>
 glvalue ([basic.lval]), modifying an object, <span class="addu">producing an injected declaration ([expr.const]),</span>
@@ -6720,7 +6811,7 @@ stronger sequencing during constant evaluation.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_108" id="pnum_108">15+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">15+</a></span>
 During the evaluation of an expression as a core constant expression
 ([expr.const]), evaluations of operands of individual operators and of
 subexpressions of individual expresssions that are otherwise either
@@ -6736,7 +6827,7 @@ determine the identity of a non-static data member.</p>
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_109" id="pnum_109">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(1.1)</a></span>
 A <em>glvalue</em> is an expression whose evaluation determines the
 identity of an object<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>or</del></span> function<span class="addu">,
 or non-static data member</span>.</li>
@@ -6749,7 +6840,7 @@ bullet 4.1 of Note 3.</p>
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_110" id="pnum_110">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(4.1)</a></span>
 a move-eligible
 <code class="sourceCode cpp"><em>id-expression</em></code>
 ([expr.prim.id.unqual]) <span class="addu">or
@@ -6765,7 +6856,7 @@ Context dependence<a href="#expr.context-context-dependence" class="self-link"><
 to the list of unevaluated operands in paragraph 1.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_111" id="pnum_111">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">1</a></span>
 In some contexts, <em>unevaluated operands</em> appear ([expr.prim.req],
 [expr.typeid], [expr.sizeof], [expr.unary.noexcept], <span class="addu">[expr.reflect],</span> [dcl.type.decltype], [temp.pre],
 [temp.concept]). An unevaluated operand is not evaluated.</p>
@@ -6775,7 +6866,7 @@ In some contexts, <em>unevaluated operands</em> appear ([expr.prim.req],
 the list of expressions in paragraph 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_112" id="pnum_112">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">2</a></span>
 In some contexts, an expression only appears for its side effects. Such
 an expression is called a <em>discarded-value expression</em>. The
 array-to-pointer and function-to-pointer standard conversions are not
@@ -6783,17 +6874,17 @@ applied. The lvalue-to-rvalue conversion is applied if and only if the
 expression is a glvalue of volatile-qualified type and it is one of the
 following:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_113" id="pnum_113">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(2.1)</a></span>
 <code class="sourceCode cpp"><span class="op">(</span> <em>expression</em> <span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is one of
 these expressions,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_114" id="pnum_114">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(2.2)</a></span>
 <code class="sourceCode cpp"><em>id-expression</em></code>
 ([expr.prim.id]),</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_115" id="pnum_115">(2.2+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(2.2+)</a></span>
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 ([expr.prim.splice]),</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_116" id="pnum_116">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">(2.3)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -6818,7 +6909,7 @@ the grammar for
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.5.1
+<h3 class="unnumbered" id="expr.prim.id.general-general"><span>7.5.4.1
 <a href="https://wg21.link/expr.prim.id.general">[expr.prim.id.general]</a></span>
 General<a href="#expr.prim.id.general-general" class="self-link"></a></h3>
 <p>Modify paragraph 2 to avoid transforming non-static members into
@@ -6826,28 +6917,28 @@ implicit member accesses when named as operands to
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_117" id="pnum_117">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">2</a></span>
 If an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><em>E</em></code> denotes a non-static
 non-type member of some class <code class="sourceCode cpp">C</code> at a
-point where the current class (<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
+point where the current class (<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>) is
 <code class="sourceCode cpp">X</code> and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_118" id="pnum_118">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">(2.1)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is potentially evaluated
 or <code class="sourceCode cpp">C</code> is
 <code class="sourceCode cpp">X</code> or a base class of
 <code class="sourceCode cpp">X</code>, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_119" id="pnum_119">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(2.2)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not the
 <code class="sourceCode cpp"><em>id-expression</em></code> of a class
 member access expression (<span>7.6.1.5 <a href="https://wg21.link/expr.ref">[expr.ref]</a></span>), and</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_120" id="pnum_120">(2.2+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(2.2+)</a></span>
 <code class="sourceCode cpp"><em>E</em></code> is not the
 <code class="sourceCode cpp"><em>id-expression</em></code> of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]), and</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_121" id="pnum_121">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(2.3)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> is a
 <code class="sourceCode cpp"><em>qualified-id</em></code>,
 <code class="sourceCode cpp"><em>E</em></code> is not the
@@ -6863,19 +6954,19 @@ as the object expression.</p>
 <p>And extend paragraph 4 to account for splices:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_122" id="pnum_122">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">4</a></span>
 An <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
 that denotes a non-static data member or implicit object member function
 of a class can only be used:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_123" id="pnum_123">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(4.1)</a></span>
 as part of a class member access (after any implicit transformation (see
 above)) in which the object expression refers to the member’s class or a
 class derived from that class, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_124" id="pnum_124">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(4.2)</a></span>
 to form a pointer to member ([expr.unary.op]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_125" id="pnum_125">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(4.3)</a></span>
 if that <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 designates</span> <span class="rm" style="color: #bf0303"><del>denotes</del></span> a non-static data
@@ -6895,14 +6986,14 @@ member and it appears in an unevaluated operand.</li>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.unqual-unqualified-names"><span>7.5.4.2 <a href="https://wg21.link/expr.prim.id.unqual">[expr.prim.id.unqual]</a></span>
 Unqualified names<a href="#expr.prim.id.unqual-unqualified-names" class="self-link"></a></h3>
 <p>Modify paragraph 15 to allow
 <code class="sourceCode cpp"><em>splice-expression</em></code>s to be
 move-eligible:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_126" id="pnum_126">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">15</a></span>
 An <em>implicitly movable entity</em> is a variable with automatic
 storage duration that is either a non-volatile object or an rvalue
 reference to a non-volatile object type. An
@@ -6910,9 +7001,9 @@ reference to a non-volatile object type. An
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 ([expr.prim.splice])</span> is <em>move-eligible</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_127" id="pnum_127">(15.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">(15.1)</a></span>
 it <span class="rm" style="color: #bf0303"><del>names</del></span> <span class="addu">designates</span> an implicitly movable entity,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_128" id="pnum_128">(15.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">(15.2)</a></span>
 it is the (possibly parenthesized) operand of a
 <code class="sourceCode cpp"><span class="cf">return</span></code>
 ([stmt.return]) or
@@ -6920,7 +7011,7 @@ it is the (possibly parenthesized) operand of a
 ([stmt.return.coroutine]) statement or of a
 <code class="sourceCode cpp"><em>throw-expression</em></code>
 ([expr.throw]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_129" id="pnum_129">(15.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">(15.3)</a></span>
 each intervening scope between the declaration of the entity and the
 innermost enclosing scope of the <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span></del></span>
 <span class="addu">expression</span> is a block scope and, for a
@@ -6931,7 +7022,7 @@ the block scope of a
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.5.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
+<h3 class="unnumbered" id="expr.prim.id.qual-qualified-names"><span>7.5.4.3 <a href="https://wg21.link/expr.prim.id.qual">[expr.prim.id.qual]</a></span>
 Qualified names<a href="#expr.prim.id.qual-qualified-names" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> as
@@ -6960,7 +7051,7 @@ well as an example:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_130" id="pnum_130">1+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">1+</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 that is not followed by
@@ -7003,7 +7094,7 @@ is preceded by
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_131" id="pnum_131">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">2</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 <em>declarative</em> if it is part of</p>
 <ul>
@@ -7041,15 +7132,15 @@ template arguments, such that the
 alone cannot designate an entity. ]</span></p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_132" id="pnum_132">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">3</a></span>
 <span class="addu">The entity designated by a
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> is
 determined as follows:</span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_133" id="pnum_133">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(3.1)</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <code class="sourceCode cpp"><span class="op">::</span></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the global namespace.<span class="addu"> </span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_134" id="pnum_134">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(3.2)</a></span>
 A <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 with a
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>
@@ -7059,7 +7150,7 @@ type <span class="rm" style="color: #bf0303"><del>denoted</del></span>
 <span class="addu">designated</span> by the
 <code class="sourceCode cpp"><em>computed-type-specifier</em></code>,
 which shall be a class or enumeration type.<span class="addu"> </span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_135" id="pnum_135">(3.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(3.3)</a></span>
 For a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of the form <code class="sourceCode cpp"><em>splice-specifier</em> <span class="op">::</span></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
@@ -7067,7 +7158,7 @@ designate a class or enumeration type or a namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_136" id="pnum_136">(3.4)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(3.4)</a></span>
 For a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of the form <code class="sourceCode cpp">template<sub><em>opt</em></sub> <em>splice-specialization-specifier</em> <span class="op">::</span></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -7087,7 +7178,7 @@ designates <code class="sourceCode cpp"><em>S</em></code> if
 the type denoted by <code class="sourceCode cpp"><em>S</em></code> if
 <code class="sourceCode cpp"><em>T</em></code> is an alias
 template.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_137" id="pnum_137">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(3.5)</a></span>
 If a <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 <em>N</em> is declarative and has a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> with a
@@ -7095,7 +7186,7 @@ template argument list <em>A</em> that involves a template parameter,
 let <em>T</em> be the template nominated by <em>N</em> without
 <em>A</em>. <em>T</em> shall be a class template.
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_138" id="pnum_138">(3.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(3.5.1)</a></span>
 If <code class="sourceCode cpp"><em>A</em></code> is the template
 argument list (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>) of the
 corresponding <code class="sourceCode cpp"><em>template-head</em></code>
@@ -7105,7 +7196,7 @@ corresponding <code class="sourceCode cpp"><em>template-head</em></code>
 <code class="sourceCode cpp"><em>H</em></code> shall be equivalent to
 the <code class="sourceCode cpp"><em>template-head</em></code> of
 <code class="sourceCode cpp"><em>T</em></code> (<span>13.7.7.2 <a href="https://wg21.link/temp.over.link">[temp.over.link]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_139" id="pnum_139">(3.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(3.5.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>N</em></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the partial specialization (<span>13.7.6
 <a href="https://wg21.link/temp.spec.partial">[temp.spec.partial]</a></span>)
 of <code class="sourceCode cpp"><em>T</em></code> whose template
@@ -7113,7 +7204,7 @@ argument list is equivalent to
 <code class="sourceCode cpp"><em>A</em></code> (<span>13.7.7.2 <a href="https://wg21.link/temp.over.link">[temp.over.link]</a></span>);
 the program is ill-formed if no such partial specialization exists.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_140" id="pnum_140">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(3.6)</a></span>
 Any other
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> <span class="rm" style="color: #bf0303"><del>nominates</del></span> <span class="addu">designates</span> the entity denoted by its
 <code class="sourceCode cpp"><em>type-name</em></code>,
@@ -7125,18 +7216,18 @@ not declarative, the entity shall not be a template.</li>
 </ul>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.6.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
+<h3 class="unnumbered" id="expr.prim.lambda.closure-closure-types"><span>7.5.5.2 <a href="https://wg21.link/expr.prim.lambda.closure">[expr.prim.lambda.closure]</a></span>
 Closure types<a href="#expr.prim.lambda.closure-closure-types" class="self-link"></a></h3>
 <p>We have to say that a closure type is not complete until the
 <code class="sourceCode cpp"><span class="op">}</span></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_141" id="pnum_141">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">1</a></span>
 The type of a lambda-expression (which is also the type of the closure
 object) is a unique, unnamed non-union class type, called the closure
 type, whose properties are described below.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_142" id="pnum_142">x</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">x</a></span>
 The closure type is not complete until the end of its corresponding
 <code class="sourceCode cpp"><em>compound-statement</em></code>.</p>
 </div>
@@ -7145,7 +7236,7 @@ The closure type is not complete until the end of its corresponding
 <p>And say that the call operator is a direct member:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_143" id="pnum_143">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">4</a></span>
 The closure type for a <em>lambda-expression</em> has a public inline
 function call operator (for a non-generic lambda) or function call
 operator template (for a generic lambda) ([over.call]) whose parameters
@@ -7158,7 +7249,7 @@ the closure type.</span> The <em>requires-clause</em> of the function
 call operator template […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="expr.prim.req.type-type-requirements"><span>7.5.8.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
+<h3 class="unnumbered" id="expr.prim.req.type-type-requirements"><span>7.5.7.3 <a href="https://wg21.link/expr.prim.req.type">[expr.prim.req.type]</a></span>
 Type requirements<a href="#expr.prim.req.type-type-requirements" class="self-link"></a></h3>
 <p>Allow splices in type requirements:</p>
 <div class="std">
@@ -7169,7 +7260,7 @@ Type requirements<a href="#expr.prim.req.type-type-requirements" class="self-lin
 <span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a><span class="va">+   typename <em>splice-specifier</em></span></span>
 <span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a><span class="va">+   typename <em>splice-specialization-specifier</em></span></span></code></pre></div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_144" id="pnum_144">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">1</a></span>
 A <code class="sourceCode cpp"><em>type-requirement</em></code> asserts
 the validity of a type. The component names of a
 <code class="sourceCode cpp"><em>type-requirement</em></code> are those
@@ -7199,7 +7290,7 @@ any) and <code class="sourceCode cpp"><em>type-name</em></code> <span class="add
 <h3 class="unnumbered" id="expr.prim.splice-expression-splicing">7.5.8*
 [expr.prim.splice] Expression splicing<a href="#expr.prim.splice-expression-splicing" class="self-link"></a></h3>
 <p>Add a new subsection of <span>7.5 <a href="https://wg21.link/expr.prim">[expr.prim]</a></span> following
-<span>7.5.8 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
+<span>7.5.7 <a href="https://wg21.link/expr.prim.req">[expr.prim.req]</a></span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
@@ -7208,7 +7299,7 @@ any) and <code class="sourceCode cpp"><em>type-name</em></code> <span class="add
 <span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a>   <em>splice-specifier</em></span>
 <span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specifier</em></span>
 <span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>   template <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_145" id="pnum_145">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -7217,6 +7308,10 @@ preceded by
 <code class="sourceCode cpp"><span class="kw">typename</span></code> is
 never interpreted as part of a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">2</a></span>
+An unparenthesized
+<code class="sourceCode cpp"><em>splice-expression</em></code> shall not
+be used as a template argument.</p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb131"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> S <span class="op">{</span> <span class="kw">static</span> <span class="kw">constexpr</span> <span class="dt">int</span> a <span class="op">=</span> <span class="dv">1</span>; <span class="op">}</span>;</span>
@@ -7230,42 +7325,47 @@ never interpreted as part of a
 <span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> V<span class="op">&gt;</span> <span class="kw">constexpr</span> <span class="dt">int</span> e <span class="op">=</span> <span class="op">[:</span>V<span class="op">:]</span>;   <span class="co">// OK</span></span>
 <span id="cb131-10"><a href="#cb131-10" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">int</span> f <span class="op">=</span> <span class="kw">template</span> <span class="op">[:^^</span>e<span class="op">:]&lt;^^</span>S<span class="op">::</span>a<span class="op">&gt;</span>;  <span class="co">// OK</span></span>
 <span id="cb131-11"><a href="#cb131-11" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a><span class="kw">auto</span> g <span class="op">=</span> <span class="kw">typename</span> <span class="op">[:^^</span><span class="dt">int</span><span class="op">:](</span><span class="dv">42</span><span class="op">)</span>;</span>
-<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">// OK, typename [:^^int:] is a splice-type-specifier</span></span></code></pre></div>
+<span id="cb131-12"><a href="#cb131-12" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> g <span class="op">=</span> <span class="kw">typename</span> <span class="op">[:^^</span><span class="dt">int</span><span class="op">:](</span><span class="dv">42</span><span class="op">)</span>;</span>
+<span id="cb131-13"><a href="#cb131-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">// OK, typename [:^^int:] is a splice-type-specifier</span></span>
+<span id="cb131-14"><a href="#cb131-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb131-15"><a href="#cb131-15" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> h <span class="op">=</span> <span class="op">^^</span>g;</span>
+<span id="cb131-16"><a href="#cb131-16" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> i <span class="op">=</span> e<span class="op">&lt;[:^^</span>h<span class="op">:]&gt;</span>;</span>
+<span id="cb131-17"><a href="#cb131-17" aria-hidden="true" tabindex="-1"></a>  <span class="co">// error: unparenthesized splice-expression used as template argument</span></span>
+<span id="cb131-18"><a href="#cb131-18" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> j <span class="op">=</span> e<span class="op">&lt;([:^^</span>h<span class="op">:])&gt;</span>;  <span class="co">// OK</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_146" id="pnum_146">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><em>splice-specifier</em></code>,
 let <code class="sourceCode cpp"><em>S</em></code> be the construct
 designated by
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_147" id="pnum_147">(2.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(3.1)</a></span>
 The expression is ill-formed if
 <code class="sourceCode cpp"><em>S</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_148" id="pnum_148">(2.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(3.1.1)</a></span>
 a constructor,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_149" id="pnum_149">(2.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">(3.1.2)</a></span>
 a destructor,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_150" id="pnum_150">(2.1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">(3.1.3)</a></span>
 an unnamed bit-field, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_151" id="pnum_151">(2.1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">(3.1.4)</a></span>
 a local entity ([basic.pre]) such that
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_152" id="pnum_152">(2.1.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">(3.1.4.1)</a></span>
 there is a lambda scope that intervenes between the expression and the
 point at which <code class="sourceCode cpp"><em>S</em></code> was
 introduced and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_153" id="pnum_153">(2.1.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">(3.1.4.2)</a></span>
 the expression would be potentially evaluated if the effect of any
 enclosing
 <code class="sourceCode cpp"><span class="kw">typeid</span></code>
 expressions ([expr.typeid]) were ignored.</li>
 </ul></li>
 </ul></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_154" id="pnum_154">(2.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">(3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 function <code class="sourceCode cpp"><em>F</em></code>, the expression
 denotes an overload set containing all declarations of
@@ -7274,7 +7374,7 @@ expression or the point immediately following the
 <code class="sourceCode cpp"><em>class-specifier</em></code> of the
 outermost class for which the expression is in a complete-class context;
 overload resolution is performed ([over.match], [over.over]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_155" id="pnum_155">(2.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">(3.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is an
 object or a non-static data member, the expression is an lvalue
 designating <code class="sourceCode cpp"><em>S</em></code>. The
@@ -7282,12 +7382,12 @@ expression has the same type as
 <code class="sourceCode cpp"><em>S</em></code>, and is a bit-field if
 and only if <code class="sourceCode cpp"><em>S</em></code> is a
 bit-field. <span class="note"><span>[ <em>Note 1:</em> </span>The
-implicit transformation (<span>7.5.5 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
+implicit transformation (<span>7.5.4 <a href="https://wg21.link/expr.prim.id">[expr.prim.id]</a></span>) whereby
 an <code class="sourceCode cpp"><em>id-expression</em></code> denoting a
 non-static member becomes a class member access does not apply to a
 <code class="sourceCode cpp"><em>splice-expression</em></code>.<span>
 — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_156" id="pnum_156">(2.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(3.4)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 variable or a structured binding,
 <code class="sourceCode cpp"><em>S</em></code> shall either have static
@@ -7303,15 +7403,15 @@ is a bit-field.</p>
 designating a variable or structured binding of reference type will be
 adjusted to a non-reference type (<span>7.2.2 <a href="https://wg21.link/expr.type">[expr.type]</a></span>).<span>
 — <em>end note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_157" id="pnum_157">(2.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(3.5)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a value
 or an enumerator, the expression is a prvalue that computes
 <code class="sourceCode cpp"><em>S</em></code> and whose type is the
 same as <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_158" id="pnum_158">(2.6)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(3.6)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_159" id="pnum_159">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">4</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> shall
@@ -7326,7 +7426,7 @@ overload resolution is performed to select a unique function. <span class="note"
 candidate function templates undergo template argument deduction and the
 resulting specializations are considered as candidate functions.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_160" id="pnum_160">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">5</a></span>
 For a <code class="sourceCode cpp"><em>splice-expression</em></code> of
 the form <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -7334,7 +7434,7 @@ the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
 shall designate a template
 <code class="sourceCode cpp"><em>T</em></code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_161" id="pnum_161">(4.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(5.1)</a></span>
 If <code class="sourceCode cpp"><em>T</em></code> is a function
 template, the expression denotes an overload set containing all
 declarations of <code class="sourceCode cpp"><em>T</em></code> that
@@ -7343,7 +7443,7 @@ precede either the expression or the point immediately following the
 outermost class for which the expression is in a complete-class context;
 overload resolution is performed to select a unique function
 ([over.match], [over.over]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_162" id="pnum_162">(4.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">(5.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>T</em></code> is a
 primary variable template, let
 <code class="sourceCode cpp"><em>S</em></code> be the specialiation of
@@ -7354,7 +7454,7 @@ any) of the
 The expression is an lvalue referring to the same object associated with
 <code class="sourceCode cpp"><em>S</em></code> and has the same type as
 <code class="sourceCode cpp"><em>S</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_163" id="pnum_163">(4.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">(5.3)</a></span>
 Otherwise, the expression is ill-formed.</p></li>
 </ul>
 <p><span class="note"><span>[ <em>Note 4:</em> </span>Class members
@@ -7394,7 +7494,7 @@ access<a href="#expr.ref-class-member-access" class="self-link"></a></h3>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_164" id="pnum_164">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">1</a></span>
 A postfix expression followed by a dot
 <code class="sourceCode cpp"><span class="op">.</span></code> or an
 arrow <code class="sourceCode cpp"><span class="op">-&gt;</span></code>,
@@ -7420,7 +7520,7 @@ and is followed by a
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_165" id="pnum_165">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">2</a></span>
 For <span class="rm" style="color: #bf0303"><del>the first option (dot),
 if the</del></span> <span class="addu">a dot that is followed by
 an</span> <code class="sourceCode cpp"><em>id-expression</em></code>
@@ -7444,7 +7544,7 @@ the remainder of [expr.ref] will address only <span class="rm" style="color: #bf
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_166" id="pnum_166">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">3</a></span>
 The postfix expression before the dot is evaluated;<sup>50</sup> the
 result of that evaluation, together with the
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -7456,7 +7556,7 @@ determines the result of the entire postfix expression.</p>
 expressions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_167" id="pnum_167">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">4</a></span>
 Abbreviating
 <code class="sourceCode cpp"><em>postfix-expression</em></code>.<code class="sourceCode cpp"><em>id-expression</em></code>
 <span class="addu">or <code class="sourceCode cpp"><em>postfix-expression</em><span class="op">.</span><em>splice-expression</em></code></span>
@@ -7473,17 +7573,17 @@ paragraph 8.</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_168" id="pnum_168">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">*</a></span>
 If <code class="sourceCode cpp">E2</code> is a
 <code class="sourceCode cpp"><em>splice-expression</em></code>, then
 <code class="sourceCode cpp">E2</code> shall designate a member of the
 type of <code class="sourceCode cpp">E1</code>.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_169" id="pnum_169">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">6</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a bit-field,
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 bit-field. […]</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_170" id="pnum_170">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">7</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="addu">designates
 an entity that</span> is declared to have type “reference to
 <code class="sourceCode cpp">T</code>”, then
@@ -7498,13 +7598,13 @@ designates the object or function to which the corresponding reference
 member of <code class="sourceCode cpp">E1</code> is bound. Otherwise,
 one of the following rules applies.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_171" id="pnum_171">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">(7.1)</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a static data member and the type of
 <code class="sourceCode cpp">E2</code> is
 <code class="sourceCode cpp">T</code>, then
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is an
 lvalue; […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_172" id="pnum_172">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">(7.2)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static data member and the type of
 <code class="sourceCode cpp">E1</code> is “<em>cq1</em> <em>vq1</em>
@@ -7523,15 +7623,15 @@ member, then the type of
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 “<em>cq12</em> <em>vq12</em>
 <code class="sourceCode cpp">T</code>”.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_173" id="pnum_173">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">(7.3)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> is an overload set, […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_174" id="pnum_174">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(7.4)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a nested type, the expression
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_175" id="pnum_175">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(7.5)</a></span>
 <span class="addu">Otherwise, if</span> <span class="rm" style="color: #bf0303"><del>If</del></span>
 <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a member enumerator and the type of
 <code class="sourceCode cpp">E2</code> is
@@ -7539,10 +7639,10 @@ ill-formed.</p></li>
 <code class="sourceCode cpp">E1<span class="op">.</span>E2</code> is a
 prvalue of type <code class="sourceCode cpp">T</code> whose value is the
 value of the enumerator.</p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_176" id="pnum_176">(7.6)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(7.6)</a></span>
 Otherwise, the program is ill-formed.</span></p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_177" id="pnum_177">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">8</a></span>
 If <code class="sourceCode cpp">E2</code> <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">designates</span> a non-static member, the program is
 ill-formed if the class of which <code class="sourceCode cpp">E2</code>
 <span class="rm" style="color: #bf0303"><del>is directly</del></span>
@@ -7551,7 +7651,7 @@ member is an ambiguous base (<span>6.5.2 <a href="https://wg21.link/class.member
 of the <span class="rm" style="color: #bf0303"><del>naming</del></span>
 <span class="addu">designating</span> class (<span>11.8.3 <a href="https://wg21.link/class.access.base">[class.access.base]</a></span>)
 of <code class="sourceCode cpp">E2</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_178" id="pnum_178">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">9</a></span>
 If <span class="addu">the entity designated by</span>
 <code class="sourceCode cpp">E2</code> is a non-static member and the
 result of <code class="sourceCode cpp">E1</code> is an object whose type
@@ -7567,7 +7667,7 @@ to the grammar for
 paragraph 1:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_179" id="pnum_179">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">1</a></span>
 Expressions with unary operators group right-to-left.</p>
 <div>
 <div class="sourceCode" id="cb133"><pre class="sourceCode diff"><code class="sourceCode diff"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a>  <em>unary-expression</em>:</span>
@@ -7581,18 +7681,18 @@ Expressions with unary operators group right-to-left.</p>
 <a href="https://wg21.link/expr.unary.op">[expr.unary.op]</a></span>
 Unary operators<a href="#expr.unary.op-unary-operators" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
-changes to paragraph 3.1 are part of the resolution to <span class="citation" data-cites="CWG3026"><a href="https://cplusplus.github.io/CWG/issues/3026.html" role="doc-biblioref">[CWG3026]</a></span>. ]</span></p>
+changes to paragraph 3.1 are part of the resolution to <span class="citation" data-cites="CWG3026">[<a href="https://cplusplus.github.io/CWG/issues/3026.html" role="doc-biblioref">CWG3026</a>]</span>. ]</span></p>
 <p>Modify paragraphs 3 and 4 to permit forming a pointer-to-member with
 a splice.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_180" id="pnum_180">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">3</a></span>
 The operand of the unary
 <code class="sourceCode cpp"><span class="op">&amp;</span></code>
 operator shall be an lvalue of some type
 <code class="sourceCode cpp">T</code>.</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_181" id="pnum_181">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(3.1)</a></span>
 If the operand is a
 <code class="sourceCode cpp"><em>qualified-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -7610,7 +7710,7 @@ member of a namespace-scope anonymous union is considered to be a class
 member access expression ([expr.prim.id.general]) and cannot be used to
 form a pointer to member.<span> — <em>end
 note</em> ]</span></span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_182" id="pnum_182">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(3.2)</a></span>
 Otherwise, the result has type “pointer to
 <code class="sourceCode cpp">T</code>” and points to the designated
 object (<span>6.7.1 <a href="https://wg21.link/intro.memory">[intro.memory]</a></span>) or
@@ -7621,7 +7721,7 @@ shall be a <code class="sourceCode cpp"><em>qualified-id</em></code>
 <span class="addu">or a
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_183" id="pnum_183">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">4</a></span>
 A pointer to member is only formed when an explicit
 <code class="sourceCode cpp"><span class="op">&amp;</span></code> is
 used and its operand is a
@@ -7647,7 +7747,7 @@ reflection operator<a href="#expr.reflect-the-reflection-operator" class="self-l
 <span id="cb134-7"><a href="#cb134-7" aria-hidden="true" tabindex="-1"></a><em>qualified-reflection-name</em>:</span>
 <span id="cb134-8"><a href="#cb134-8" aria-hidden="true" tabindex="-1"></a>   <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>identifier</em></span>
 <span id="cb134-9"><a href="#cb134-9" aria-hidden="true" tabindex="-1"></a>   <em>nested-name-specifier</em> template <em>identifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_184" id="pnum_184">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">1</a></span>
 The unary <code class="sourceCode cpp"><span class="op">^^</span></code>
 operator, called the <em>reflection operator</em>, yields a prvalue of
 type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
@@ -7657,14 +7757,14 @@ places no restriction on representing, by reflections, constructs not
 described by this document or using such constructs as operands of
 <code class="sourceCode cpp"><em>reflect-expression</em></code>s.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_185" id="pnum_185">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 are those of its
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code> (if
 any) and its
 <code class="sourceCode cpp"><em>identifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_186" id="pnum_186">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">3</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> is
 parsed as the longest possible sequence of tokens that could
 syntactically form a
@@ -7692,18 +7792,24 @@ followed by
 <span id="cb135-13"><a href="#cb135-13" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_187" id="pnum_187">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">4</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code> of the
 form <code class="sourceCode cpp"><span class="op">^^</span> <span class="op">::</span></code>
 represents the global namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_188" id="pnum_188">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">5</a></span>
 If a <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> matches the form <code class="sourceCode cpp"><span class="op">^^</span> <em>qualified-reflection-name</em></code>,
 it is interpreted as such and its representation is determined as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_189" id="pnum_189">(5.1)</a></span>
-If the <code class="sourceCode cpp"><em>identifier</em></code> is a
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(5.1)</a></span>
+If the <code class="sourceCode cpp"><em>identifier</em></code> names a
+<code class="sourceCode cpp"><em>using-declarator</em></code>
+([namespace.udecl]), <code class="sourceCode cpp"><em>R</em></code> is
+ill-formed.</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">(5.2)</a></span>
+Otherwise, if the
+<code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>namespace-name</em></code> that names a
 namespace alias ([namespace.alias]),
 <code class="sourceCode cpp"><em>R</em></code> represents that namespace
@@ -7711,36 +7817,36 @@ alias. For any other
 <code class="sourceCode cpp"><em>namespace-name</em></code>,
 <code class="sourceCode cpp"><em>R</em></code> represents the denoted
 namespace.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_190" id="pnum_190">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(5.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>concept-name</em></code>
 ([temp.concept]), <code class="sourceCode cpp"><em>R</em></code>
 represents the denoted concept.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_191" id="pnum_191">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(5.4)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>template-name</em></code>
 ([temp.names]), the representation of
 <code class="sourceCode cpp"><em>R</em></code> is determined as follows:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_192" id="pnum_192">(5.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(5.4.1)</a></span>
 If the <code class="sourceCode cpp"><em>template-name</em></code> names
 an injected-class-name ([class.pre]), then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_193" id="pnum_193">(5.3.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(5.4.1.1)</a></span>
 If the
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 is of the form <code class="sourceCode cpp"><em>nested-name-specifier</em> <span class="kw">template</span> <em>identifier</em></code>,
 then <code class="sourceCode cpp"><em>R</em></code> represents the class
 template named by the injected-class-name.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_194" id="pnum_194">(5.3.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(5.4.1.2)</a></span>
 Otherwise, the injected-class-name shall be unambiguous when considered
 as a <code class="sourceCode cpp"><em>type-name</em></code> and
 <code class="sourceCode cpp"><em>R</em></code> represents the class
 template specialization so named.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_195" id="pnum_195">(5.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(5.4.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>template-name</em></code> names a
 function template <code class="sourceCode cpp"><em>F</em></code>, then
@@ -7751,14 +7857,14 @@ an overload set containing only
 <code class="sourceCode cpp"><em>F</em></code>.
 <code class="sourceCode cpp"><em>R</em></code> represents
 <code class="sourceCode cpp"><em>F</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_196" id="pnum_196">(5.3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(5.4.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>template-name</em></code> denotes a
 primary class template, primary variable template, or alias template,
 <code class="sourceCode cpp"><em>R</em></code> represents that
 template.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_197" id="pnum_197">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">(5.5)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> names a type
 alias that was introduced by the declaration of a template parameter,
@@ -7767,20 +7873,20 @@ entity of that type alias. For any other
 <code class="sourceCode cpp"><em>identifier</em></code> that names a
 type alias, <code class="sourceCode cpp"><em>R</em></code> represents
 that type alias.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_198" id="pnum_198">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">(5.6)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> is a
 <code class="sourceCode cpp"><em>class-name</em></code> or an
 <code class="sourceCode cpp"><em>enum-name</em></code>,
 <code class="sourceCode cpp"><em>R</em></code> represents the denoted
 type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_199" id="pnum_199">(5.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(5.7)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>identifier</em></code> names a class
 member of an anonymous union ([class.union.anon]),
 <code class="sourceCode cpp"><em>R</em></code> represents that class
 member.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_200" id="pnum_200">(5.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(5.8)</a></span>
 Otherwise, the
 <code class="sourceCode cpp"><em>qualified-reflection-name</em></code>
 shall be an <code class="sourceCode cpp"><em>id-expression</em></code>
@@ -7789,22 +7895,22 @@ shall be an <code class="sourceCode cpp"><em>id-expression</em></code>
 <code class="sourceCode cpp"><span class="op">^^</span> <em>I</em></code>
 (see below).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_201" id="pnum_201">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">6</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> of the form
 <code class="sourceCode cpp"><span class="op">^^</span> <em>type-id</em></code>
 represents an entity determined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_202" id="pnum_202">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(6.1)</a></span>
 If the <code class="sourceCode cpp"><em>type-id</em></code> designates a
 placeholder type, <code class="sourceCode cpp"><em>R</em></code> is
 ill-formed.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_203" id="pnum_203">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(6.2)</a></span>
 Otherwise, if the <code class="sourceCode cpp"><em>type-id</em></code>
 names a type alias that is a specialization of an alias template,
 <code class="sourceCode cpp"><em>R</em></code> represents that type
 alias.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_204" id="pnum_204">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(6.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> represents the
 type denoted by the
 <code class="sourceCode cpp"><em>type-id</em></code>.</li>
@@ -7815,12 +7921,12 @@ other cases for
 by
 <code class="sourceCode default"><em>qualified-reflection-name</em></code>.
 ]</span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_205" id="pnum_205">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">7</a></span>
 A <code class="sourceCode cpp"><em>reflect-expression</em></code>
 <code class="sourceCode cpp"><em>R</em></code> of the form <code class="sourceCode cpp"><span class="op">^^</span> <em>id-expression</em></code>
 represents an entity determined as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_206" id="pnum_206">(7.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">(7.1)</a></span>
 If the <code class="sourceCode cpp"><em>id-expression</em></code>
 denotes an overload set <code class="sourceCode cpp"><em>S</em></code>,
 overload resolution for the expression
@@ -7828,21 +7934,21 @@ overload resolution for the expression
 with no target shall select a unique function ([over.over]);
 <code class="sourceCode cpp"><em>R</em></code> represents that
 function.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_207" id="pnum_207">(7.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(7.2)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 variable declared by an
 <code class="sourceCode cpp"><em>init-capture</em></code>
 ([expr.prim.lambda.capture]),
 <code class="sourceCode cpp"><em>R</em></code> is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_208" id="pnum_208">(7.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(7.3)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 local parameter introduced by a
 <code class="sourceCode cpp"><em>requires-expression</em></code>
 ([expr.prim.req]), <code class="sourceCode cpp"><em>R</em></code> is
 ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_209" id="pnum_209">(7.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(7.4)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 local entity <code class="sourceCode cpp"><em>E</em></code>
@@ -7850,7 +7956,7 @@ local entity <code class="sourceCode cpp"><em>E</em></code>
 <code class="sourceCode cpp"><em>R</em></code> and the point at which
 <code class="sourceCode cpp"><em>E</em></code> was introduced,
 <code class="sourceCode cpp"><em>R</em></code> is ill-formed.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_210" id="pnum_210">(7.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(7.5)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 function-local predefined variable ([dcl.fct.def.general]),
@@ -7858,13 +7964,13 @@ function-local predefined variable ([dcl.fct.def.general]),
 other <code class="sourceCode cpp"><em>id-expression</em></code> that
 denotes a variable, <code class="sourceCode cpp"><em>R</em></code>
 represents that variable.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_211" id="pnum_211">(7.6)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">(7.6)</a></span>
 Otherwise, if the
 <code class="sourceCode cpp"><em>id-expression</em></code> denotes a
 structured binding, enumerator, or non-static data member,
 <code class="sourceCode cpp"><em>R</em></code> represents that
 entity.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_212" id="pnum_212">(7.7)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">(7.7)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> is ill-formed.
 <span class="note"><span>[ <em>Note 2:</em> </span>This includes
 <code class="sourceCode cpp"><em>pack-index-expression</em></code>s and
@@ -7896,7 +8002,11 @@ unevaluated operand ([expr.context]).</p>
 <span id="cb136-18"><a href="#cb136-18" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> X <span class="op">{}</span> Y;</span>
 <span id="cb136-19"><a href="#cb136-19" aria-hidden="true" tabindex="-1"></a><span class="kw">typedef</span> <span class="kw">struct</span> Z <span class="op">{}</span> Z;</span>
 <span id="cb136-20"><a href="#cb136-20" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> e <span class="op">=</span> <span class="op">^^</span>Y;  <span class="co">// OK, represents the type alias Y</span></span>
-<span id="cb136-21"><a href="#cb136-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> f <span class="op">=</span> <span class="op">^^</span>Z;  <span class="co">// OK, represents the type Z (not the type alias)</span></span></code></pre></div>
+<span id="cb136-21"><a href="#cb136-21" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> f <span class="op">=</span> <span class="op">^^</span>Z;  <span class="co">// OK, represents the type Z (not the type alias)</span></span>
+<span id="cb136-22"><a href="#cb136-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb136-23"><a href="#cb136-23" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> B <span class="op">{</span> <span class="dt">int</span> m; <span class="op">}</span>;</span>
+<span id="cb136-24"><a href="#cb136-24" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> D <span class="op">:</span> B <span class="op">{</span> <span class="kw">using</span> B<span class="op">::</span>m; <span class="op">}</span>;</span>
+<span id="cb136-25"><a href="#cb136-25" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="kw">auto</span> g <span class="op">=</span> <span class="op">^^</span>D<span class="op">::</span>m;  <span class="co">// error: D::m names a using-declarator</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
@@ -7907,33 +8017,33 @@ Operators<a href="#expr.eq-equality-operators" class="self-link"></a></h3>
 <p>Add a new paragraph between paragraphs 5 and 6:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_213" id="pnum_213">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">5</a></span>
 Two operands of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> or
 one operand of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code> and
 the other a null pointer constant compare equal.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_214" id="pnum_214">5+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">5+</a></span>
 If both operands are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 comparison is defined as follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_215" id="pnum_215">(5+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(5+.1)</a></span>
 If one operand is a null reflection value, then they compare equal if
 and only if the other operand is also a null reflection value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_216" id="pnum_216">(5+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(5+.2)</a></span>
 Otherwise, if one operand represents a value, then they compare equal if
 and only if the other operand represents a value that is
 template-argument-equivalent (<span>13.6 <a href="https://wg21.link/temp.type">[temp.type]</a></span>).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_217" id="pnum_217">(5+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(5+.3)</a></span>
 Otherwise, if one operand represents an object, then they compare equal
 if and only if the other operand represents the same object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_218" id="pnum_218">(5+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(5+.4)</a></span>
 Otherwise, if one operand represents an entity, then they compare equal
 if and only if the other operand represents the same entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_219" id="pnum_219">(5+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(5+.5)</a></span>
 Otherwise, if one operand represents a direct base class relationship,
 then they compare equal if and only if the other operand represents the
 same direct base class relationship.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_220" id="pnum_220">(5+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">(5+.6)</a></span>
 Otherwise, both operands
 <code class="sourceCode cpp">O<sub><em>1</em></sub></code> and
 <code class="sourceCode cpp">O<sub><em>2</em></sub></code> represent
@@ -7944,7 +8054,7 @@ data member descriptions represented by
 (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_221" id="pnum_221">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">6</a></span>
 If two operands compare equal, the result is
 <code class="sourceCode cpp"><span class="kw">true</span></code> for the
 <code class="sourceCode cpp"><span class="op">==</span></code> operator
@@ -7966,7 +8076,7 @@ production of injected declarations from any core constant expression
 that isn’t a consteval block.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_222" id="pnum_222">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">10</a></span>
 An expression <code class="sourceCode cpp"><em>E</em></code> is a
 <em>core constant expression</em> unless the evaluation of
 <code class="sourceCode cpp"><em>E</em></code>, following the rules of
@@ -7974,7 +8084,7 @@ the abstract machine ([intro.execution]), would evaluate one of the
 following:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_223" id="pnum_223">(10.27)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(10.27)</a></span>
 a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>
 ([expr.dynamic.cast]) expression,
@@ -7983,16 +8093,16 @@ a
 <code class="sourceCode cpp"><em>new-expression</em></code> ([expr.new])
 that would throw an exception where no definition of the exception type
 is reachable;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_224" id="pnum_224">(10.27+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">(10.27+)</a></span>
 an expression that would produce an injected declaration (see below),
 unless <code class="sourceCode cpp"><em>E</em></code> is the
 corresponding expression of a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
 ([dcl.pre]);</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_225" id="pnum_225">(10.28)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(10.28)</a></span>
 an <code class="sourceCode cpp"><em>asm-declaration</em></code>
 ([dcl.asm]);</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_226" id="pnum_226">(10.29)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(10.29)</a></span>
 […]</li>
 </ul>
 </blockquote>
@@ -8001,7 +8111,7 @@ an <code class="sourceCode cpp"><em>asm-declaration</em></code>
 <code class="sourceCode cpp"><em>splice-expression</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_227" id="pnum_227">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">17</a></span>
 During the evaluation of an expression
 <code class="sourceCode cpp"><em>E</em></code> as a core constant
 expression, all
@@ -8019,15 +8129,15 @@ includes the entire constant evaluation. […]</p>
 and references to consteval-only objects from constant expressions.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_228" id="pnum_228">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">22</a></span>
 A <em>constant expression</em> is either a glvalue core constant
 expression <span class="addu"><code class="sourceCode cpp"><em>E</em></code></span> that
 <span class="addu"> </span></p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_229" id="pnum_229">(22.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">(22.1)</a></span>
 refers to an object or a non-immediate function<span class="addu">,
 and</span></p></li>
-<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_230" id="pnum_230">(22.2)</a></span>
+<li><p><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">(22.2)</a></span>
 if <code class="sourceCode cpp"><em>E</em></code> designates a function
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>)
 or an object whose complete object is of consteval-only type, then
@@ -8052,22 +8162,22 @@ type,</span></p>
 <p>or a prvalue core constant expression whose result object
 ([basic.lval]) satisfies the following constraints:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_231" id="pnum_231">(22.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(22.3)</a></span>
 each constituent reference refers to an object or a non-immediate
 function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_232" id="pnum_232">(22.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(22.4)</a></span>
 no constituent value of scalar type is an indeterminate value or
-erroneous value (<span>6.7.5 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_233" id="pnum_233">(22.5)</a></span>
+erroneous value (<span>6.7.4 <a href="https://wg21.link/basic.indet">[basic.indet]</a></span>),</li>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">(22.5)</a></span>
 no constituent value of pointer type is a pointer to an immediate
 function or an invalid pointer value ([basic.compound]), <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_234" id="pnum_234">(22.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(22.6)</a></span>
 no constituent value of pointer-to-member type designates an immediate
 function<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_235" id="pnum_235">(22.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(22.7)</a></span>
 unless the value is of consteval-only type, no constituent value of
 pointer or pointer-to-member type is
 <ul>
@@ -8086,13 +8196,13 @@ expression</em> in paragraph 25 to also apply to expressions of
 consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_236" id="pnum_236">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">25</a></span>
 A<span class="rm" style="color: #bf0303"><del>n</del></span> <span class="addu">potentially-evaluated</span> expression or conversion is
 <em>immediate-escalating</em> if it is <span class="rm" style="color: #bf0303"><del>not</del></span> <span class="addu">neither</span> initially in an immediate function context
 <span class="addu">nor a subexpression of an immediate
 invocation,</span> and it is <span class="rm" style="color: #bf0303"><del>either</del></span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_237" id="pnum_237">(25.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(25.1)</a></span>
 <span class="rm" style="color: #bf0303"><del>a
 potentially-evaluated</del></span> <span class="addu">an</span>
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
@@ -8100,10 +8210,10 @@ potentially-evaluated</del></span> <span class="addu">an</span>
 that <span class="rm" style="color: #bf0303"><del>denotes</del></span>
 <span class="addu">designates</span> an immediate function<span class="addu">,</span> <span class="rm" style="color: #bf0303"><del>that
 is not a subexpression of an immediate invocation, or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_238" id="pnum_238">(25.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(25.2)</a></span>
 an immediate invocation that is not a constant expression<span class="addu">, or</span> <span class="rm" style="color: #bf0303"><del>and is not a subexpression of an immediate
 invocation.</del></span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_239" id="pnum_239">(25.3)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">(25.3)</a></span>
 of consteval-only type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>).</span></li>
 </ul>
 </blockquote>
@@ -8113,21 +8223,21 @@ to include functions containing a declaration of a variable of
 consteval-only type.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_240" id="pnum_240">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">27</a></span>
 An <em>immediate function</em> is a function or constructor that is
 <span class="addu">either</span></p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_241" id="pnum_241">(27.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">(27.1)</a></span>
 declared with the
 <code class="sourceCode cpp"><span class="kw">consteval</span></code>
 specifier, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_242" id="pnum_242">(27.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">(27.2)</a></span>
 an immediate-escalating function <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>F</em></code></span></del></span>
 whose function <span class="rm" style="color: #bf0303"><del>body
 contains</del></span> <span class="addu">parameter scope is the
 innermost non-block scope enclosing either</span>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_243" id="pnum_243">(27.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">(27.2.1)</a></span>
 an immediate-escalating expression <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>E</em></code></span>
 such that
 <span><code class="sourceCode default"><em>E</em></code></span>’s
@@ -8135,7 +8245,7 @@ innermost enclosing non-block scope is
 <span><code class="sourceCode default"><em>F</em></code></span>’s
 function parameter scope.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_244" id="pnum_244">(27.2.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">(27.2.2)</a></span>
 a definition of a non-constexpr variable with consteval-only
 type.</span></li>
 </ul></li>
@@ -8148,7 +8258,7 @@ injecting declarations and renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_245" id="pnum_245">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">28</a></span>
 The evaluation of an expression can introduce one or more <em>injected
 declarations</em>. Each such declaration has an associated
 <em>synthesized point</em> which follows the last non-synthesized
@@ -8159,7 +8269,7 @@ concerning reachability apply to synthesized points (<span>10.7 <a href="https:/
 — <em>end note</em> ]</span></span></p>
 <p>No member of an injected declaration shall have a name reserved by
 the implementation ([lex.name]); no diagnostic is required.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_246" id="pnum_246">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">29</a></span>
 Let <code class="sourceCode cpp"><em>C</em></code> be a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>,
 the evaluation of whose corresponding expression produces an injected
@@ -8167,11 +8277,11 @@ declaration for an entity <code class="sourceCode cpp"><em>E</em></code>
 ([meta.reflection.define.aggregate]). The program is ill-formed if
 either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_247" id="pnum_247">(29.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(29.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is enclosed by a scope
 associated with a declaration of
 <code class="sourceCode cpp"><em>E</em></code> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_248" id="pnum_248">(29.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">(29.2)</a></span>
 letting <code class="sourceCode cpp"><em>P</em></code> be a point whose
 immediate scope is that to which
 <code class="sourceCode cpp"><em>E</em></code> belongs, there is a
@@ -8237,7 +8347,7 @@ function parameter scope or class scope that encloses exactly one of
 <span id="cb138-54"><a href="#cb138-54" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_249" id="pnum_249">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">30</a></span>
 The <em>evaluation context</em> is a set of program points that
 determines the behavior of certain functions used for reflection
 ([meta.reflection]). During the evaluation
@@ -8245,7 +8355,7 @@ determines the behavior of certain functions used for reflection
 <code class="sourceCode cpp"><em>E</em></code> as a core constant
 expression, the evaluation context consists of the following points:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_250" id="pnum_250">(30.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(30.1)</a></span>
 <code class="sourceCode cpp"><em>EVAL-PT</em><span class="op">(</span><em>P</em><sub><em><span class="math inline"><em>E</em></span></em></sub><span class="op">)</span></code>,
 where
 <code class="sourceCode cpp"><em>P</em><sub><em><span class="math inline"><em>E</em></span></em></sub></code>
@@ -8253,7 +8363,7 @@ is the point at which <code class="sourceCode cpp"><em>E</em></code>
 appears and <code class="sourceCode cpp"><em>EVAL-PT</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
 is a point determined as follows:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_251" id="pnum_251">(30.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">(30.2)</a></span>
 If a potentially-evaluated subexpression ([intro.execution]) of a
 default member initializer
 <code class="sourceCode cpp"><em>I</em></code> appears at
@@ -8262,17 +8372,17 @@ aggregate) initialization is using
 <code class="sourceCode cpp"><em>I</em></code>, <code class="sourceCode cpp"><em>EVAL-PT</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>
 where <code class="sourceCode cpp"><em>Q</em></code> is the point at
 which that initialization appears.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_252" id="pnum_252">(30.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">(30.3)</a></span>
 Otherwise, if a potentially-evaluated subexpression of a default
 argument ([dcl.fct.default]) appears at
 <code class="sourceCode cpp"><em>P</em></code>, and an invocation of a
 function ([expr.call]) is using that default argument, <code class="sourceCode cpp"><em>EVAL-PT</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>
 where <code class="sourceCode cpp"><em>Q</em></code> is the point at
 which that invocation appears.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_253" id="pnum_253">(30.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">(30.4)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>P</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_254" id="pnum_254">(30.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">(30.5)</a></span>
 Each synthesized point corresponding to an injected declaration produced
 by any evaluation sequenced before
 <code class="sourceCode cpp"><em>X</em></code> ([intro.execution]).</li>
@@ -8321,7 +8431,7 @@ with its associated type from paragraph 8 (type aliases are entities
 now).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_255" id="pnum_255">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">8</a></span>
 If the <code class="sourceCode cpp"><em>decl-specifier-seq</em></code>
 contains the
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -8335,12 +8445,12 @@ type</del></span> (<span>9.2.4 <a href="https://wg21.link/dcl.typedef">[dcl.type
 blocks:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_256" id="pnum_256">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">14</a></span>
 <em>Recommended practice</em>: When a
 <code class="sourceCode cpp"><em>static_assert-declaration</em></code>
 fails, […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_257" id="pnum_257">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">*</a></span>
 For a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
 <code class="sourceCode cpp"><em>D</em></code>, the expression
@@ -8370,7 +8480,7 @@ can produce injected declarations as side effects ([expr.const]).<span>
 <span> — <em>end example</em> ]</span>
 </div>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_258" id="pnum_258">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">15</a></span>
 An <code class="sourceCode cpp"><em>empty-declaration</em></code> has no
 effect.</p>
 </blockquote>
@@ -8383,7 +8493,7 @@ specifier<a href="#dcl.typedef-the-typedef-specifier" class="self-link"></a></h3
 specifier now introduces an entity.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_259" id="pnum_259">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">1</a></span>
 Declarations containing the
 <code class="sourceCode cpp"><em>decl-specifier</em></code>
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -8404,7 +8514,7 @@ and it shall not be used in the
 nor in the
 <code class="sourceCode cpp"><em>decl-specifier-seq</em></code> of a
 <code class="sourceCode cpp"><em>function-definition</em></code>
-(<span>9.6 <a href="https://wg21.link/dcl.fct.def">[dcl.fct.def]</a></span>). If a
+(<span>9.5 <a href="https://wg21.link/dcl.fct.def">[dcl.fct.def]</a></span>). If a
 <code class="sourceCode cpp"><em>typedef-specifier</em></code> appears
 in a declaration without a
 <code class="sourceCode cpp"><em>declarator</em></code>, the program is
@@ -8425,8 +8535,8 @@ alias is</span> the type associated with the
 a <code class="sourceCode cpp"><em>typedef-name</em></code> <span class="rm" style="color: #bf0303"><del>is</del></span> thus <span class="rm" style="color: #bf0303"><del>a synonym for</del></span> <span class="addu">denotes</span> another type. A
 <code class="sourceCode cpp"><em>typedef-name</em></code> does not
 introduce a new type the way a class declaration (<span>11.3 <a href="https://wg21.link/class.name">[class.name]</a></span>) or enum
-declaration (<span>9.8.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_260" id="pnum_260">2</a></span>
+declaration (<span>9.7.1 <a href="https://wg21.link/dcl.enum">[dcl.enum]</a></span>) does.</p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">2</a></span>
 A <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span> can also be <span class="rm" style="color: #bf0303"><del>introduced</del></span> <span class="addu">declared</span> by an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>. The
@@ -8464,7 +8574,7 @@ to accommodate
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_261" id="pnum_261">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">3</a></span>
 A
 <code class="sourceCode cpp"><em>placeholder-type-specifier</em></code>
 is a placeholder for a type to be deduced ([dcl.spec.auto]). A
@@ -8472,10 +8582,10 @@ is a placeholder for a type to be deduced ([dcl.spec.auto]). A
 is a placeholder for a deduced class type ([dcl.type.class.deduct])
 <span class="addu">if it either </span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_262" id="pnum_262">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">(3.1)</a></span>
 is of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>nested-name-specifier</em><sub><em>opt</em></sub> <em>template-name</em></code>,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_263" id="pnum_263">(3.2)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">(3.2)</a></span>
 is of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>
 and the <code class="sourceCode cpp"><em>splice-specifier</em></code>
@@ -8576,13 +8686,13 @@ Decltype specifiers<a href="#dcl.type.decltype-decltype-specifiers" class="self-
 extend the example that follows the paragraph:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_264" id="pnum_264">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">1</a></span>
 For an expression <code class="sourceCode cpp"><em>E</em></code>, the
 type denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
 is defined as follows:</p>
 <p>[…]</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_265" id="pnum_265">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">(1.3)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>id-expression</em></code> or an
@@ -8590,7 +8700,7 @@ unparenthesized class member access ([expr.ref]), <code class="sourceCode cpp"><
 is the type of the entity named by
 <code class="sourceCode cpp"><em>E</em></code>. If there is no such
 entity, the program is ill-formed;</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_266" id="pnum_266">(1.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">(1.3+)</a></span>
 otherwise, if <code class="sourceCode cpp"><em>E</em></code> is an
 unparenthesized
 <code class="sourceCode cpp"><em>splice-expression</em></code>, <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>E</em><span class="op">)</span></code>
@@ -8631,7 +8741,7 @@ Placeholder type specifiers<a href="#dcl.spec.auto.general-placeholder-type-spec
 to account for splicing:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_267" id="pnum_267">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">13</a></span>
 If a variable or function with an undeduced placeholder type is <span class="addu">either</span> named by an expression ([basic.def.odr])
 <span class="addu">or designated by a
 <code class="sourceCode cpp"><em>splice-specifier</em></code> in an
@@ -8675,7 +8785,7 @@ statements.</p>
 <div class="sourceCode" id="cb148"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb148-1"><a href="#cb148-1" aria-hidden="true" tabindex="-1"></a><em>splice-type-specifier</em>:</span>
 <span id="cb148-2"><a href="#cb148-2" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specifier</em></span>
 <span id="cb148-3"><a href="#cb148-3" aria-hidden="true" tabindex="-1"></a>   typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_268" id="pnum_268">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 immediately followed by
@@ -8704,7 +8814,7 @@ within a type-only context (<span>13.8.1 <a href="https://wg21.link/temp.res.gen
 <span id="cb149-11"><a href="#cb149-11" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> alias <span class="op">=</span> <span class="op">[:^^</span>S<span class="op">::</span>type<span class="op">:]</span>;    <span class="co">// OK, type-only context</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_269" id="pnum_269">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">2</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form
 <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specifier</em></code>,
@@ -8713,7 +8823,7 @@ designate a type, a primary class template, or an alias template. The
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 designates the same entity as the
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_270" id="pnum_270">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">3</a></span>
 For a <code class="sourceCode cpp"><em>splice-type-specifier</em></code>
 of the form <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code>,
 the <code class="sourceCode cpp"><em>splice-specifier</em></code> of the
@@ -8735,7 +8845,7 @@ members<a href="#dcl.mptr-pointers-to-members" class="self-link"></a></h3>
 paragraph 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_271" id="pnum_271">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">2</a></span>
 In a declaration <code class="sourceCode cpp">T D</code> where
 <code class="sourceCode cpp">D</code> has the form</p>
 <div class="sourceCode" id="cb150"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><em>nested-name-specifier</em> * <em>attribute-specifier-seq</em><sub><em>opt</em></sub> <em>cv-qualifier-seq</em><sub><em>opt</em></sub> D1</span></code></pre></div>
@@ -8760,11 +8870,11 @@ not designate an anonymous union.</span></p>
 </div>
 <h3 class="unnumbered" id="dcl.array-arrays"><span>9.3.4.5 <a href="https://wg21.link/dcl.array">[dcl.array]</a></span> Arrays<a href="#dcl.array-arrays" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: This
-change is part of the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+change is part of the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Use “host scope” in lieu of “inhabits” in paragraph 8:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_272" id="pnum_272">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">8</a></span>
 Furthermore, if there is a reachable declaration of the entity that
 <span class="rm" style="color: #bf0303"><del>inhabits</del></span> <span class="addu">has</span> the same <span class="addu">host</span> scope in
 which the bound was specified, an omitted array bound is taken to be the
@@ -8778,7 +8888,7 @@ clear about the entity being referred to, and add a bullet to allow for
 reflections of abominable function types:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_273" id="pnum_273">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">9</a></span>
 A function type with a
 <code class="sourceCode cpp"><em>cv-qualifier-seq</em></code> or a
 <code class="sourceCode cpp"><em>ref-qualifier</em></code> (including a
@@ -8787,19 +8897,19 @@ type <span class="rm" style="color: #bf0303"><del>named</del></span>
 <code class="sourceCode cpp"><em>typedef-name</em></code>
 ([dcl.typedef], [temp.param])) shall appear only as:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_274" id="pnum_274">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(9.1)</a></span>
 the function type for a non-static member function,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_275" id="pnum_275">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">(9.2)</a></span>
 the function type to which a pointer to member refers,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_276" id="pnum_276">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(9.3)</a></span>
 the top-level function type of a function typedef declaration or
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_277" id="pnum_277">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">(9.4)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> in the default
 argument of a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
 ([temp.param]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_278" id="pnum_278">(9.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">(9.5)</a></span>
 the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><em>template-argument</em></code> for a
 <code class="sourceCode cpp"><em>type-parameter</em></code>
@@ -8808,7 +8918,7 @@ or</span></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_279" id="pnum_279">(9.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">(9.6)</a></span>
 the operand of a
 <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect]).</li>
@@ -8837,11 +8947,11 @@ of an abominable function type:</p>
 Default arguments<a href="#dcl.fct.default-default-arguments" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes related to “host scopes” in paragraphs 4 and 9 are part of the
-resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. ]</span></p>
+resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. ]</span></p>
 <p>Use “host scope” in lieu of “inhabits” in paragraph 4:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_280" id="pnum_280">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">4</a></span>
 For non-template functions, default arguments can be added in later
 declarations of a function that <span class="rm" style="color: #bf0303"><del>inhabit</del></span> <span class="addu">have</span> the same <span class="addu">host</span> scope.
 Declarations that <span class="rm" style="color: #bf0303"><del>inhabit</del></span> <span class="addu">have</span> different <span class="addu">host</span> scopes
@@ -8853,7 +8963,7 @@ appear in default function arguments, extend example 8 which follows,
 and use “host scope” rather than “inhabits” following example 9.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_281" id="pnum_281">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">9</a></span>
 A default argument is evaluated each time the function is called with no
 argument for the corresponding parameter.</p>
 <p>[…]</p>
@@ -8896,54 +9006,54 @@ example</em> ]</span></p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.5.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<h3 class="unnumbered" id="dcl.init.general-initializers-general"><span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 Initializers (General)<a href="#dcl.init.general-initializers-general" class="self-link"></a></h3>
-<p>Change paragraphs 6-8 of <span>9.5.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
+<p>Change paragraphs 6-8 of <span>9.4.1 <a href="https://wg21.link/dcl.init.general">[dcl.init.general]</a></span>
 <span class="ednote" style="color: #0000ff">[ Editor&#39;s note: No changes
 are necessary for value-initialization, which already forwards to
 zero-initialization for scalar types ]</span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_282" id="pnum_282">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">6</a></span>
 To <em>zero-initialize</em> an object or reference of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_283" id="pnum_283">(6.0)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">(6.0)</a></span>
 <span class="addu">if <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is initialized to a null reflection value;</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_284" id="pnum_284">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">(6.1)</a></span>
 if <code class="sourceCode cpp">T</code> is <span class="rm" style="color: #bf0303"><del>a</del></span> <span class="addu">any
 other</span> scalar type (<span>6.8.1 <a href="https://wg21.link/basic.types.general">[basic.types.general]</a></span>),
 the object is initialized to the value obtained by converting the
 integer literal
 <code class="sourceCode cpp"><span class="dv">0</span></code> (zero) to
 <code class="sourceCode cpp">T</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_285" id="pnum_285">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">(6.2)</a></span>
 […]</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_286" id="pnum_286">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">7</a></span>
 To <em>default-initialize</em> an object of type
 <code class="sourceCode cpp">T</code> means:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_287" id="pnum_287">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a (possibly cv-qualified)
 class type ([class]), […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_288" id="pnum_288">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">(7.2)</a></span>
 If T is an array type, […]</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_289" id="pnum_289">(7.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">(7.*)</a></span>
 <span class="addu">If <code class="sourceCode cpp">T</code> is <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,
 the object is zero-initialized.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_290" id="pnum_290">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">(7.3)</a></span>
 Otherwise, no initialization is performed.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_291" id="pnum_291">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">8</a></span>
 A class type <code class="sourceCode cpp">T</code> is
 <em>const-default-constructible</em> if default-initialization of
 <code class="sourceCode cpp">T</code> would invoke a user-provided
 constructor of <code class="sourceCode cpp">T</code> (not inherited from
 a base class) or if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_292" id="pnum_292">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(8.1)</a></span>
 […]</li>
 </ul>
 <p>If a program calls for the default-initialization of an object of a
@@ -8951,11 +9061,11 @@ const-qualified type <code class="sourceCode cpp">T</code>,
 <code class="sourceCode cpp">T</code> shall be <span class="addu"><code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 or</span> a const-default-constructible class type, or array
 thereof.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_293" id="pnum_293">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">9</a></span>
 To value-initialize an object of type T means: […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.fct.def.general-function-definitions"><span>9.6.1 <a href="https://wg21.link/dcl.fct.def.general">[dcl.fct.def.general]</a></span>
+<h3 class="unnumbered" id="dcl.fct.def.general-function-definitions"><span>9.5.1 <a href="https://wg21.link/dcl.fct.def.general">[dcl.fct.def.general]</a></span>
 Function definitions<a href="#dcl.fct.def.general-function-definitions" class="self-link"></a></h3>
 <p>Disallow using
 <code class="sourceCode cpp"><span class="ot">__func__</span></code> in
@@ -8963,32 +9073,32 @@ a <code class="sourceCode cpp"><span class="kw">consteval</span></code>
 block:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_294" id="pnum_294">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">7</a></span>
 A <em>function-local predefined variable</em> is a variable with static
 storage duration that is implicitly defined in a function parameter
 scope<span class="addu">, other than the function parameter scope of the
 expression corresponding to a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code></span>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_295" id="pnum_295">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">8</a></span>
 The function-local predefined variable
 <code class="sourceCode cpp"><span class="ot">__func__</span></code> is
 defined as if a definition of the form […]</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.fct.def.delete-deleted-definitions"><span>9.6.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
+<h3 class="unnumbered" id="dcl.fct.def.delete-deleted-definitions"><span>9.5.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
 Deleted definitions<a href="#dcl.fct.def.delete-deleted-definitions" class="self-link"></a></h3>
-<p>Change paragraph 2 of <span>9.6.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
+<p>Change paragraph 2 of <span>9.5.3 <a href="https://wg21.link/dcl.fct.def.delete">[dcl.fct.def.delete]</a></span>
 to allow for reflections of deleted functions:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_296" id="pnum_296">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">2</a></span>
 A program that refers to a deleted function implicitly or explicitly,
 other than to declare it <span class="addu">or to use as the operand of
 a <code class="sourceCode cpp"><em>reflect-expression</em></code>
 ([expr.reflect])</span>, is ill-formed.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.8.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
+<h3 class="unnumbered" id="enum.udecl-the-using-enum-declaration"><span>9.7.2 <a href="https://wg21.link/enum.udecl">[enum.udecl]</a></span> The <code class="sourceCode cpp"><span class="kw">using</span> <span class="kw">enum</span></code>
 declaration<a href="#enum.udecl-the-using-enum-declaration" class="self-link"></a></h3>
 <p>Extend the grammar for
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> as
@@ -9010,7 +9120,7 @@ follows:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_297" id="pnum_297">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">1</a></span>
 <span class="addu">A
 <code class="sourceCode cpp"><em>using-enum-declarator</em></code> of
 the form
@@ -9029,7 +9139,7 @@ shall designate a non-dependent type with a reachable
 <code class="sourceCode cpp"><em>enum-specifier</em></code>.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="namespace.alias-namespace-alias"><span>9.9.3
+<h3 class="unnumbered" id="namespace.alias-namespace-alias"><span>9.8.3
 <a href="https://wg21.link/namespace.alias">[namespace.alias]</a></span>
 Namespace alias<a href="#namespace.alias-namespace-alias" class="self-link"></a></h3>
 <p>Modify the grammar for
@@ -9038,7 +9148,7 @@ in paragraph 1, and clarify that such declarations declare a “namespace
 alias” (which is now an entity as per [basic.pre]).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_298" id="pnum_298">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">1</a></span>
 A
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 declares <span class="rm" style="color: #bf0303"><del>an alternative
@@ -9066,7 +9176,7 @@ this will fall out from the “underlying entity” of the namespace alias
 defined below:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_299" id="pnum_299">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">2</a></span>
 The <code class="sourceCode cpp"><em>identifier</em></code> in a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 becomes a <code class="sourceCode cpp"><em>namespace-alias</em></code>
@@ -9080,7 +9190,7 @@ note:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_300" id="pnum_300">2+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">2+</a></span>
 The underlying entity (<span>6.1 <a href="https://wg21.link/basic.pre">[basic.pre]</a></span>) of the
 namespace alias is the namespace either denoted by the
 <code class="sourceCode cpp"><em>qualified-namespace-specifier</em></code>
@@ -9089,7 +9199,7 @@ or designated by the
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.9.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
+<h3 class="unnumbered" id="namespace.udir-using-namespace-directive"><span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>
 Using namespace directive<a href="#namespace.udir-using-namespace-directive" class="self-link"></a></h3>
 <p>Add <code class="sourceCode cpp"><em>splice-specifier</em></code> to
 the grammar for
@@ -9103,12 +9213,12 @@ the grammar for
 </div>
 </blockquote>
 </div>
-<p>Add the following prior to the first paragraph of <span>9.9.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>, and
+<p>Add the following prior to the first paragraph of <span>9.8.4 <a href="https://wg21.link/namespace.udir">[namespace.udir]</a></span>, and
 renumber accordingly:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_301" id="pnum_301">0</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">0</a></span>
 The <code class="sourceCode cpp"><em>splice-specifier</em></code> (if
 any) shall designate a namespace other than the global namespace. The
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
@@ -9116,7 +9226,7 @@ any) shall designate a namespace other than the global namespace. The
 <code class="sourceCode cpp"><em>splice-specifier</em></code> shall not
 be dependent.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_302" id="pnum_302">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">1</a></span>
 A <code class="sourceCode cpp"><em>using-directive</em></code> shall not
 appear in class scope, but may appear in namespace scope or in block
 scope.</p>
@@ -9147,7 +9257,7 @@ namespaces <span class="rm" style="color: #bf0303"><del>nominated</del></span> <
 eligible to be considered.<span> — <em>end note</em> ]</span></span></p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.13.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
+<h3 class="unnumbered" id="dcl.attr.grammar-attribute-syntax-and-semantics"><span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
 Attribute syntax and semantics<a href="#dcl.attr.grammar-attribute-syntax-and-semantics" class="self-link"></a></h3>
 <p>Add a production to the grammar for
 <code class="sourceCode cpp"><em>attribute-specifier</em></code> as
@@ -9176,11 +9286,11 @@ follows:</p>
 </div>
 </blockquote>
 </div>
-<p>Change a sentence in paragraph 4 of <span>9.13.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
+<p>Change a sentence in paragraph 4 of <span>9.12.1 <a href="https://wg21.link/dcl.attr.grammar">[dcl.attr.grammar]</a></span>
 as follows:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_303" id="pnum_303">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">4</a></span>
 […] An <code class="sourceCode cpp"><em>attribute-specifier</em></code>
 that contains no <code class="sourceCode cpp"><em>attribute</em></code>s
 <span class="addu">and no
@@ -9197,28 +9307,28 @@ the two-token sequence
 — <em>end note</em> ]</span></span></span> …</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.deprecated-deprecated-attribute"><span>9.13.4 <a href="https://wg21.link/dcl.attr.deprecated">[dcl.attr.deprecated]</a></span>
+<h3 class="unnumbered" id="dcl.attr.deprecated-deprecated-attribute"><span>9.12.5 <a href="https://wg21.link/dcl.attr.deprecated">[dcl.attr.deprecated]</a></span>
 Deprecated attribute<a href="#dcl.attr.deprecated-deprecated-attribute" class="self-link"></a></h3>
 <p>Prefer “type alias” to
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” in paragraph
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_304" id="pnum_304">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">2</a></span>
 The attribute may be applied to the declaration of a class, a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, a variable, a non-static data
 member, a function, a namespace, an enumeration, an enumerator, a
 concept, or a template specialization.</p>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="dcl.attr.unused-maybe-unused-attribute"><span>9.13.8 <a href="https://wg21.link/dcl.attr.unused">[dcl.attr.unused]</a></span>
+<h3 class="unnumbered" id="dcl.attr.unused-maybe-unused-attribute"><span>9.12.9 <a href="https://wg21.link/dcl.attr.unused">[dcl.attr.unused]</a></span>
 Maybe unused attribute<a href="#dcl.attr.unused-maybe-unused-attribute" class="self-link"></a></h3>
 <p>Prefer “type alias” to
 “<code class="sourceCode cpp"><em>typedef-name</em></code>” in paragraph
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_305" id="pnum_305">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">2</a></span>
 The attribute may be applied to the declaration of a class, <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>typedef-name</em></code></span></del></span>
 <span class="addu">type alias</span>, variable (including a structured
 binding declaration), structured binding, non-static data member,
@@ -9234,7 +9344,7 @@ Module interface<a href="#module.interface-module-interface" class="self-link"><
 aliases now being entities.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_306" id="pnum_306">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">5</a></span>
 If an exported declaration is a
 <code class="sourceCode cpp"><em>using-declaration</em></code>
 ([namespace.udecl]) and is not within a header unit, all entities <span class="rm" style="color: #bf0303"><del>to which all of</del></span>
@@ -9262,11 +9372,11 @@ additional bullet further clarifying that it is unspecified whether any
 splice specifier is replaced.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_307" id="pnum_307">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">3</a></span>
 […]</p>
 <p>In this determination, it is unspecified</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_308" id="pnum_308">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">(3.6)</a></span>
 whether a reference to an
 <code class="sourceCode cpp"><em>alias-declaration</em></code>,
 <code class="sourceCode cpp"><span class="kw">typedef</span></code>
@@ -9275,22 +9385,22 @@ declaration,
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 is replaced by the declarations they name prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_309" id="pnum_309">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(3.7)</a></span>
 whether a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> that
 does not denote a dependent type and whose
 <code class="sourceCode cpp"><em>template-name</em></code> names an
 alias template is replaced by its denoted type prior to this
 determination,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_310" id="pnum_310">(3.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(3.8)</a></span>
 whether a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
 that does not <span class="rm" style="color: #bf0303"><del>denote</del></span> <span class="addu">designate</span> a dependent type is replaced by its <span class="rm" style="color: #bf0303"><del>denoted</del></span> <span class="addu">designated</span> type prior to this determination, <span class="rm" style="color: #bf0303"><del>and</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_311" id="pnum_311">(3.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(3.9)</a></span>
 whether a non-value-dependent constant expression is replaced by the
 result of constant evaluation prior to this determination<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">, and</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_312" id="pnum_312">(3.10)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(3.10)</a></span>
 whether a <code class="sourceCode cpp"><em>splice-specifier</em></code>
 or <code class="sourceCode cpp"><em>splice-expression</em></code> that
 is not dependent is replaced by the construct that it designates prior
@@ -9306,14 +9416,14 @@ synthesized points in the instantiation context, and add a paragraph
 clarifying that the context contains only these points.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_313" id="pnum_313">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">2</a></span>
 During the implicit definition of a defaulted function ([special],
 [class.compare.default]), the instantiation context <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">contains
 each point in</span> the union of the instantiation context from the
 definition of the class and the instantiation context of the program
 construct that resulted in the implicit definition of the defaulted
 function.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_314" id="pnum_314">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">3</a></span>
 During the implicit instantiation of a template whose point of
 instantiation is specified as that of an enclosing specialization
 ([temp.point]), the instantiation context <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">contains
@@ -9328,25 +9438,25 @@ primary module interface unit of
 <code class="sourceCode cpp"><em>M</em></code> (prior to the
 <code class="sourceCode cpp"><em>private-module-fragment</em></code>, if
 any).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_315" id="pnum_315">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">4</a></span>
 During the implicit instantiation of a template that is implicitly
 instantiated because it is referenced from within the implicit
 definition of a defaulted function, the instantiation context <span class="rm" style="color: #bf0303"><del>is</del></span> <span class="addu">contains each point in</span> the instantiation context of
 the defaulted function.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_316" id="pnum_316">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">5</a></span>
 During the instantiation of any other template specialization, the
 instantiation context <span class="rm" style="color: #bf0303"><del>comprises</del></span> <span class="addu">contains</span> the point of instantiation of the
 template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_317" id="pnum_317">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">6</a></span>
 In any other case, the instantiation context at a point within the
 program <span class="rm" style="color: #bf0303"><del>comprises</del></span> <span class="addu">contains</span> that point.</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_318" id="pnum_318">6+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">6+</a></span>
 During the implicit instantiation of any construct that resulted from
 the evaluation of an expression as a core constant expression, the
 instantiation context also contains each point ([expr.const]) in the
 evaluation context ([expr.const]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_319" id="pnum_319">6++</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">6++</a></span>
 The instantiation context contains only those points specified
 above.</p>
 </div>
@@ -9358,23 +9468,23 @@ Reachability<a href="#module.reach-reachability" class="self-link"></a></h3>
 declarations:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_320" id="pnum_320">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> is
 <em>reachable from</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_321" id="pnum_321">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(3.1)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>P</em></code> is not
 a synthesized point and</span>
 <code class="sourceCode cpp"><em>D</em></code> appears prior to
 <code class="sourceCode cpp"><em>P</em></code> in the same translation
 unit, <span class="rm" style="color: #bf0303"><del>or</del></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_322" id="pnum_322">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(3.2)</a></span>
 <span class="addu"><code class="sourceCode cpp"><em>D</em></code> is an
 injected declaration for which
 <code class="sourceCode cpp"><em>P</em></code> is the corresponding
 synthesized point, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_323" id="pnum_323">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(3.3)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not discarded
 (<span>10.4 <a href="https://wg21.link/module.global.frag">[module.global.frag]</a></span>),
 appears in a translation unit that is reachable from
@@ -9430,25 +9540,25 @@ follows:</p>
 <p>Update paragraph 4 accordingly:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_324" id="pnum_324">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">4</a></span>
 A <code class="sourceCode cpp"><em>member-declaration</em></code> does
 not declare new members of the class if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_325" id="pnum_325">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(4.1)</a></span>
 a friend declaration ([class.friend]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_326" id="pnum_326">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(4.2)</a></span>
 a <code class="sourceCode cpp"><em>deduction-guide</em></code>
 ([temp.deduct.guide]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_327" id="pnum_327">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">(4.3)</a></span>
 a <code class="sourceCode cpp"><em>template-declaration</em></code>
 whose declaration is one of the above,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_328" id="pnum_328">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">(4.4)</a></span>
 a <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>static_assert-declaration</em></code></span>,</del></span>
 <span class="addu"><code class="sourceCode cpp"><em>vacuous-declaration</em></code></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_329" id="pnum_329">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">(4.5)</a></span>
 a <code class="sourceCode cpp"><em>using-declaration</em></code>
 ([namespace.udecl]) , or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_330" id="pnum_330">(4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(4.6)</a></span>
 an <code class="sourceCode cpp"><em>empty-declaration</em></code>.</li>
 </ul>
 </blockquote>
@@ -9458,7 +9568,7 @@ subobjects corresponding to non-static data members of reference
 types.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_331" id="pnum_331">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">6</a></span>
 A data member or member function may be declared
 <code class="sourceCode cpp"><span class="kw">static</span></code> in
 its <code class="sourceCode cpp"><em>member-declaration</em></code>, in
@@ -9487,7 +9597,7 @@ member description</em>:</p>
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_332" id="pnum_332">30+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">30+</a></span>
 A <em>data member description</em> is a quintuple
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -9496,19 +9606,19 @@ A <em>data member description</em> is a quintuple
 <code class="sourceCode cpp"><em>NUA</em></code>) describing the
 potential declaration of a nonstatic data member where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_333" id="pnum_333">(30+.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(30+.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a type or type
 alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_334" id="pnum_334">(30+.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(30+.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is an
 <code class="sourceCode cpp"><em>identifier</em></code> or ⊥,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_335" id="pnum_335">(30+.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(30+.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is an alignment or
 ⊥,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_336" id="pnum_336">(30+.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(30+.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is a bit-field width or
 ⊥, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_337" id="pnum_337">(30+.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">(30+.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is a boolean
 value.</li>
 </ul>
@@ -9518,30 +9628,30 @@ components are same types, same identifiers, and equal values.</p>
 <p><span>[ <em>Note 4:</em> </span>The components of a data member
 description describe a data member such that</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_338" id="pnum_338">(30+.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">(30+.6)</a></span>
 its type is specified using the type or type alias given by
 <code class="sourceCode cpp"><em>T</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_339" id="pnum_339">(30+.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">(30+.7)</a></span>
 it is declared with the name given by
 <code class="sourceCode cpp"><em>N</em></code> if
 <code class="sourceCode cpp"><em>N</em></code> does not equal ⊥ and is
 otherwise unnamed,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_340" id="pnum_340">(30+.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">(30+.8)</a></span>
 it is declared with the
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>
-(<span>9.13.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
+(<span>9.12.2 <a href="https://wg21.link/dcl.align">[dcl.align]</a></span>) given by
 <code class="sourceCode cpp"><span class="kw">alignas</span><span class="op">(</span><em>A</em><span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>A</em></code> does not equal ⊥ and
 is otherwise declared without an
 <code class="sourceCode cpp"><em>alignment-specifier</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_341" id="pnum_341">(30+.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">(30+.9)</a></span>
 it is a bit-field (<span>11.4.10 <a href="https://wg21.link/class.bit">[class.bit]</a></span>) with the
 width given by <code class="sourceCode cpp"><em>W</em></code> if
 <code class="sourceCode cpp"><em>W</em></code> does not equal ⊥ and is
 otherwise not a bit-field,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_342" id="pnum_342">(30+.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">(30+.10)</a></span>
 it is declared with the attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
-(<span>9.13.11 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
+(<span>9.12.12 <a href="https://wg21.link/dcl.attr.nouniqueaddr">[dcl.attr.nouniqueaddr]</a></span>)
 if <code class="sourceCode cpp"><em>NUA</em></code> is
 <code class="sourceCode cpp"><span class="kw">true</span></code> and is
 otherwise declared without that attribute.</li>
@@ -9565,7 +9675,7 @@ with <code class="sourceCode cpp"><em>vacuous-declaration</em></code> in
 paragraph 1.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_343" id="pnum_343">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">1</a></span>
 […] Each <code class="sourceCode cpp"><em>member-declaration</em></code>
 in the <code class="sourceCode cpp"><em>member-specification</em></code>
 of an anonymous union shall either define one or more public non-static
@@ -9581,7 +9691,7 @@ General<a href="#class.derived.general-general" class="self-link"></a></h3>
 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_344" id="pnum_344">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">2</a></span>
 The component names of a
 <code class="sourceCode cpp"><em>class-or-decltype</em></code> are those
 of its
@@ -9635,7 +9745,7 @@ designated through
 accessible.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_345" id="pnum_345">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">5</a></span>
 […]</p>
 <p><span class="rm" style="color: #bf0303"><del>The access to a member
 is affected by the class in which the member is named. This naming class
@@ -9645,12 +9755,12 @@ is the</del></span> <span class="addu">An expression
 that affects the access to <code class="sourceCode cpp">m</code>. This
 designating class is either</span></p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_346" id="pnum_346">(5.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(5.1)</a></span>
 the innermost class of which <code class="sourceCode cpp">m</code> is
 directly a member if <code class="sourceCode cpp">E</code> is a
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_347" id="pnum_347">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(5.2)</a></span>
 <span class="addu">the</span> class in whose scope lookup performed a
 search that found <span class="addu"><code class="sourceCode cpp">m</code></span> <span class="rm" style="color: #bf0303"><del>the member</del></span> <span class="addu">otherwise</span>.</li>
 </ul>
@@ -9671,16 +9781,16 @@ note</em> ]</span></span></p>
 point <code class="sourceCode cpp"><em>R</em></code> when <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> in class
 <code class="sourceCode cpp">N</code> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_348" id="pnum_348">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(5.3)</a></span>
 <code class="sourceCode cpp">m</code> as a member of
 <code class="sourceCode cpp">N</code> is public, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_349" id="pnum_349">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">(5.4)</a></span>
 <code class="sourceCode cpp">m</code> as a member of
 <code class="sourceCode cpp">N</code> is private, and
 <code class="sourceCode cpp"><em>R</em></code> occurs in a direct member
 or friend of class <code class="sourceCode cpp"><em>N</em></code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_350" id="pnum_350">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">(5.5)</a></span>
 <code class="sourceCode cpp">m</code> as a member of
 <code class="sourceCode cpp">N</code> is protected, and
 <code class="sourceCode cpp"><em>R</em></code> occurs in a direct member
@@ -9690,11 +9800,11 @@ a member of a class <code class="sourceCode cpp">P</code> derived from
 <code class="sourceCode cpp">m</code> as a member of
 <code class="sourceCode cpp">P</code> is public, private, or protected,
 or</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_351" id="pnum_351">(5.6)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">(5.6)</a></span>
 <code class="sourceCode cpp">m</code> is designated by a
 <code class="sourceCode cpp"><em>splice-expression</em></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_352" id="pnum_352">(5.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">(5.7)</a></span>
 there exists a base class <code class="sourceCode cpp">B</code> of
 <code class="sourceCode cpp">N</code> that is accessible at
 <code class="sourceCode cpp"><em>R</em></code>, and
@@ -9708,7 +9818,7 @@ there exists a base class <code class="sourceCode cpp">B</code> of
 “designated class”:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_353" id="pnum_353">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">6</a></span>
 If a class member access operator, including an implicit “<code class="sourceCode cpp"><span class="kw">this</span><span class="op">-&gt;</span></code>”,
 is used to access a non-static data member or non-static member
 function, the reference is ill-formed if the left operand (considered as
@@ -9725,7 +9835,7 @@ note</em> ]</span></span></p>
 paragraph 2.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_354" id="pnum_354">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">2</a></span>
 When a function is named <span class="addu">or designated</span> in a
 call, which function declaration is being referenced and the validity of
 the call are determined by comparing the types of the arguments at the
@@ -9753,7 +9863,7 @@ to named function<a href="#over.call.func-call-to-named-function" class="self-li
 splices of function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_355" id="pnum_355">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">1</a></span>
 Of interest in [over.call.func] are only those function calls in which
 the <code class="sourceCode cpp"><em>posfix-expression</em></code>
 ultimately contains an
@@ -9780,7 +9890,7 @@ qualified function calls and unqualified function calls.</p>
 the wording to better account for member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_356" id="pnum_356">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">2</a></span>
 In qualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by an
 <code class="sourceCode cpp"><em>id-expression</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-expression</em></code></span>
@@ -9817,7 +9927,7 @@ in the normalized member function call as the implied object argument
 the wording to better account for member function templates.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_357" id="pnum_357">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">3</a></span>
 In unqualified function calls, the function is <span class="rm" style="color: #bf0303"><del>named</del></span> <span class="addu">designated</span> by a
 <code class="sourceCode cpp"><em>primary-expression</em></code> <span class="addu">(call it
 <code class="sourceCode cpp"><em>E</em></code>)</span>. <span class="rm" style="color: #bf0303"><del>The</del></span> <span class="addu">A set
@@ -9846,7 +9956,7 @@ augmented by the addition of an implied function argument as in a
 qualified function call. If the current class is, or is derived from,
 <code class="sourceCode cpp">T</code>, and the keyword
 <code class="sourceCode cpp"><span class="kw">this</span></code>
-(<span>7.5.3 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
+(<span>7.5.2 <a href="https://wg21.link/expr.prim.this">[expr.prim.this]</a></span>)
 refers to it, then the implied object argument is <code class="sourceCode cpp"><span class="op">(*</span><span class="kw">this</span><span class="op">)</span></code>.
 Otherwise, a contrived object of type
 <code class="sourceCode cpp">T</code> becomes the implied object
@@ -9861,7 +9971,7 @@ Class template argument deduction<a href="#over.match.class.deduct-class-templat
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_358" id="pnum_358">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">1</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.8 <a href="https://wg21.link/dcl.type.class.deduct">[dcl.type.class.deduct]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -9871,7 +9981,7 @@ where the <code class="sourceCode cpp"><em>template-name</em></code>
 templates, called the guides of <code class="sourceCode cpp">C</code>,
 is formed comprising:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_359" id="pnum_359">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(1.1)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -9880,7 +9990,7 @@ is formed comprising:</p>
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_360" id="pnum_360">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">3</a></span>
 When resolving a placeholder for a deduced class type (<span>9.2.9.3 <a href="https://wg21.link/dcl.type.simple">[dcl.type.simple]</a></span>)
 where the <code class="sourceCode cpp"><em>template-name</em></code>
 <span class="addu">or
@@ -9900,7 +10010,7 @@ Viable functions<a href="#over.match.viable-viable-functions" class="self-link">
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes to paragraph 2.3 (except for the wording related to
 <code class="sourceCode default"><em>splice-expression</em>s</code>) are
-a part of the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>. These changes render
+a part of the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>. These changes render
 [over.match.best.general]/4 redundant, hence the relocation of its
 associated example to this section. ]</span></p>
 <p>Specify rules for overload sets denoted by
@@ -9912,23 +10022,23 @@ example covering
 <code class="sourceCode cpp"><em>splice-expression</em></code>s).</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_361" id="pnum_361">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">2</a></span>
 First, to be a viable function, a candidate function shall have enough
 parameters to agree in number with the arguments in the list.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_362" id="pnum_362">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(2.1)</a></span>
 If there are <code class="sourceCode cpp"><em>m</em></code> arguments in
 the lists, all candidate functions having exactly
 <code class="sourceCode cpp"><em>m</em></code> parameters are
 viable.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_363" id="pnum_363">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(2.2)</a></span>
 A candidate function having fewer than
 <code class="sourceCode cpp"><em>m</em></code> parameters is viable only
 if it has an ellipsis in its parameter list ([dcl.fct]). For the
 purposes of overload resolution, any argument for which there is no
 corresponding parameter is considered to “match the ellipsis”
 ([over.ics.ellipsis]).</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_364" id="pnum_364">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(2.3)</a></span>
 A candidate function having more than
 <code class="sourceCode cpp"><em>m</em></code> parameters is viable only
 if <span class="addu">there is a declaration
@@ -9985,13 +10095,13 @@ right, so that there are exactly
 General<a href="#over.match.best.general-general" class="self-link"></a></h3>
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 changes to [over.match.viable]/2.3 included in this proposal (part of
-the resolution to <span class="citation" data-cites="CWG2701"><a href="https://wg21.link/cwg2701" role="doc-biblioref">[CWG2701]</a></span>) render paragraph 4 redundant;
+the resolution to <span class="citation" data-cites="CWG2701">[<a href="https://wg21.link/cwg2701" role="doc-biblioref">CWG2701</a>]</span>) render paragraph 4 redundant;
 the contents of example 9 now follow [over.match.viable]/2. ]</span></p>
 <p>Delete paragraph 4 and example 9.</p>
 <div class="std">
 <blockquote>
 <div class="rm" style="color: #bf0303">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_365" id="pnum_365">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">4</a></span>
 If the best viable function resolves to a function for which multiple
 declarations were found, and if any two of these declarations inhabit
 different scopes and specify a default argument that made the function
@@ -10026,7 +10136,7 @@ paragraph 1 to allow taking the address of an overload set specified by
 a <code class="sourceCode cpp"><em>splice-expression</em></code>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_366" id="pnum_366">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">1</a></span>
 An <span class="rm" style="color: #bf0303"><del><span><code class="sourceCode default"><em>id-expression</em></code></span>
 whose terminal name refers to</del></span> <span class="addu">expression
 that designates</span> an overload set
@@ -10048,7 +10158,7 @@ operators<a href="#over.built-built-in-operators" class="self-link"></a></h3>
 to <span>12.5 <a href="https://wg21.link/over.built">[over.built]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_367" id="pnum_367">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">16</a></span>
 For every <code class="sourceCode cpp">T</code>, where
 <code class="sourceCode cpp">T</code> is a pointer-to-member type<span class="addu">, <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>,</span>
 or <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
@@ -10065,7 +10175,7 @@ being used in a
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_368" id="pnum_368">3+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">3+</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of a <code class="sourceCode cpp"><em>type-constraint</em></code>, if
 any, shall not be dependent.</p>
@@ -10077,32 +10187,32 @@ template specializations<a href="#temp.names-names-of-template-specializations" 
 <p>Extend and re-format paragraph 3 of <span>13.3 <a href="https://wg21.link/temp.names">[temp.names]</a></span>:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_369" id="pnum_369">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">3</a></span>
 A <code class="sourceCode cpp"><span class="op">&lt;</span></code> is
 interpreted as the delimiter of a
 <code class="sourceCode cpp"><em>template-argument-list</em></code> if
 it follows</p>
 <ul>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_370" id="pnum_370">(3.1)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">(3.1)</a></span>
 a <code class="sourceCode cpp"><em>splice-specifier</em></code> that
 either appears in a type-only context or is preceded by
 <code class="sourceCode cpp"><span class="kw">template</span></code> or
 <code class="sourceCode cpp"><span class="kw">typename</span></code>,
 or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_371" id="pnum_371">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">(3.2)</a></span>
 a name that is not a
 <code class="sourceCode cpp"><em>conversion-function-id</em></code> and
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_372" id="pnum_372">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(3.2.1)</a></span>
 that follows the keyword template or a ~ after a nested-name-specifier
 or in a class member access expression, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_373" id="pnum_373">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(3.2.2)</a></span>
 for which name lookup finds the injected-class-name of a class template
 or finds any declaration of a template, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_374" id="pnum_374">(3.2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(3.2.3)</a></span>
 that is an unqualified name for which name lookup either finds one or
 more functions or finds nothing, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_375" id="pnum_375">(3.2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(3.2.4)</a></span>
 that is a terminal name in a using-declarator ([namespace.udecl]), in a
 declarator-id ([dcl.meaning]), or in a type-only context other than a
 nested-name-specifier ([temp.res]).</li>
@@ -10142,7 +10252,7 @@ disambiguation in paragraph 4 also applies to the parsing of
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_376" id="pnum_376">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">4</a></span>
 When parsing a
 <code class="sourceCode cpp"><em>template-argument-list</em></code>, the
 first non-nested
@@ -10171,27 +10281,27 @@ cast).<span> — <em>end note</em> ]</span></span></p>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_377" id="pnum_377">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">7</a></span>
 A <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is <em>valid</em> if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_378" id="pnum_378">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(7.1)</a></span>
 there are at most as many arguments as there are parameters or a
 parameter is a template parameter pack (<span>13.7.4 <a href="https://wg21.link/temp.variadic">[temp.variadic]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_379" id="pnum_379">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(7.2)</a></span>
 there is an argument for each non-deducible non-pack parameter that does
 not have a default
 <code class="sourceCode cpp"><em>template-argument</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_380" id="pnum_380">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(7.3)</a></span>
 each <code class="sourceCode cpp"><em>template-argument</em></code>
 matches the corresponding
 <code class="sourceCode cpp"><em>template-parameter</em></code>
 (<span>13.4 <a href="https://wg21.link/temp.arg">[temp.arg]</a></span>),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_381" id="pnum_381">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(7.4)</a></span>
 substitution of each template argument into the following template
 parameters (if any) succeeds, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_382" id="pnum_382">(7.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(7.5)</a></span>
 if the <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 is non-dependent, the associated constraints are satisfied as specified
@@ -10208,7 +10318,7 @@ shall be valid unless it names a function template specialization
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_383" id="pnum_383">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">8</a></span>
 When the <code class="sourceCode cpp"><em>template-name</em></code> of a
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or the
 <code class="sourceCode cpp"><em>splice-specifier</em></code> of a
@@ -10228,7 +10338,7 @@ of the constrained template shall be satisfied (<span>13.5.2 <a href="https://wg
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_384" id="pnum_384">108)</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">108)</a></span>
 A <code class="sourceCode cpp"><span class="op">&gt;</span></code> that
 encloses the <code class="sourceCode cpp"><em>type-id</em></code> of a
 <code class="sourceCode cpp"><span class="kw">dynamic_cast</span></code>,
@@ -10250,7 +10360,7 @@ General<a href="#temp.arg.general-general" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_385" id="pnum_385">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">1</a></span>
 The type and form of each
 <code class="sourceCode cpp"><em>template-argument</em></code> specified
 in a <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or in a
@@ -10267,7 +10377,7 @@ pack, it will correspond to zero or more
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_386" id="pnum_386">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">9</a></span>
 When a <code class="sourceCode cpp"><em>simple-template-id</em></code>
 <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -10284,27 +10394,27 @@ equivalence<a href="#temp.type-type-equivalence" class="self-link"></a></h3>
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_387" id="pnum_387">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">1</a></span>
 Two <code class="sourceCode cpp"><em>template-id</em></code>s <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>s</span>
 are the same if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_388" id="pnum_388">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(1.1)</a></span>
 their <code class="sourceCode cpp"><em>template-name</em></code>s,
 <code class="sourceCode cpp"><em>operator-function-id</em></code>s,
 <span class="rm" style="color: #bf0303"><del>or</del></span>
 <code class="sourceCode cpp"><em>literal-operator-id</em></code>s<span class="addu">, or
 <code class="sourceCode cpp"><em>splice-specifier</em></code>s</span>
 refer to the same template, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_389" id="pnum_389">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">(1.2)</a></span>
 their corresponding type
 <code class="sourceCode cpp"><em>template-argument</em></code>s are the
 same type, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_390" id="pnum_390">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(1.3)</a></span>
 the template parameter values determined by their corresponding constant
 template arguments ([temp.arg.nontype]) are template-argument-equivalent
 (see below), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_391" id="pnum_391">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(1.4)</a></span>
 their corresponding template
 <code class="sourceCode cpp"><em>template-argument</em></code>s refer to
 the same template.</li>
@@ -10319,23 +10429,23 @@ that are the same refer to the same class, function, or variable.</p>
 and add a note between that paragraph and the following example:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_392" id="pnum_392">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">2</a></span>
 Two values are <em>template-argument-equivalent</em> if they are of the
 same type and</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_393" id="pnum_393">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(2.1)</a></span>
 they are of integral type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_394" id="pnum_394">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">(2.2)</a></span>
 they are of floating-point type and their values are identical, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_395" id="pnum_395">(2.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">(2.3)</a></span>
 they are of type <code class="sourceCode cpp">std<span class="op">::</span>nullptr_t</code>,
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_396" id="pnum_396">(2.*)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(2.*)</a></span>
 <span class="addu">they are of type <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="op">::</span>info</code>
 and their values are equivalent, or</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_397" id="pnum_397">(2.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">(2.4)</a></span>
 they are of enumeration type and their values are the same, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_398" id="pnum_398">(2.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">(2.5)</a></span>
 […]</li>
 </ul>
 <p><span class="addu"><span class="note"><span>[ <em>Note 1:</em>
@@ -10357,7 +10467,7 @@ Deduction guides<a href="#temp.deduct.guide-deduction-guides" class="self-link">
 also leverage deduction guides.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_399" id="pnum_399">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">1</a></span>
 Deduction guides are used when a
 <code class="sourceCode cpp"><em>template-name</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code></span>
@@ -10398,7 +10508,7 @@ templates<a href="#temp.alias-alias-templates" class="self-link"></a></h3>
 specializations.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_400" id="pnum_400">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">2</a></span>
 <span class="rm" style="color: #bf0303"><del>When a</del></span> <span class="addu">A</span>
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">that</span> refers to the specialization of an alias
 template<span class="rm" style="color: #bf0303"><del>, it is equivalent
@@ -10425,22 +10535,22 @@ be elided from a
 non-dependent contexts.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_401" id="pnum_401">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">4</a></span>
 A qualified or unqualified name is said to be in a
 <code class="sourceCode cpp"><em>type-only context</em></code> if it is
 the terminal name of</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_402" id="pnum_402">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">(4.1)</a></span>
 a <code class="sourceCode cpp"><em>typename-specifier</em></code>,
 <code class="sourceCode cpp"><em>type-requirement</em></code>,
 <code class="sourceCode cpp"><em>nested-name-specifier</em></code>,
 <code class="sourceCode cpp"><em>elaborated-type-specifier</em></code>,
 <code class="sourceCode cpp"><em>class-or-decltype</em></code>, <span class="addu"><code class="sourceCode cpp"><em>using-enum-declarator</em></code></span>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_403" id="pnum_403">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">(4.2)</a></span>
 […]
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_404" id="pnum_404">(4.4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(4.4.6)</a></span>
 <code class="sourceCode cpp"><em>parameter-declaration</em></code> of a
 <code class="sourceCode cpp"><em>template-parameter</em></code> (which
 necessarily declares a constant template parameter).</li>
@@ -10487,19 +10597,19 @@ Dependent types<a href="#temp.dep.type-dependent-types" class="self-link"></a></
 paragraph 10:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_405" id="pnum_405">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">10</a></span>
 A type is dependent if it is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_406" id="pnum_406">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(10.1)</a></span>
 a template parameter,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_407" id="pnum_407">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(10.2)</a></span>
 …</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_408" id="pnum_408">(10.13)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(10.13)</a></span>
 denoted by <code class="sourceCode cpp"><span class="kw">decltype</span><span class="op">(</span><em>expression</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>expression</em></code> is
 type-dependent<span class="rm" style="color: #bf0303"><del>.</del></span><span class="addu">,
 or</span></li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_409" id="pnum_409">(10.14)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(10.14)</a></span>
 denoted by a
 <code class="sourceCode cpp"><em>splice-type-specifier</em></code> in
 which either the
@@ -10536,7 +10646,7 @@ Type-dependent expressions<a href="#temp.dep.expr-type-dependent-expressions" cl
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_410" id="pnum_410">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">9</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>
@@ -10553,10 +10663,10 @@ Value-dependent expressions<a href="#temp.dep.constexpr-value-dependent-expressi
 (before the note):</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_411" id="pnum_411">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">2</a></span>
 An <em>id-expression</em> is value-dependent if:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_412" id="pnum_412">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">(2.1)</a></span>
 […]</li>
 </ul>
 <p>Expressions of the following form are value-dependent if the
@@ -10584,7 +10694,7 @@ it contains a value-dependent or type-dependent
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_413" id="pnum_413">6+</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">6+</a></span>
 A <code class="sourceCode cpp"><em>primary-expression</em></code> of the
 form <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><span class="kw">template</span> <em>splice-specialization-specifier</em></code>
@@ -10604,7 +10714,7 @@ and renumber accordingly.</p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent splice specifiers [temp.dep.splice]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_414" id="pnum_414">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">1</a></span>
 A <code class="sourceCode cpp"><em>splice-specifier</em></code> is
 dependent if its converted
 <code class="sourceCode cpp"><em>constant-expression</em></code> is
@@ -10618,7 +10728,7 @@ dependent if its
 <code class="sourceCode cpp"><em>splice-specifier</em></code> or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>
 is dependent.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_415" id="pnum_415">2</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">2</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb170"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">auto</span> T, <span class="kw">auto</span> NS<span class="op">&gt;</span></span>
@@ -10637,7 +10747,7 @@ is dependent.</p>
 <span id="cb170-14"><a href="#cb170-14" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_416" id="pnum_416">3</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">3</a></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
 <div class="sourceCode" id="cb171"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span><span class="op">&gt;</span> <span class="kw">class</span> X<span class="op">&gt;</span></span>
@@ -10662,7 +10772,7 @@ is dependent.</p>
 <blockquote>
 <div class="addu">
 <p><strong>Dependent namespaces [temp.dep.namespace]</strong></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_417" id="pnum_417">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">1</a></span>
 A namespace alias is dependent if it is introduced by a
 <code class="sourceCode cpp"><em>namespace-alias-definition</em></code>
 whose <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
@@ -10693,7 +10803,7 @@ Explicit specialization<a href="#temp.expl.spec-explicit-specialization" class="
 to be used like incompletely-defined classes.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_418" id="pnum_418">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">9</a></span>
 A <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
 that <span class="rm" style="color: #bf0303"><del>names</del></span>
@@ -10711,7 +10821,7 @@ General<a href="#temp.deduct.general-general" class="self-link"></a></h3>
 in paragraph 2:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_419" id="pnum_419">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">2</a></span>
 When an explicit template argument list is specified, if the given
 <code class="sourceCode cpp"><em>template-id</em></code> <span class="addu">or
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code></span>
@@ -10732,7 +10842,7 @@ the same as parameter types that are specified using
 <div class="std">
 <blockquote>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_420" id="pnum_420">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">(4.3)</a></span>
 If <code class="sourceCode cpp">P</code> is a class and
 <code class="sourceCode cpp">P</code> has the form
 <code class="sourceCode cpp"><em>simple-template-id</em></code> <span class="addu">or <code class="sourceCode cpp">typename<sub><em>opt</em></sub> <em>splice-specialization-specifier</em></code></span>,
@@ -10764,27 +10874,27 @@ Deducing template arguments from a type<a href="#temp.deduct.type-deducing-templ
 list of non-deduced contexts in paragraph 5:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_421" id="pnum_421">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">5</a></span>
 The non-deduced contexts are:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_422" id="pnum_422">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">(5.1)</a></span>
 The <code class="sourceCode cpp"><em>nested-name-specifier</em></code>
 of a type that was specified using a
 <code class="sourceCode cpp"><em>qualified-id</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_423" id="pnum_423">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">(5.2)</a></span>
 A <code class="sourceCode cpp"><em>pack-index-specifier</em></code> or a
 <code class="sourceCode cpp"><em>pack-index-expression</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_424" id="pnum_424">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">(5.3)</a></span>
 The <code class="sourceCode cpp"><em>expression</em></code> of a
 <code class="sourceCode cpp"><em>decltype-specifier</em></code>.</li>
-<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_425" id="pnum_425">(5.3+)</a></span>
+<li><span class="addu"><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">(5.3+)</a></span>
 The <code class="sourceCode cpp"><em>constant-expression</em></code> of
 a
 <code class="sourceCode cpp"><em>splice-specifier</em></code>.</span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_426" id="pnum_426">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">(5.4)</a></span>
 A constant template argument or an array bound in which a subexpression
 references a template parameter.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_427" id="pnum_427">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">(5.5)</a></span>
 …</li>
 </ul>
 </blockquote>
@@ -10794,7 +10904,7 @@ template argument might also be a
 <code class="sourceCode cpp"><em>splice-specialization-specifier</em></code>.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_428" id="pnum_428">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">20</a></span>
 If <code class="sourceCode cpp">P</code> has a form that contains <code class="sourceCode cpp"><span class="op">&lt;</span>i<span class="op">&gt;</span></code>,
 and if the type of <code class="sourceCode cpp">i</code> differs from
 the type of the corresponding template parameter of the template named
@@ -10819,7 +10929,7 @@ appear in preprocessor directives, while also applying a “drive-by fix”
 to disallow lambdas in the same context.</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_429" id="pnum_429">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">10</a></span>
 Preprocessing directives of the forms</p>
 <div class="sourceCode" id="cb173"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># if      <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span>
 <span id="cb173-2"><a href="#cb173-2" aria-hidden="true" tabindex="-1"></a>     <span class="pp"># elif    <em>constant-expression</em> <em>new-line</em> <em>group</em><sub><em>opt</em></sub></span></span></code></pre></div>
@@ -10837,25 +10947,25 @@ Detailed specifications<a href="#structure.specifications-detailed-specification
 <span>16.3.2.4 <a href="https://wg21.link/structure.specifications">[structure.specifications]</a></span>/3:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_430" id="pnum_430">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">3</a></span>
 Descriptions of function semantics contain the following elements (as
 appropriate):</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_431" id="pnum_431">(3.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">(3.1)</a></span>
 <em>Constraints</em>: […]</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_432" id="pnum_432">(3.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">(3.2)</a></span>
 <em>Mandates</em>: the conditions that, if not met, render the program
 ill-formed. […]</p></li>
 </ul>
 <div class="addu">
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_433" id="pnum_433">(3.2+1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(3.2+1)</a></span>
 <em>Constant When</em>: the conditions that are required for a call to
 the function to be a constant subexpression
 ([defns.const.subexpr]).</li>
 </ul>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_434" id="pnum_434">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">4</a></span>
 […] Next, the semantics of the code sequence are determined by the
 <em>Constraints</em>, <em>Mandates</em>, <span class="addu"><em>Constant
 When</em>,</span> <em>Preconditions</em>, <em>Effects</em>,
@@ -11202,7 +11312,7 @@ Namespace std<a href="#namespace.std-namespace-std" class="self-link"></a></h3>
 <p>Insert before paragraph 7:</p>
 <div class="std">
 <blockquote>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_435" id="pnum_435">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">6</a></span>
 Let F denote a standard library function ([global.functions]), a
 standard library static member function, or an instantiation of a
 standard library function template. Unless F is designated an
@@ -11210,7 +11320,7 @@ standard library function template. Unless F is designated an
 unspecified (possibly ill-formed) if it explicitly or implicitly
 attempts to form a pointer to F. […]</p>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_436" id="pnum_436">6a</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">6a</a></span>
 Let F denote a standard library function or function template. Unless F
 is designated an addressable function, it is unspecified if or how a
 reflection value designating the associated entity can be formed. <span class="note"><span>[ <em>Note 1:</em> </span>For example, it is possible
@@ -11218,14 +11328,14 @@ that <code class="sourceCode cpp">std<span class="op">::</span>meta<span class="
 will not return reflections of standard library functions that an
 implementation handles through an extra-linguistic mechanism.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_437" id="pnum_437">6b</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">6b</a></span>
 Let <code class="sourceCode cpp">C</code> denote a standard library
 class or class template specialization. It is unspecified if or how a
 reflection value can be formed to any private member of
 <code class="sourceCode cpp">C</code>, or what the names of such members
 may be.</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_438" id="pnum_438">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">7</a></span>
 A translation unit shall not declare namespace std to be an inline
 namespace ([namespace.def]).</p>
 </blockquote>
@@ -11756,11 +11866,11 @@ synopsis</strong></p>
 <span id="cb179-337"><a href="#cb179-337" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb179-338"><a href="#cb179-338" aria-hidden="true" tabindex="-1"></a>  consteval strong_ordering type_order(info type_a, info type_b);</span>
 <span id="cb179-339"><a href="#cb179-339" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_439" id="pnum_439">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">1</a></span>
 Unless otherwise specified, each function, and each specialization of
 any function template, specified in this header is a designated
 addressable function ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_440" id="pnum_440">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">2</a></span>
 The behavior of any function specified in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code> is
 implementation-defined when a reflection of a construct not otherwise
@@ -11791,7 +11901,7 @@ definition, the specialization is implicitly instantiated
 </div>
 <span> — <em>end note</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_441" id="pnum_441">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">3</a></span>
 Any function in namespace
 <code class="sourceCode cpp">std<span class="op">::</span>meta</code>
 whose return type is <code class="sourceCode cpp">string_view</code> or
@@ -11808,7 +11918,7 @@ equals <code class="sourceCode cpp"><span class="ch">&#39;</span><span class="sc
 <span id="cb181-6"><a href="#cb181-6" aria-hidden="true" tabindex="-1"></a><span class="kw">static_assert</span><span class="op">(</span>sv<span class="op">.</span>data<span class="op">()[</span><span class="dv">1</span><span class="op">]</span> <span class="op">==</span> <span class="ch">&#39;</span><span class="sc">\0</span><span class="ch">&#39;</span><span class="op">)</span>;</span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_442" id="pnum_442">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">4</a></span>
 For the purpose of exposition, throughout this clause
 <code class="sourceCode cpp"><span class="op">^^</span><em>E</em></code>
 is used to indicate a reflection representing source construct
@@ -11825,7 +11935,7 @@ Operator representations<a href="#meta.reflection.operators-operator-representat
 <span id="cb182-2"><a href="#cb182-2" aria-hidden="true" tabindex="-1"></a>  <em>see below</em>;</span>
 <span id="cb182-3"><a href="#cb182-3" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb182-4"><a href="#cb182-4" aria-hidden="true" tabindex="-1"></a><span class="kw">using</span> <span class="kw">enum</span> operators;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_443" id="pnum_443">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">1</a></span>
 The enumeration type <code class="sourceCode cpp">operators</code>
 specifies constants used to identify operators that can be overloaded,
 with the meanings listed in Table 1. The values of the constants are
@@ -12079,10 +12189,10 @@ Table 1: Enum class <code class="sourceCode cpp">operators</code>
 </tbody>
 </table>
 <div class="sourceCode" id="cb183"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> operators operator_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_444" id="pnum_444">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an operator function or operator function template.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_445" id="pnum_445">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">3</a></span>
 <em>Returns</em>: The value of the enumerator from
 <code class="sourceCode cpp">operators</code> whose corresponding
 <code class="sourceCode cpp"><em>operator-function-id</em></code> is the
@@ -12090,11 +12200,11 @@ unqualified name of the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb184"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span>
 <span id="cb184-2"><a href="#cb184-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8symbol_of<span class="op">(</span>operators op<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_446" id="pnum_446">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">4</a></span>
 <em>Constant When</em>: The value of
 <code class="sourceCode cpp">op</code> corresponds to one of the
 enumerators in <code class="sourceCode cpp">operators</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_447" id="pnum_447">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code> containing the
 characters of the operator symbol name corresponding to
@@ -12109,21 +12219,21 @@ Reflection names and locations<a href="#meta.reflection.names-reflection-names-a
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb185"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_identifier<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_448" id="pnum_448">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">1</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_449" id="pnum_449">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(1.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an entity that has a
 typedef name for linkage purposes ([dcl.typedef]), then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_450" id="pnum_450">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(1.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 unnamed entity, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_451" id="pnum_451">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(1.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a class
 type, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_452" id="pnum_452">(1.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">(1.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 function, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -12132,7 +12242,7 @@ is <code class="sourceCode cpp"><span class="kw">false</span></code> and
 the function is not a constructor, destructor, operator function, or
 conversion function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_453" id="pnum_453">(1.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">(1.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 template, then
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -12140,30 +12250,30 @@ template, then
 template, operator function template, or conversion function template.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_454" id="pnum_454">(1.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">(1.6)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 variable, then
 <code class="sourceCode cpp"><span class="kw">false</span></code> if the
 declaration of that variable was instantiated from a function parameter
 pack. Otherwise, <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_455" id="pnum_455">(1.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">(1.7)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 structured binding, then
 <code class="sourceCode cpp"><span class="kw">false</span></code> if the
 declaration of that structured binding was instantiated from a
 structured binding pack. Otherwise,
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_456" id="pnum_456">(1.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">(1.8)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a type
 alias, then <code class="sourceCode cpp"><span class="op">!</span>has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_457" id="pnum_457">(1.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">(1.9)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator, non-static data member, namespace, or namespace alias, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_458" id="pnum_458">(1.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">(1.10)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">has_identifier<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_459" id="pnum_459">(1.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(1.11)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12176,38 +12286,38 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 </ul>
 <div class="sourceCode" id="cb186"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8identifier_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_460" id="pnum_460">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">2</a></span>
 Let <em>E</em> be UTF-8 for
 <code class="sourceCode cpp">u8identifier_of</code>, and otherwise the
 ordinary literal encoding.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_461" id="pnum_461">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">3</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_identifier<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 the identifier that would be returned (see below) is representable by
 <code class="sourceCode cpp"><em>E</em></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_462" id="pnum_462">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">4</a></span>
 <em>Returns</em>: An NTMBS, encoded with
 <code class="sourceCode cpp"><em>E</em></code>, determined as
 follows:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_463" id="pnum_463">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an entity with a
 typedef name for linkage purposes, then that name.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_464" id="pnum_464">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a literal
 operator or literal operator template, then the
 <code class="sourceCode cpp"><em>ud-suffix</em></code> of the operator
 or operator template.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_465" id="pnum_465">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 entity, then the identifier introduced by the declaration of that
 entity.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_466" id="pnum_466">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>
 or <code class="sourceCode cpp">u8identifier_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>,
 respectively.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_467" id="pnum_467">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">(4.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12221,21 +12331,21 @@ containing the identifier
 </ul>
 <div class="sourceCode" id="cb187"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> string_view display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb187-2"><a href="#cb187-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> u8string_view u8display_string_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_468" id="pnum_468">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">5</a></span>
 <em>Returns</em>: An implementation-defined
 <code class="sourceCode cpp">string_view</code> or
 <code class="sourceCode cpp">u8string_view</code>, respectively.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_469" id="pnum_469">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">6</a></span>
 <em>Recommended practice</em>: Where possible, implementations should
 return a string suitable for identifying the represented construct.</p>
 <div class="sourceCode" id="cb188"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> source_location source_location_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_470" id="pnum_470">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">7</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 value, a type other than a class type or an enumeration type, the global
 namespace, or a data member description, then <code class="sourceCode cpp">source_location<span class="op">{}</span></code>.
 Otherwise, an implementation-defined
 <code class="sourceCode cpp">source_location</code> value.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_471" id="pnum_471">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">8</a></span>
 <em>Recommended practice</em>: If <code class="sourceCode cpp">r</code>
 represents an entity with a definition that is reachable from the
 evaluation context, a value corresponding to a definition should be
@@ -12249,7 +12359,7 @@ Reflection queries<a href="#meta.reflection.queries-reflection-queries" class="s
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb189"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> <em>has-type</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_472" id="pnum_472">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">1</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value, object,
@@ -12258,23 +12368,23 @@ non-static data member, unnamed bit-field, direct base class
 relationship, or data member description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb190"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info type_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_473" id="pnum_473">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_474" id="pnum_474">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">3</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_475" id="pnum_475">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">(3.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a value, object,
 variable, function, non-static data member, or unnamed bit-field, then
 the type of what is represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_476" id="pnum_476">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">(3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator <code class="sourceCode cpp"><em>N</em></code> of an
 enumeration <code class="sourceCode cpp"><em>E</em></code>, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_477" id="pnum_477">(3.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">(3.2.1)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is defined by a
 declaration <code class="sourceCode cpp"><em>D</em></code> that precedes
 a point <code class="sourceCode cpp"><em>P</em></code> in the evaluation
@@ -12283,17 +12393,17 @@ occur within an
 <code class="sourceCode cpp"><em>enum-specifier</em></code> of
 <code class="sourceCode cpp"><em>D</em></code>, then a reflection of
 <code class="sourceCode cpp"><em>E</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_478" id="pnum_478">(3.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">(3.2.2)</a></span>
 Otherwise, a reflection of the type of
 <code class="sourceCode cpp"><em>N</em></code> prior to the closing
 brace of the <code class="sourceCode cpp"><em>enum-specifier</em></code>
 as specified in [dcl.enum].</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_479" id="pnum_479">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">(3.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then a reflection of the type of the direct
 base class.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_480" id="pnum_480">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">(3.4)</a></span>
 Otherwise, for a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -12304,36 +12414,36 @@ a reflection of the type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb191"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info object_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_481" id="pnum_481">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">4</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> is a
 reflection representing either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_482" id="pnum_482">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">(4.1)</a></span>
 an object with static storage duration ([basic.stc.general]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_483" id="pnum_483">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">(4.2)</a></span>
 a variable that either declares or refers to such an object, and if that
 variable is a reference <code class="sourceCode cpp"><em>R</em></code>
 then either
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_484" id="pnum_484">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">(4.2.1)</a></span>
 <code class="sourceCode cpp"><em>R</em></code> is usable in constant
 expressions ([expr.const]), or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_485" id="pnum_485">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">(4.2.2)</a></span>
 the lifetime of <code class="sourceCode cpp"><em>R</em></code> began
 within the core constant expression currently under evaluation.</li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_486" id="pnum_486">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">5</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_487" id="pnum_487">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">(5.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an object, then
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_488" id="pnum_488">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">(5.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 reference, then a reflection of the object referred to by that
 reference.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_489" id="pnum_489">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">(5.3)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a variable;
 a reflection of the object declared by that variable.</li>
 </ul>
@@ -12349,17 +12459,17 @@ a reflection of the object declared by that variable.</li>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb193"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info constant_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_490" id="pnum_490">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">6</a></span>
 Let <code class="sourceCode cpp"><em>R</em></code> be a constant
 expression of type <code class="sourceCode cpp">info</code> such that
 <code class="sourceCode cpp"><em>R</em> <span class="op">==</span> r</code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_491" id="pnum_491">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp"><span class="op">[:</span> <em>R</em> <span class="op">:]</span></code>
 is a valid
 <code class="sourceCode cpp"><em>splice-expression</em></code>
 ([expr.prim.splice]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_492" id="pnum_492">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">8</a></span>
 <em>Effects</em>: Equivalent to:</p>
 <div class="sourceCode" id="cb194"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a><span class="cf">return</span> reflect_constant<span class="op">([:</span> <em>R</em> <span class="op">:])</span>;</span></code></pre></div>
 <div class="example">
@@ -12393,7 +12503,7 @@ is a valid
 <div class="sourceCode" id="cb196"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_public<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_protected<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb196-3"><a href="#cb196-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_private<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_493" id="pnum_493">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">9</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member, unnamed
@@ -12401,7 +12511,7 @@ bit-field, or direct base class relationship that is public, protected,
 or private, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb197"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_virtual<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_494" id="pnum_494">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">10</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents either a virtual member
@@ -12409,7 +12519,7 @@ function or a direct base class relationship that is virtual. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb198"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb198-1"><a href="#cb198-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_pure_virtual<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb198-2"><a href="#cb198-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_override<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_495" id="pnum_495">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">11</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -12417,7 +12527,7 @@ is pure virtual or overrides another member function, respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb199"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb199-1"><a href="#cb199-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_final<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_496" id="pnum_496">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">12</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a final class or a
@@ -12425,7 +12535,7 @@ final member function. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb200"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb200-1"><a href="#cb200-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_deleted<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb200-2"><a href="#cb200-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_defaulted<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_497" id="pnum_497">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">13</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12434,7 +12544,7 @@ deleted function ([dcl.fct.def.delete]) or defaulted function
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb201"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb201-1"><a href="#cb201-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_provided<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb201-2"><a href="#cb201-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_user_declared<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_498" id="pnum_498">14</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">14</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is
@@ -12442,7 +12552,7 @@ user-provided or user-declared ([dcl.fct.def.default]), respectively.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb202"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb202-1"><a href="#cb202-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_explicit<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_499" id="pnum_499">15</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">15</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a member function that
@@ -12457,7 +12567,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb203"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb203-1"><a href="#cb203-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_noexcept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_500" id="pnum_500">16</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">16</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -12474,7 +12584,7 @@ is still
 because in general such queries for templates cannot be answered.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb204"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb204-1"><a href="#cb204-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_bit_field<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_501" id="pnum_501">17</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">17</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a bit-field, or if
@@ -12488,7 +12598,7 @@ for which <code class="sourceCode cpp"><em>W</em></code> is not ⊥.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb205"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb205-1"><a href="#cb205-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_502" id="pnum_502">18</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">18</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an enumerator.
@@ -12496,12 +12606,12 @@ Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb206"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb206-1"><a href="#cb206-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_const<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb206-2"><a href="#cb206-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_volatile<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_503" id="pnum_503">19</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">19</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_504" id="pnum_504">20</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">20</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a const or
@@ -12509,7 +12619,7 @@ volatile type, respectively, or a const- or volatile-qualified function
 type, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb207"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb207-1"><a href="#cb207-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_mutable_member<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_505" id="pnum_505">21</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">21</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a
@@ -12518,12 +12628,12 @@ non-static data member. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb208"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_lvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_rvalue_reference_qualified<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_506" id="pnum_506">22</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">22</a></span>
 Let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">type_of<span class="op">(</span>r<span class="op">)</span></code>
 if <code class="sourceCode cpp"><em>has-type</em><span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 Otherwise, let <code class="sourceCode cpp"><em>T</em></code> be <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_507" id="pnum_507">23</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">23</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp"><em>T</em></code> represents a lvalue- or
@@ -12532,7 +12642,7 @@ rvalue-reference qualified function type, respectively. Otherwise,
 <div class="sourceCode" id="cb209"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_static_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb209-2"><a href="#cb209-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_thread_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb209-3"><a href="#cb209-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_automatic_storage_duration<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_508" id="pnum_508">24</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">24</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an object or variable
@@ -12546,7 +12656,7 @@ duration.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_external_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb210-4"><a href="#cb210-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_c_language_linkage<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb210-5"><a href="#cb210-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_linkage<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_509" id="pnum_509">25</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">25</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable, function,
@@ -12555,7 +12665,7 @@ linkage, external linkage, C language linkage, or any linkage,
 respectively ([basic.link]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb211"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_complete_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_510" id="pnum_510">26</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">26</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_type<span class="op">(</span>r<span class="op">)</span></code>
@@ -12565,15 +12675,15 @@ represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<sp
 is not an incomplete type ([basic.types]). Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb212"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_enumerable_type<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_511" id="pnum_511">27</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">27</a></span>
 A type <code class="sourceCode cpp"><em>T</em></code> is
 <em>enumerable</em> from a point
 <code class="sourceCode cpp"><em>P</em></code> if either</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_512" id="pnum_512">(27.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">(27.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is a class type complete
 at <code class="sourceCode cpp"><em>P</em></code> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_513" id="pnum_513">(27.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">(27.2)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is an enumeration type
 defined by a declaration <code class="sourceCode cpp"><em>D</em></code>
 such that <code class="sourceCode cpp"><em>D</em></code> is reachable
@@ -12582,7 +12692,7 @@ from <code class="sourceCode cpp"><em>P</em></code> but
 <code class="sourceCode cpp"><em>enum-specifier</em></code> of
 <code class="sourceCode cpp"><em>D</em></code> ([dcl.enum]).</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_514" id="pnum_514">28</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">28</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
@@ -12612,14 +12722,14 @@ context. Otherwise,
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb214"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_variable<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_515" id="pnum_515">29</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">29</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a variable. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb215"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_516" id="pnum_516">30</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">30</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents an entity whose
@@ -12627,7 +12737,7 @@ underlying entity is a type or namespace, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb216"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_type_alias<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_namespace_alias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_517" id="pnum_517">31</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">31</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a type alias or
@@ -12636,7 +12746,7 @@ namespace alias, respectively <span class="note"><span>[ <em>Note
 alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb217"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_function<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_518" id="pnum_518">32</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">32</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function. Otherwise,
@@ -12644,7 +12754,7 @@ alias<span> — <em>end note</em> ]</span></span>. Otherwise,
 <div class="sourceCode" id="cb218"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_conversion_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_operator_function<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_519" id="pnum_519">33</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">33</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12660,7 +12770,7 @@ or literal operator ([over.literal]), respectively. Otherwise,
 <span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_copy_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_move_assignment<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_destructor<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_520" id="pnum_520">34</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">34</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function that is a
@@ -12670,14 +12780,14 @@ operator, a copy assignment operator, a move assignment operator, or a
 destructor, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb220"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_template<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_521" id="pnum_521">35</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">35</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
 class template, variable template, alias template, or concept.
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_522" id="pnum_522">36</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">36</a></span>
 <span class="note"><span>[ <em>Note 5:</em> </span>A template
 specialization is not a template. <code class="sourceCode cpp">is_template<span class="op">(^^</span>std<span class="op">::</span>vector<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> but
@@ -12694,7 +12804,7 @@ is
 <span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_literal_operator_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb221-8"><a href="#cb221-8" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_constructor_template<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb221-9"><a href="#cb221-9" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_concept<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_523" id="pnum_523">37</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">37</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a function template,
@@ -12704,14 +12814,14 @@ constructor template, or concept respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb222"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_value<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_object<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_524" id="pnum_524">38</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">38</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a value or object,
 respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb223"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_structured_binding<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_525" id="pnum_525">39</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">39</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a structured binding.
@@ -12722,7 +12832,7 @@ Otherwise,
 <span id="cb224-3"><a href="#cb224-3" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_nonstatic_data_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb224-4"><a href="#cb224-4" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_static_member<span class="op">(</span>info r<span class="op">)</span>;</span>
 <span id="cb224-5"><a href="#cb224-5" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_base<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_526" id="pnum_526">40</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">40</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a class member,
@@ -12730,72 +12840,72 @@ namespace member, non-static data member, static member, or direct base
 class relationship, respectively. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb225"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_default_member_initializer<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_527" id="pnum_527">41</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">41</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a non-static data
 member that has a default member initializer. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb226"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb226-1"><a href="#cb226-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_parent<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_528" id="pnum_528">42</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">42</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_529" id="pnum_529">(42.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">(42.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents the global
 namespace, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_530" id="pnum_530">(42.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">(42.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 that has C language linkage ([dcl.link]), then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_531" id="pnum_531">(42.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">(42.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 that has a language linkage other than C++ language linkage, then an
 implementation-defined value.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_532" id="pnum_532">(42.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">(42.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a type
 that is neither a class nor enumeration type, then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_533" id="pnum_533">(42.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">(42.5)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an entity
 or direct base class relationship, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_534" id="pnum_534">(42.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">(42.6)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
 </ul>
 <div class="sourceCode" id="cb227"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info parent_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_535" id="pnum_535">43</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">43</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_parent<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_536" id="pnum_536">44</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">44</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_537" id="pnum_537">(44.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(44.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member that is a direct member of an anonymous union, or an unnamed
 bit-field declared within the
 <code class="sourceCode cpp"><em>member-specification</em></code> of
 such a union, then a reflection representing the innermost enclosing
 anonymous union.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_538" id="pnum_538">(44.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(44.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents an
 enumerator, then a reflection representing the corresponding enumeration
 type.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_539" id="pnum_539">(44.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">(44.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship between a class
 <code class="sourceCode cpp"><em>D</em></code> and a direct base class
 <code class="sourceCode cpp"><em>B</em></code>, then a reflection
 representing <code class="sourceCode cpp"><em>D</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_540" id="pnum_540">(44.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(44.4)</a></span>
 Otherwise, let <code class="sourceCode cpp"><em>E</em></code> be the
 class, function, or namespace whose class scope, function parameter
 scope, or namespace scope, respectively, is the innermost such scope
 that either is, or encloses, the target scope of a declaration of what
 is represented by <code class="sourceCode cpp">r</code>.
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_541" id="pnum_541">(44.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">(44.5)</a></span>
 If <code class="sourceCode cpp"><em>E</em></code> is the function call
 operator of a closure type for a
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
@@ -12805,7 +12915,7 @@ first <code class="sourceCode cpp">parent_of</code> will be the closure
 type, so the second <code class="sourceCode cpp">parent_of</code> is
 necessary to give the parent of that closure type.<span> — <em>end
 note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_542" id="pnum_542">(44.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">(44.6)</a></span>
 Otherwise,
 <code class="sourceCode cpp"><span class="op">^^</span><em>E</em></code>.</li>
 </ul></li>
@@ -12834,13 +12944,13 @@ Otherwise,
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb229"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info dealias<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_543" id="pnum_543">45</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">45</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 an entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_544" id="pnum_544">46</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">46</a></span>
 <em>Returns</em>: A reflection representing the underlying entity of
 what <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_545" id="pnum_545">47</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">47</a></span></p>
 <div class="example">
 <span>[ <em>Example 5:</em> </span>
 <div class="sourceCode" id="cb230"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a>using X = int;</span>
@@ -12851,7 +12961,7 @@ what <code class="sourceCode cpp">r</code> represents.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb231"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_template_arguments<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_546" id="pnum_546">48</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">48</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a specialization of a
@@ -12859,17 +12969,17 @@ function template, variable template, class template, or an alias
 template. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb232"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info template_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_547" id="pnum_547">49</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">49</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_548" id="pnum_548">50</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">50</a></span>
 <em>Returns</em>: A reflection of the primary template of the
 specialization represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb233"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> template_arguments_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_549" id="pnum_549">51</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">51</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">has_template_arguments<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_550" id="pnum_550">52</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">52</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of the template arguments of the template
 specialization represented by <code class="sourceCode cpp">r</code>, in
@@ -12879,7 +12989,7 @@ its corresponding reflection
 <code class="sourceCode cpp"><em>R</em></code> is determined as
 follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_551" id="pnum_551">(52.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(52.1)</a></span>
 If <code class="sourceCode cpp"><em>A</em></code> denotes a type or a
 type alias, then <code class="sourceCode cpp"><em>R</em></code> is a
 reflection representing the underlying entity of
@@ -12887,27 +12997,27 @@ reflection representing the underlying entity of
 </span><code class="sourceCode cpp"><em>R</em></code> always represents
 a type, never a type alias.<span> — <em>end
 note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_552" id="pnum_552">(52.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">(52.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>A</em></code> denotes a
 class template, variable template, concept, or alias template, then
 <code class="sourceCode cpp"><em>R</em></code> is a reflection
 representing <code class="sourceCode cpp"><em>A</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_553" id="pnum_553">(52.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">(52.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>A</em></code> is a constant
 template argument ([temp.arg.nontype]). Let
 <code class="sourceCode cpp"><em>P</em></code> be the corresponding
 template parameter.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_554" id="pnum_554">(52.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(52.3.1)</a></span>
 If <code class="sourceCode cpp"><em>P</em></code> has reference type,
 then <code class="sourceCode cpp"><em>R</em></code> is a reflection
 representing the object or function referred to by
 <code class="sourceCode cpp"><em>A</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_555" id="pnum_555">(52.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(52.3.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>P</em></code> has class
 type, then <code class="sourceCode cpp"><em>R</em></code> represents the
 corresponding template parameter object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_556" id="pnum_556">(52.3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">(52.3.3)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>R</em></code> is a
 reflection representing the value computed by
 <code class="sourceCode cpp"><em>A</em></code>.</li>
@@ -12946,12 +13056,12 @@ Access control context<a href="#meta.reflection.access.context-access-control-co
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_557" id="pnum_557">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">1</a></span>
 The <code class="sourceCode cpp">access_context</code> class is a
 non-aggregate type that represents a namespace, class, or function from
 which queries pertaining to access rules may be performed, as well as
 the naming class ([class.access.base]), if any.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_558" id="pnum_558">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">2</a></span>
 An <code class="sourceCode cpp">access_context</code> has an associated
 scope and naming class.</p>
 <div class="sourceCode" id="cb235"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb235-1"><a href="#cb235-1" aria-hidden="true" tabindex="-1"></a><span class="kw">struct</span> access_context <span class="op">{</span></span>
@@ -12965,7 +13075,7 @@ scope and naming class.</p>
 <span id="cb235-9"><a href="#cb235-9" aria-hidden="true" tabindex="-1"></a>   <span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span>
 <span id="cb235-10"><a href="#cb235-10" aria-hidden="true" tabindex="-1"></a>   <span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span>
 <span id="cb235-11"><a href="#cb235-11" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_559" id="pnum_559">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">3</a></span>
 <code class="sourceCode cpp">access_context</code> is a structural type.
 Two values <code class="sourceCode cpp">ac1</code> and
 <code class="sourceCode cpp">ac2</code> of type
@@ -12977,20 +13087,20 @@ and <code class="sourceCode cpp">ac2<span class="op">.</span>naming_class<span c
 are template-argument-equivalent.</p>
 <div class="sourceCode" id="cb236"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb236-1"><a href="#cb236-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info scope<span class="op">()</span> <span class="kw">const</span>;</span>
 <span id="cb236-2"><a href="#cb236-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info naming_class<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_560" id="pnum_560">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">4</a></span>
 <em>Returns</em>: The
 <code class="sourceCode cpp">access_context</code>’s associated scope
 and naming class, respectively.</p>
 <div class="sourceCode" id="cb237"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb237-1"><a href="#cb237-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context current<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_561" id="pnum_561">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">5</a></span>
 <code class="sourceCode cpp">current</code> is not an addressable
 function ([namespace.std]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_562" id="pnum_562">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">6</a></span>
 Given a program point <code class="sourceCode cpp"><em>P</em></code>,
 let <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
 be the following program point:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_563" id="pnum_563">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">(6.1)</a></span>
 If a potentially-evaluated subexpression ([intro.execution]) of a
 default member initializer
 <code class="sourceCode cpp"><em>I</em></code> for a member of a class
@@ -12998,30 +13108,30 @@ default member initializer
 appears at <code class="sourceCode cpp"><em>P</em></code>, then a point
 determined as follows:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_564" id="pnum_564">(6.1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">(6.1.1)</a></span>
 If an aggregate initialization is using
 <code class="sourceCode cpp"><em>I</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>Q</em></code> is the point at
 which that aggregate initialization appears.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_565" id="pnum_565">(6.1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">(6.1.2)</a></span>
 Otherwise, if an initialization by an inherited constructor
 ([class.inhctor.init]) is using
 <code class="sourceCode cpp"><em>I</em></code>, a point whose immediate
 scope is the class scope corresponding to
 <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_566" id="pnum_566">(6.1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">(6.1.3)</a></span>
 Otherwise, a point whose immediate scope is the function parameter scope
 corresponding to the constructor definition that is using
 <code class="sourceCode cpp"><em>I</em></code>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_567" id="pnum_567">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">(6.2)</a></span>
 Otherwise, if a potentially-evaluated subexpression of a default
 argument ([dcl.fct.default]) appears at
 <code class="sourceCode cpp"><em>P</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>,
 where <code class="sourceCode cpp"><em>Q</em></code> is the point at
 which the invocation of the function ([expr.call]) using that default
 argument appears.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_568" id="pnum_568">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">(6.3)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a function parameter
 scope introduced by a declaration
@@ -13033,7 +13143,7 @@ trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
 scope is the innermost scope enclosing the locus of
 <code class="sourceCode cpp"><em>D</em></code> that is not a template
 parameter scope.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_569" id="pnum_569">(6.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">(6.4)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a function parameter
 scope introduced by a
@@ -13045,7 +13155,7 @@ at point <code class="sourceCode cpp"><em>Q</em></code>, and
 <code class="sourceCode cpp"><em>trailing-return-type</em></code> or the
 trailing <code class="sourceCode cpp"><em>requires-clause</em></code> of
 <code class="sourceCode cpp"><em>L</em></code>, <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>Q</em><span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_570" id="pnum_570">(6.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">(6.5)</a></span>
 Otherwise, if the immediate scope of
 <code class="sourceCode cpp"><em>P</em></code> is a block scope and the
 innermost function parameter scope enclosing
@@ -13055,41 +13165,41 @@ innermost function parameter scope enclosing
 outermost
 <code class="sourceCode cpp"><em>consteval-block-declaration</em></code>
 that contains <code class="sourceCode cpp"><em>P</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_571" id="pnum_571">(6.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">(6.6)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>P</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_572" id="pnum_572">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">7</a></span>
 Given a scope <code class="sourceCode cpp"><em>S</em></code>, let <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="op">)</span></code>
 be the following scope:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_573" id="pnum_573">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">(7.1)</a></span>
 If <code class="sourceCode cpp"><em>S</em></code> is a class scope or a
 namespace scope, <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_574" id="pnum_574">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">(7.2)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a
 function parameter scope introduced by the declaration of a function,
 <code class="sourceCode cpp"><em>S</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_575" id="pnum_575">(7.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">(7.3)</a></span>
 Otherwise, if <code class="sourceCode cpp"><em>S</em></code> is a lambda
 scope introduced by a
 <code class="sourceCode cpp"><em>lambda-expression</em></code>
 <code class="sourceCode cpp"><em>L</em></code>, the function parameter
 scope corresponding to the call operator of the closure type for
 <code class="sourceCode cpp"><em>L</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_576" id="pnum_576">(7.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">(7.4)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>ctx-scope</em><span class="op">(</span><em>S</em><span class="ch">&#39;)</span></code>
 where
 <code class="sourceCode cpp"><em>S</em><span class="ch">&#39;</span></code>
 is the parent scope of
 <code class="sourceCode cpp"><em>S</em></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_577" id="pnum_577">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">8</a></span>
 An invocation of <code class="sourceCode cpp">current</code> that
 appears at a program point
 <code class="sourceCode cpp"><em>P</em></code> is value-dependent
 ([temp.dep.contexpr]) if <code class="sourceCode cpp"><em>eval-point</em><span class="op">(</span><em>P</em><span class="op">)</span></code>
 is enclosed by a scope corresponding to a templated entity.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_578" id="pnum_578">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">9</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class is the null reflection and whose scope represents the
 function, class, or namespace whose corresponding function parameter
@@ -13142,19 +13252,19 @@ appears.</p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb239"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb239-1"><a href="#cb239-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unprivileged<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_579" id="pnum_579">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">10</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class is the null reflection and whose scope is the global
 namespace.</p>
 <div class="sourceCode" id="cb240"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb240-1"><a href="#cb240-1" aria-hidden="true" tabindex="-1"></a><span class="kw">static</span> <span class="kw">consteval</span> access_context unchecked<span class="op">()</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_580" id="pnum_580">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">11</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose naming class and scope are both the null reflection.</p>
 <div class="sourceCode" id="cb241"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb241-1"><a href="#cb241-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> access_context via<span class="op">(</span>info cls<span class="op">)</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_581" id="pnum_581">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">cls</code> is
 either the null reflection or a reflection of a complete class type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_582" id="pnum_582">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">13</a></span>
 <em>Returns</em>: An <code class="sourceCode cpp">access_context</code>
 whose scope is <code class="sourceCode cpp"><span class="kw">this</span><span class="op">-&gt;</span>scope<span class="op">()</span></code>
 and whose naming class is <code class="sourceCode cpp">cls</code>.</p>
@@ -13167,44 +13277,44 @@ Member accessibility queries<a href="#meta.reflection.access.queries-member-acce
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb242"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_accessible<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_583" id="pnum_583">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">1</a></span>
 Let <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_584" id="pnum_584">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(1.1)</a></span>
 If <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_585" id="pnum_585">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(1.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>parent_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_586" id="pnum_586">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">2</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_587" id="pnum_587">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(2.1)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a class member
 for which <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>
 is an incomplete class and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_588" id="pnum_588">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(2.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a direct base
 class relationship between a base class and an incomplete derived
 class.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_589" id="pnum_589">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">3</a></span>
 Let <code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_590" id="pnum_590">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">(3.1)</a></span>
 If <code class="sourceCode cpp">ctx<span class="op">.</span>naming_class<span class="op">()</span></code>
 represents a class <code class="sourceCode cpp"><em>C</em></code>, then
 <code class="sourceCode cpp"><em>C</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_591" id="pnum_591">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">(3.2)</a></span>
 Otherwise, <code class="sourceCode cpp"><em>PARENT-CLS</em><span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_592" id="pnum_592">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">4</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_593" id="pnum_593">(4.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">(4.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents an unnamed bit-field
 <code class="sourceCode cpp"><em>F</em></code>, then <code class="sourceCode cpp">is_accessible<span class="op">(</span>r<sub><span class="math inline"><em>H</em></span></sub>, ctx<span class="op">)</span></code>
 where
@@ -13216,35 +13326,35 @@ with the same access as <code class="sourceCode cpp"><em>F</em></code>.
 are treated as class members for the purpose of
 <code class="sourceCode cpp">is_accessible</code>.<span> — <em>end
 note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_594" id="pnum_594">(4.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">(4.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> does not represent a
 class member or a direct base class relationship, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_595" id="pnum_595">(4.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">(4.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_596" id="pnum_596">(4.3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">(4.3.1)</a></span>
 a class member that is not a (possibly indirect or variant) member of
 <code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_597" id="pnum_597">(4.3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">(4.3.2)</a></span>
 a direct base class relationship such that <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 does not represent <code class="sourceCode cpp"><em>DESIGNATING-CLS</em><span class="op">(</span>r, ctx<span class="op">)</span></code>
 or a (direct or indirect) base class thereof,</li>
 </ul>
 <p>then
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_598" id="pnum_598">(4.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">(4.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>
 is the null reflection, then
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_599" id="pnum_599">(4.5)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">(4.5)</a></span>
 Otherwise, letting <code class="sourceCode cpp"><em>P</em></code> be a
 program point whose immediate scope is the function parameter scope,
 class scope, or namespace scope corresponding to the function, class, or
 namespace represented by <code class="sourceCode cpp">ctx<span class="op">.</span>scope<span class="op">()</span></code>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_600" id="pnum_600">(4.5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">(4.5.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a direct base class
 relationship with base class
 <code class="sourceCode cpp"><em>B</em></code>, then
@@ -13253,7 +13363,7 @@ class <code class="sourceCode cpp"><em>B</em></code> of <code class="sourceCode 
 is accessible at <code class="sourceCode cpp"><em>P</em></code>
 ([class.access.base]); otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_601" id="pnum_601">(4.5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">(4.5.2)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a class
 member <code class="sourceCode cpp"><em>M</em></code>;
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
@@ -13295,17 +13405,17 @@ note</em> ]</span></p>
 <div class="sourceCode" id="cb244"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb244-1"><a href="#cb244-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_nonstatic_data_members<span class="op">(</span></span>
 <span id="cb244-2"><a href="#cb244-2" aria-hidden="true" tabindex="-1"></a>      info r,</span>
 <span id="cb244-3"><a href="#cb244-3" aria-hidden="true" tabindex="-1"></a>      access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_602" id="pnum_602">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">5</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_603" id="pnum_603">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">(5.1)</a></span>
 <code class="sourceCode cpp">nonstatic_data_members_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_604" id="pnum_604">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">(5.2)</a></span>
 <code class="sourceCode cpp">r</code> does not represent a closure
 type.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_605" id="pnum_605">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">6</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13314,10 +13424,10 @@ any <code class="sourceCode cpp"><em>R</em></code> in <code class="sourceCode cp
 Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb245"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb245-1"><a href="#cb245-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> has_inaccessible_bases<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_606" id="pnum_606">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">bases_of<span class="op">(</span>r, access_context<span class="op">::</span>unchecked<span class="op">())</span></code>
 is a constant subexpression.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_607" id="pnum_607">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">8</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">is_accessible<span class="op">(</span><em>R</em>, ctx<span class="op">)</span></code>
@@ -13334,11 +13444,11 @@ Reflection member queries<a href="#meta.reflection.member.queries-reflection-mem
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb246"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb246-1"><a href="#cb246-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> members_of<span class="op">(</span>info r, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_608" id="pnum_608">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection representing either a class type that is complete from
 some point in the evaluation context or a namespace.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_609" id="pnum_609">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">2</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code>
 <em>members-of-precedes</em> a point
 <code class="sourceCode cpp"><em>P</em></code> if
@@ -13348,36 +13458,36 @@ following the
 <code class="sourceCode cpp"><em>class-specifier</em></code> of the
 outermost class for which <code class="sourceCode cpp"><em>P</em></code>
 is in a complete-class context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_610" id="pnum_610">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">3</a></span>
 A declaration <code class="sourceCode cpp"><em>D</em></code> of a member
 <code class="sourceCode cpp"><em>M</em></code> of a class or namespace
 <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible</em>
 if</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_611" id="pnum_611">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">(3.1)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> is not a friend
 declaration,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_612" id="pnum_612">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">(3.2)</a></span>
 <code class="sourceCode cpp"><em>D</em></code> does not inhabit a block
 scope,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_613" id="pnum_613">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">(3.3)</a></span>
 the target scope of <code class="sourceCode cpp"><em>D</em></code> is
 <code class="sourceCode cpp"><em>Q</em></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_614" id="pnum_614">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">(3.4)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a closure type
 ([expr.prim.lambda.closure]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_615" id="pnum_615">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">(3.5)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is not a specialization
 of a template ([temp.pre]),</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_616" id="pnum_616">(3.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">(3.6)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a class that is not
 a closure type, then <code class="sourceCode cpp"><em>M</em></code> is a
 direct member of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.mem.general]) that is not a variant member of a nested anonymous
 union of <code class="sourceCode cpp"><em>Q</em></code>
 ([class.union.anon]), and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_617" id="pnum_617">(3.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">(3.7)</a></span>
 if <code class="sourceCode cpp"><em>Q</em></code> is a closure type,
 then <code class="sourceCode cpp"><em>M</em></code> is a function call
 operator or function call operator template.</li>
@@ -13385,7 +13495,7 @@ operator or function call operator template.</li>
 <p>It is implementation-defined whether declarations of other members of
 a closure type <code class="sourceCode cpp"><em>Q</em></code> are
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-eligible.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_618" id="pnum_618">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">4</a></span>
 A member <code class="sourceCode cpp"><em>M</em></code> of a class or
 namespace <code class="sourceCode cpp"><em>Q</em></code> is
 <em><code class="sourceCode cpp"><em>Q</em></code>-members-of-representable</em>
@@ -13395,34 +13505,34 @@ declaration of <code class="sourceCode cpp"><em>M</em></code>
 members-of-precedes <code class="sourceCode cpp"><em>P</em></code> and
 <code class="sourceCode cpp"><em>M</em></code> is</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_619" id="pnum_619">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">(4.1)</a></span>
 a class or enumeration type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_620" id="pnum_620">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">(4.2)</a></span>
 a type alias,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_621" id="pnum_621">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">(4.3)</a></span>
 a primary class template, function template, primary variable template,
 alias template, or concept,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_622" id="pnum_622">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">(4.4)</a></span>
 a variable or reference,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_623" id="pnum_623">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">(4.5)</a></span>
 a function <code class="sourceCode cpp"><em>F</em></code> for which
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_624" id="pnum_624">(4.6)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">(4.6)</a></span>
 the type of <code class="sourceCode cpp"><em>F</em></code> does not
 contain an undeduced placeholder type,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_625" id="pnum_625">(4.7)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">(4.7)</a></span>
 the constraints (if any) of
 <code class="sourceCode cpp"><em>F</em></code> are satisfied, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_626" id="pnum_626">(4.8)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">(4.8)</a></span>
 if <code class="sourceCode cpp"><em>F</em></code> is a prospective
 destructor, <code class="sourceCode cpp"><em>F</em></code> is the
 selected destructor ([class.dtor]),</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_627" id="pnum_627">(4.9)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">(4.9)</a></span>
 a non-static data member,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_628" id="pnum_628">(4.10)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">(4.10)</a></span>
 a namespace, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_629" id="pnum_629">(4.11)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">(4.11)</a></span>
 a namespace alias.</li>
 </ul>
 <p><span class="note"><span>[ <em>Note 1:</em> </span>Examples of direct
@@ -13433,18 +13543,18 @@ unscoped enumerators ([enum]), partial specializations of templates
 ([temp.spec.partial]), and closure types
 ([expr.prim.lambda.closure]).<span> — <em>end
 note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_630" id="pnum_630">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">5</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing reflections of all members
 <code class="sourceCode cpp"><em>M</em></code> of the entity
 <code class="sourceCode cpp"><em>Q</em></code> represented by <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 for which</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_631" id="pnum_631">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">(5.1)</a></span>
 <code class="sourceCode cpp"><em>M</em></code> is
 <code class="sourceCode cpp"><em>Q</em></code>-members-of-representable
 from some point in the evaluation context and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_632" id="pnum_632">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">(5.2)</a></span>
 <code class="sourceCode cpp">is_accessible<span class="op">(^^</span><em>M</em>, ctx<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
@@ -13478,11 +13588,11 @@ note</em> ]</span></span></p>
 <span> — <em>end example</em> ]</span>
 </div>
 <div class="sourceCode" id="cb248"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb248-1"><a href="#cb248-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> bases_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_633" id="pnum_633">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class type that is complete from some point in the
 evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_634" id="pnum_634">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">7</a></span>
 <em>Returns</em>: Let <code class="sourceCode cpp"><em>C</em></code> be
 the class represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.
 A <code class="sourceCode cpp">vector</code> containing the reflections
@@ -13495,33 +13605,33 @@ corresponding base classes appear in the
 <code class="sourceCode cpp"><em>base-specifier-list</em></code> of
 <code class="sourceCode cpp"><em>C</em></code>.</p>
 <div class="sourceCode" id="cb249"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb249-1"><a href="#cb249-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> static_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_635" id="pnum_635">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">8</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class type that is complete from some point in the
 evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_636" id="pnum_636">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">9</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_variable<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
 <div class="sourceCode" id="cb250"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb250-1"><a href="#cb250-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> nonstatic_data_members_of<span class="op">(</span>info type, access_context ctx<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_637" id="pnum_637">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">10</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents a class type that is complete from some point in the
 evaluation context.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_638" id="pnum_638">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">11</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing each element <code class="sourceCode cpp">e</code> of <code class="sourceCode cpp">members_of<span class="op">(</span>type, ctx<span class="op">)</span></code>
 such that <code class="sourceCode cpp">is_nonstatic_data_member<span class="op">(</span>e<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>,
 preserving their order.</p>
 <div class="sourceCode" id="cb251"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb251-1"><a href="#cb251-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> vector<span class="op">&lt;</span>info<span class="op">&gt;</span> enumerators_of<span class="op">(</span>info type_enum<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_639" id="pnum_639">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">12</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>
 represents an enumeration type and <code class="sourceCode cpp">is_enumerable_type<span class="op">(</span>type_enum<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_640" id="pnum_640">13</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">13</a></span>
 <em>Returns</em>: A <code class="sourceCode cpp">vector</code>
 containing the reflections of each enumerator of the enumeration
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type_enum<span class="op">)</span></code>,
@@ -13542,22 +13652,22 @@ Reflection layout queries<a href="#meta.reflection.layout-reflection-layout-quer
 <span id="cb252-6"><a href="#cb252-6" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span>
 <span id="cb252-7"><a href="#cb252-7" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb252-8"><a href="#cb252-8" aria-hidden="true" tabindex="-1"></a><span class="kw">constexpr</span> <span class="dt">ptrdiff_t</span> member_offset<span class="op">::</span>total_bits<span class="op">()</span> <span class="kw">const</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_641" id="pnum_641">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">1</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">bytes <span class="op">*</span> CHAR_BIT <span class="op">+</span> bits</code>.</p>
 <div class="sourceCode" id="cb253"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb253-1"><a href="#cb253-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> member_offset offset_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_642" id="pnum_642">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">2</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">r</code> represents
 a non-static data member, unnamed bit-field, or direct base class
 relationship other than a virtual base class of an abstract class.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_643" id="pnum_643">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">3</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be the offset in bits
 from the beginning of a complete object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>
 to the subobject associated with the entity represented by
 <code class="sourceCode cpp">r</code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_644" id="pnum_644">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">{</span><em>V</em> <span class="op">/</span> CHAR_BIT, <em>V</em> <span class="op">%</span> CHAR_BIT<span class="op">}</span></code>.</p>
 <div class="sourceCode" id="cb254"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb254-1"><a href="#cb254-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_645" id="pnum_645">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member that is not a bit-field, direct base class
@@ -13570,7 +13680,7 @@ relationship, or data member description
 where <code class="sourceCode cpp"><em>W</em></code> is not ⊥. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_646" id="pnum_646">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">6</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents a
 non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>, a data member
@@ -13592,34 +13702,34 @@ If <code class="sourceCode cpp">b</code> represents a direct base class
 relationship of an empty base class, then <code class="sourceCode cpp">size_of<span class="op">(</span>b<span class="op">)</span> <span class="op">&gt;</span> <span class="dv">0</span></code>.<span>
 — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb255"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> alignment_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_647" id="pnum_647">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">7</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, variable of non-reference type,
 non-static data member that is not a bit-field, direct base class
 relationship, or data member description. If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type, then <code class="sourceCode cpp">is_complete_type<span class="op">(</span>r<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_648" id="pnum_648">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">8</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_649" id="pnum_649">(8.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">(8.1)</a></span>
 If <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a type <code class="sourceCode cpp"><em>T</em></code>, then
 the alignment requirement for the layout-associated type
 ([class.mem.general]) for a non-static data member of type
 <code class="sourceCode cpp"><em>T</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_650" id="pnum_650">(8.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">(8.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 represents a variable or object, then the alignment requirement of the
 variable or object.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_651" id="pnum_651">(8.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">(8.3)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a direct
 base class relationship, then <code class="sourceCode cpp">alignment_of<span class="op">(</span>type_of<span class="op">(</span>r<span class="op">))</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_652" id="pnum_652">(8.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">(8.4)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a
 non-static data member, then the alignment requirement of the subobject
 associated with the represented entity within any object of type <code class="sourceCode cpp">parent_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_653" id="pnum_653">(8.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">(8.5)</a></span>
 Otherwise, <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>TR</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13633,7 +13743,7 @@ where the corresponding subobject of
 <code class="sourceCode cpp"><em>T</em></code>.</li>
 </ul>
 <div class="sourceCode" id="cb256"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb256-1"><a href="#cb256-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> bit_size_of<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_654" id="pnum_654">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">dealias<span class="op">(</span>r<span class="op">)</span></code>
 is a reflection of a type, object, value, variable of non-reference
 type, non-static data member, unnamed bit-field, direct base class
@@ -13641,15 +13751,15 @@ relationship, or data member description. If <code class="sourceCode cpp">dealia
 represents a type <code class="sourceCode cpp"><em>T</em></code>, there
 is a point within the evaluation context from which
 <code class="sourceCode cpp"><em>T</em></code> is not incomplete.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_655" id="pnum_655">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">10</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_656" id="pnum_656">(10.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">(10.1)</a></span>
 If <code class="sourceCode cpp">r</code> represents a non-static data
 member that is a bit-field or an unnamed bit-field with width
 <code class="sourceCode cpp"><em>W</em></code>, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_657" id="pnum_657">(10.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">(10.2)</a></span>
 Otherwise, if <code class="sourceCode cpp">r</code> represents a data
 member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -13658,7 +13768,7 @@ member description (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>NUA</em></code>) ([class.mem.general])
 and <code class="sourceCode cpp"><em>W</em></code> is not ⊥, then
 <code class="sourceCode cpp"><em>W</em></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_658" id="pnum_658">(10.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">(10.3)</a></span>
 Otherwise, <code class="sourceCode cpp">CHAR_BIT <span class="op">*</span> size_of<span class="op">(</span>r<span class="op">)</span></code>.</li>
 </ul>
 </div>
@@ -13669,25 +13779,25 @@ Value extraction<a href="#meta.reflection.extract-value-extraction" class="self-
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_659" id="pnum_659">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">1</a></span>
 The <code class="sourceCode cpp">extract</code> function template may be
 used to extract a value out of a reflection when its type is known.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_660" id="pnum_660">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">2</a></span>
 The following are defined for exposition only to aid in the
 specification of <code class="sourceCode cpp">extract</code>:</p>
 <div class="sourceCode" id="cb257"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb257-1"><a href="#cb257-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb257-2"><a href="#cb257-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-ref</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_661" id="pnum_661">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">3</a></span>
 <span class="note"><span>[ <em>Note 1:</em>
 </span><code class="sourceCode cpp">T</code> is a reference type.<span>
 — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_662" id="pnum_662">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_663" id="pnum_663">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">(4.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a variable or object of
 type <code class="sourceCode cpp">U</code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_664" id="pnum_664">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">(4.2)</a></span>
 <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>remove_reference_t<span class="op">&lt;</span>U<span class="op">&gt;(*)[]</span>, remove_reference_t<span class="op">&lt;</span>T<span class="op">&gt;(*)[]&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>, and
 <span class="note"><span>[ <em>Note 2:</em> </span>The intent is to
@@ -13695,13 +13805,13 @@ allow only qualification conversions from
 <code class="sourceCode cpp">U</code> to
 <code class="sourceCode cpp">T</code>.<span> — <em>end
 note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_665" id="pnum_665">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">(4.3)</a></span>
 if <code class="sourceCode cpp">r</code> represents a variable, then
 either that variable is usable in constant expressions or its lifetime
 began within the core constant expression currently under
 evaluation.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_666" id="pnum_666">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">5</a></span>
 <em>Returns</em>: If <code class="sourceCode cpp">r</code> represents an
 object <code class="sourceCode cpp"><em>O</em></code>, then a reference
 to <code class="sourceCode cpp"><em>O</em></code>. Otherwise, a
@@ -13709,10 +13819,10 @@ reference to the object declared, or referred to, by the variable
 represented by <code class="sourceCode cpp">r</code>.</p>
 <div class="sourceCode" id="cb258"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb258-1"><a href="#cb258-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb258-2"><a href="#cb258-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-member-or-function</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_667" id="pnum_667">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">6</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_668" id="pnum_668">(6.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">(6.1)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-static data
 member with type <code class="sourceCode cpp">X</code>, that is not a
 bit-field, that is a direct member of a class
@@ -13722,7 +13832,7 @@ bit-field, that is a direct member of a class
 similar types ([conv.qual]), and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>X C<span class="op">::*</span>, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_669" id="pnum_669">(6.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">(6.2)</a></span>
 <code class="sourceCode cpp">r</code> represents an implicit object
 member function with type <code class="sourceCode cpp">F</code> or
 <code class="sourceCode cpp">F <span class="kw">noexcept</span></code>
@@ -13730,7 +13840,7 @@ that is a direct member of a class <code class="sourceCode cpp">C</code>
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F C<span class="op">::*</span></code>;
 or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_670" id="pnum_670">(6.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">(6.3)</a></span>
 <code class="sourceCode cpp">r</code> represents a non-member function,
 static member function, or explicit object member function of function
 type <code class="sourceCode cpp">F</code> or
@@ -13738,49 +13848,49 @@ type <code class="sourceCode cpp">F</code> or
 and <code class="sourceCode cpp">T</code> is
 <code class="sourceCode cpp">F<span class="op">*</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_671" id="pnum_671">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">7</a></span>
 <em>Returns</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_672" id="pnum_672">(7.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">(7.1)</a></span>
 If <code class="sourceCode cpp">T</code> is a pointer type, then a
 pointer value pointing to the function represented by
 <code class="sourceCode cpp">r</code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_673" id="pnum_673">(7.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">(7.2)</a></span>
 Otherwise, a pointer-to-member value designating the non-static data
 member or function represented by
 <code class="sourceCode cpp">r</code>.</li>
 </ul>
 <div class="sourceCode" id="cb259"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb259-1"><a href="#cb259-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb259-2"><a href="#cb259-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T <em>extract-value</em><span class="op">(</span>info r<span class="op">)</span>; <span class="co">// exposition only</span></span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_674" id="pnum_674">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">8</a></span>
 Let <code class="sourceCode cpp">U</code> be the type of the value or
 object that <code class="sourceCode cpp">r</code> represents.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_675" id="pnum_675">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_676" id="pnum_676">(9.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">(9.1)</a></span>
 <code class="sourceCode cpp">U</code> is a pointer type,
 <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are either similar or both
 function pointer types, and <code class="sourceCode cpp">is_convertible_v<span class="op">&lt;</span>U, T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_677" id="pnum_677">(9.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">(9.2)</a></span>
 <code class="sourceCode cpp">U</code> is not a pointer type and the
 cv-unqualified types of <code class="sourceCode cpp">T</code> and
 <code class="sourceCode cpp">U</code> are the same,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_678" id="pnum_678">(9.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">(9.3)</a></span>
 <code class="sourceCode cpp">U</code> is an array type,
 <code class="sourceCode cpp">T</code> is a pointer type, and the value
 that <code class="sourceCode cpp">r</code> represents is convertible to
 <code class="sourceCode cpp">T</code>, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_679" id="pnum_679">(9.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(9.4)</a></span>
 <code class="sourceCode cpp">U</code> is a closure type,
 <code class="sourceCode cpp">T</code> is a function pointer type, and
 the value that <code class="sourceCode cpp">r</code> represents is
 convertible to <code class="sourceCode cpp">T</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_680" id="pnum_680">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">10</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="kw">static_cast</span><span class="op">&lt;</span>T<span class="op">&gt;([:</span><em>R</em><span class="op">:])</span></code>,
 where <code class="sourceCode cpp"><em>R</em></code> is a constant
 expression of type <code class="sourceCode cpp">info</code> such that
@@ -13788,7 +13898,7 @@ expression of type <code class="sourceCode cpp">info</code> such that
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
 <div class="sourceCode" id="cb260"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb260-1"><a href="#cb260-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span></span>
 <span id="cb260-2"><a href="#cb260-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> T extract<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_681" id="pnum_681">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">11</a></span>
 <em>Effects</em>: Let <code class="sourceCode cpp">U</code> be <code class="sourceCode cpp">remove_cv_t<span class="op">&lt;</span>T<span class="op">&gt;</span></code>.
 Equivalent to:</p>
 <div class="sourceCode" id="cb261"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb261-1"><a href="#cb261-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="kw">constexpr</span> <span class="op">(</span>is_reference_type<span class="op">(^^</span>T<span class="op">))</span> <span class="op">{</span></span>
@@ -13813,19 +13923,19 @@ Reflection substitution<a href="#meta.reflection.substitute-reflection-substitut
 <span id="cb262-5"><a href="#cb262-5" aria-hidden="true" tabindex="-1"></a>  same_as<span class="op">&lt;</span>remove_cvref_t<span class="op">&lt;</span>ranges<span class="op">::</span>range_reference_t<span class="op">&lt;</span>R<span class="op">&gt;&gt;</span>, info<span class="op">&gt;</span>;</span></code></pre></div>
 <div class="sourceCode" id="cb263"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb263-1"><a href="#cb263-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb263-2"><a href="#cb263-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> can_substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_682" id="pnum_682">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">1</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">templ</code>
 represents a template and every reflection in
 <code class="sourceCode cpp">arguments</code> represents a construct
 usable as a template argument ([temp.arg]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_683" id="pnum_683">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">2</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the reflections
 held by the elements of <code class="sourceCode cpp">arguments</code>,
 in order.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_684" id="pnum_684">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">3</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
@@ -13833,29 +13943,29 @@ is a valid <code class="sourceCode cpp"><em>template-id</em></code>
 ([temp.names]) that does not name a function whose type contains an
 undeduced placeholder type. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_685" id="pnum_685">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">4</a></span>
 <span class="note"><span>[ <em>Note 1:</em> </span>If forming <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 leads to a failure outside of the immediate context, the program is
 ill-formed.<span> — <em>end note</em> ]</span></span></p>
 <div class="sourceCode" id="cb264"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb264-2"><a href="#cb264-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info substitute<span class="op">(</span>info templ, R<span class="op">&amp;&amp;</span> arguments<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_686" id="pnum_686">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">5</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">can_substitute<span class="op">(</span>templ, arguments<span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_687" id="pnum_687">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">6</a></span>
 Let <code class="sourceCode cpp">Z</code> be the template represented by
 <code class="sourceCode cpp">templ</code> and let
 <code class="sourceCode cpp">Args<span class="op">...</span></code> be a
 sequence of prvalue constant expressions that compute the reflections
 held by the elements of <code class="sourceCode cpp">arguments</code>,
 in order.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_688" id="pnum_688">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp"><span class="op">^^</span>Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_689" id="pnum_689">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">8</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>If forming <code class="sourceCode cpp">Z<span class="op">&lt;[:</span>Args<span class="op">:]...&gt;</span></code>
 leads to a failure outside of the immediate context, the program is
 ill-formed.<span> — <em>end note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_690" id="pnum_690">9</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">9</a></span></p>
 <div class="example">
 <span>[ <em>Example 1:</em> </span>
 <div class="sourceCode" id="cb265"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
@@ -13876,7 +13986,7 @@ ill-formed.<span> — <em>end note</em> ]</span></span></p>
 <span id="cb265-16"><a href="#cb265-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">// error: instantiation of body of fn&lt;int&gt; is needed to deduce return type</span></span></code></pre></div>
 <span> — <em>end example</em> ]</span>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_691" id="pnum_691">10</a></span></p>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">10</a></span></p>
 <div class="example">
 <span>[ <em>Example 2:</em> </span>
 <div class="sourceCode" id="cb266"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb266-1"><a href="#cb266-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info to_integral_constant<span class="op">(</span><span class="dt">unsigned</span> i<span class="op">)</span> <span class="op">{</span></span>
@@ -13896,27 +14006,27 @@ Expression result reflection<a href="#meta.reflection.result-expression-result-r
 <div class="addu">
 <div class="sourceCode" id="cb267"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb267-1"><a href="#cb267-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb267-2"><a href="#cb267-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_constant<span class="op">(</span>T expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_692" id="pnum_692">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">1</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">is_copy_constructible_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">T</code> is a cv-unqualified structural
 type ([temp.param]) that is not a reference type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_693" id="pnum_693">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">2</a></span>
 Let <code class="sourceCode cpp"><em>V</em></code> be:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_694" id="pnum_694">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">(2.1)</a></span>
 if <code class="sourceCode cpp">T</code> is a class type, then an object
 that is template-argument-equivalent to the value of
 <code class="sourceCode cpp">expr</code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_695" id="pnum_695">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">(2.2)</a></span>
 otherwise, the value of <code class="sourceCode cpp">expr</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_696" id="pnum_696">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">3</a></span>
 <em>Constant When</em>: Given the invented template</p>
 <div class="sourceCode" id="cb268"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb268-1"><a href="#cb268-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span>T P<span class="op">&gt;</span> <span class="kw">struct</span> TCls;</span></code></pre></div>
 <p>the <code class="sourceCode cpp"><em>template-id</em></code> <code class="sourceCode cpp">TCls<span class="op">&lt;</span><em>V</em><span class="op">&gt;</span></code>
 would be valid.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_697" id="pnum_697">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">4</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">template_arguments_of<span class="op">(^^</span>TCls<span class="op">&lt;</span><em>V</em><span class="op">&gt;)[</span><span class="dv">0</span><span class="op">]</span></code>.
 <span class="note"><span>[ <em>Note 1:</em> </span>This is a reflection
 of an object for class types and a reflection of a value
@@ -13943,30 +14053,30 @@ otherwise.<span> — <em>end note</em> ]</span></span></p>
 </div>
 <div class="sourceCode" id="cb270"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb270-1"><a href="#cb270-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb270-2"><a href="#cb270-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_object<span class="op">(</span>T<span class="op">&amp;</span> expr<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_698" id="pnum_698">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">5</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is an object
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_699" id="pnum_699">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">6</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">expr</code> is
 suitable for use as a constant template argument for a constant template
 parameter of type
 <code class="sourceCode cpp">T<span class="op">&amp;</span></code>
 ([temp.arg.nontype]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_700" id="pnum_700">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">7</a></span>
 <em>Returns</em>: A reflection of the object designated by
 <code class="sourceCode cpp">expr</code>.</p>
 <div class="sourceCode" id="cb271"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb271-1"><a href="#cb271-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">typename</span> T<span class="op">&gt;</span></span>
 <span id="cb271-2"><a href="#cb271-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info reflect_function<span class="op">(</span>T<span class="op">&amp;</span> fn<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_701" id="pnum_701">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">8</a></span>
 <em>Mandates</em>: <code class="sourceCode cpp">T</code> is a function
 type.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_702" id="pnum_702">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">9</a></span>
 <em>Constant When</em>: <code class="sourceCode cpp">fn</code> is
 suitable for use as a constant template argument for a constant template
 parameter of type
 <code class="sourceCode cpp">T<span class="op">&amp;</span></code>
 ([temp.arg.nontype]).</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_703" id="pnum_703">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">10</a></span>
 <em>Returns</em>: A reflection of the function designated by
 <code class="sourceCode cpp">fn</code>.</p>
 </div>
@@ -13994,19 +14104,19 @@ Reflection class definition generation<a href="#meta.reflection.define.aggregate
 <span id="cb272-15"><a href="#cb272-15" aria-hidden="true" tabindex="-1"></a>  optional<span class="op">&lt;</span><span class="dt">int</span><span class="op">&gt;</span> bit_width;</span>
 <span id="cb272-16"><a href="#cb272-16" aria-hidden="true" tabindex="-1"></a>  <span class="dt">bool</span> no_unique_address <span class="op">=</span> <span class="kw">false</span>;</span>
 <span id="cb272-17"><a href="#cb272-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_704" id="pnum_704">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">1</a></span>
 The classes <code class="sourceCode cpp">data_member_options</code> and
 <code class="sourceCode cpp">data_member_options<span class="op">::</span><em>name-type</em></code>
 are consteval-only types ([basic.types.general]), and are not structural
 types ([temp.param]).</p>
 <div class="sourceCode" id="cb273"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb273-1"><a href="#cb273-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span> <span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>u8string, T<span class="op">&gt;</span></span>
 <span id="cb273-2"><a href="#cb273-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_705" id="pnum_705">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">2</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">u8string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="sourceCode" id="cb274"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb274-1"><a href="#cb274-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> T<span class="op">&gt;</span> <span class="kw">requires</span> constructible_from<span class="op">&lt;</span>string, T<span class="op">&gt;</span></span>
 <span id="cb274-2"><a href="#cb274-2" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> data_member_options<span class="op">::</span><em>name-type</em><span class="op">(</span>T<span class="op">&amp;&amp;</span> value<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_706" id="pnum_706">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">3</a></span>
 <em>Effects</em>: Initializes
 <code class="sourceCode cpp"><em>contents</em></code> with <code class="sourceCode cpp">string<span class="op">(</span>std<span class="op">::</span>forward<span class="op">&lt;</span>T<span class="op">&gt;(</span>value<span class="op">))</span></code>.</p>
 <div class="note">
@@ -14030,24 +14140,24 @@ literal (or <code class="sourceCode cpp">u8string_view</code>,
 </div>
 <div class="sourceCode" id="cb276"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb276-1"><a href="#cb276-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info data_member_spec<span class="op">(</span>info type,</span>
 <span id="cb276-2"><a href="#cb276-2" aria-hidden="true" tabindex="-1"></a>                                data_member_options options<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_707" id="pnum_707">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">4</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_708" id="pnum_708">(4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(4.1)</a></span>
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 represents either an object type or a reference type;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_709" id="pnum_709">(4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">(4.2)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 contains a value, then:
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_710" id="pnum_710">(4.2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">(4.2.1)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>u8string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 contains a valid identifier ([lex.name]) that is not a keyword
 ([lex.key]) when interpreted with UTF-8, or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_711" id="pnum_711">(4.2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">(4.2.2)</a></span>
 <code class="sourceCode cpp">holds_alternative<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> and
 <code class="sourceCode cpp">get<span class="op">&lt;</span>string<span class="op">&gt;(</span>options<span class="op">.</span>name<span class="op">-&gt;</span><em>contents</em><span class="op">)</span></code>
@@ -14062,38 +14172,38 @@ to the spelling of an identifier token after phase 6 of translation
 fail. For example, <code class="sourceCode cpp"><span class="st">R&quot;(\u03B1)&quot;</span></code>
 is an invalid identifier and is not interpreted as <code class="sourceCode cpp"><span class="st">&quot;α&quot;</span></code>.<span>
 — <em>end note</em> ]</span></span></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_712" id="pnum_712">(4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">(4.3)</a></span>
 if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value, then <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_713" id="pnum_713">(4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">(4.4)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 contains a value <code class="sourceCode cpp"><em>V</em></code>, then
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_714" id="pnum_714">(4.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">(4.4.1)</a></span>
 <code class="sourceCode cpp">is_integral_type<span class="op">(</span>type<span class="op">)</span> <span class="op">||</span> is_enumeration_type<span class="op">(</span>type<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_715" id="pnum_715">(4.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">(4.4.2)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_716" id="pnum_716">(4.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">(4.4.3)</a></span>
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>,
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_717" id="pnum_717">(4.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">(4.4.4)</a></span>
 if <code class="sourceCode cpp"><em>V</em></code> equals
 <code class="sourceCode cpp"><span class="dv">0</span></code> then
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value; and</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_718" id="pnum_718">(4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">(4.5)</a></span>
 if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp">alignment_of<span class="op">(</span>type<span class="op">)</span></code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_719" id="pnum_719">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">5</a></span>
 <em>Returns</em>: A reflection of a data member description
 (<code class="sourceCode cpp"><em>T</em></code>,
 <code class="sourceCode cpp"><em>N</em></code>,
@@ -14102,31 +14212,31 @@ contains a value, it is an alignment value ([basic.align]) not less than
 <code class="sourceCode cpp"><em>NUA</em></code>) (<span>11.4.1 <a href="https://wg21.link/class.mem.general">[class.mem.general]</a></span>)
 where</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_720" id="pnum_720">(5.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">(5.1)</a></span>
 <code class="sourceCode cpp"><em>T</em></code> is the type represented
 by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_721" id="pnum_721">(5.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">(5.2)</a></span>
 <code class="sourceCode cpp"><em>N</em></code> is either the identifier
 encoded by
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 or ⊥ if
 <code class="sourceCode cpp">options<span class="op">.</span>name</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_722" id="pnum_722">(5.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">(5.3)</a></span>
 <code class="sourceCode cpp"><em>A</em></code> is either the alignment
 value held by <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>alignment</code>
 does not contain a value,</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_723" id="pnum_723">(5.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">(5.4)</a></span>
 <code class="sourceCode cpp"><em>W</em></code> is either the value held
 by <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 or ⊥ if <code class="sourceCode cpp">options<span class="op">.</span>bit_width</code>
 does not contain a value, and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_724" id="pnum_724">(5.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">(5.5)</a></span>
 <code class="sourceCode cpp"><em>NUA</em></code> is the value held by
 <code class="sourceCode cpp">options<span class="op">.</span>no_unique_address</code>.</li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_725" id="pnum_725">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">6</a></span>
 <span class="note"><span>[ <em>Note 3:</em> </span>The returned
 reflection value is primarily useful in conjunction with
 <code class="sourceCode cpp">define_aggregate</code>; it can also be
@@ -14136,7 +14246,7 @@ queried by certain other functions in
 <code class="sourceCode cpp">identifier_of</code>).<span> — <em>end
 note</em> ]</span></span></p>
 <div class="sourceCode" id="cb277"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb277-1"><a href="#cb277-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">bool</span> is_data_member_spec<span class="op">(</span>info r<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_726" id="pnum_726">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">7</a></span>
 <em>Returns</em>:
 <code class="sourceCode cpp"><span class="kw">true</span></code> if
 <code class="sourceCode cpp">r</code> represents a data member
@@ -14144,7 +14254,7 @@ description. Otherwise,
 <code class="sourceCode cpp"><span class="kw">false</span></code>.</p>
 <div class="sourceCode" id="cb278"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb278-1"><a href="#cb278-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">template</span> <span class="op">&lt;</span>reflection_range R <span class="op">=</span> initializer_list<span class="op">&lt;</span>info<span class="op">&gt;&gt;</span></span>
 <span id="cb278-2"><a href="#cb278-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">consteval</span> info define_aggregate<span class="op">(</span>info class_type, R<span class="op">&amp;&amp;</span> mdescrs<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_727" id="pnum_727">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">8</a></span>
 Let <code class="sourceCode cpp"><em>C</em></code> be the class
 represented by <code class="sourceCode cpp">class_type</code> and
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code> be the
@@ -14159,10 +14269,10 @@ value in <code class="sourceCode cpp">mdescrs</code>. For every
 <code class="sourceCode cpp"><span class="math inline"><em>N</em><em>U</em><em>A</em></span><sub><span class="math inline"><em>K</em></span></sub></code>) be the corresponding
 data member description represented by
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_728" id="pnum_728">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">9</a></span>
 <em>Constant When</em>:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_729" id="pnum_729">(9.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">(9.1)</a></span>
 <code class="sourceCode cpp"><em>C</em></code> is incomplete from every
 point in the evaluation context; <span class="note"><span>[ <em>Note
 4:</em> </span><code class="sourceCode cpp"><em>C</em></code> can be a
@@ -14170,17 +14280,17 @@ class template specialization for which there is a reachable definition
 of the primary class template. In this case, the injected declaration is
 an explicit specialization.<span> — <em>end
 note</em> ]</span></span></p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_730" id="pnum_730">(9.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">(9.2)</a></span>
 <code class="sourceCode cpp">is_data_member_spec<span class="op">(</span><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>;</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_731" id="pnum_731">(9.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">(9.3)</a></span>
 <code class="sourceCode cpp">is_complete_type<span class="op">(</span><span class="math inline"><em>T</em></span><sub><span class="math inline"><em>K</em></span></sub><span class="op">)</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code> for
 every
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>; and</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_732" id="pnum_732">(9.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">(9.4)</a></span>
 for every pair
 (<code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>,
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>) where
@@ -14189,10 +14299,10 @@ for every pair
 <code class="sourceCode cpp"><span class="math inline"><em>N</em></span><sub><span class="math inline"><em>L</em></span></sub></code> is not ⊥, then
 either:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_733" id="pnum_733">(9.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">(9.4.1)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>N</em></span><sub><span class="math inline"><em>K</em></span></sub> <span class="op">!=</span> <span class="math inline"><em>N</em></span><sub><span class="math inline"><em>L</em></span></sub></code> is
 <code class="sourceCode cpp"><span class="kw">true</span></code> or</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_734" id="pnum_734">(9.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">(9.4.2)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>N</em></span><sub><span class="math inline"><em>K</em></span></sub> <span class="op">==</span> <span class="st">u8&quot;_&quot;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>.
 <span class="note"><span>[ <em>Note 5:</em> </span>Every provided
@@ -14200,28 +14310,28 @@ identifier is unique or <code class="sourceCode cpp"><span class="st">&quot;_&qu
 — <em>end note</em> ]</span></span></li>
 </ul></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_735" id="pnum_735">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">10</a></span>
 <em>Effects</em>: Produces an injected declaration
 <code class="sourceCode cpp"><em>D</em></code> ([expr.const]) that
 defines <code class="sourceCode cpp"><em>C</em></code> and has
 properties as follows:</p>
 <ul>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_736" id="pnum_736">(10.1)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">(10.1)</a></span>
 The target scope of <code class="sourceCode cpp"><em>D</em></code> is
 the scope to which <code class="sourceCode cpp"><em>C</em></code>
 belongs ([basic.scope.scope]).</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_737" id="pnum_737">(10.2)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">(10.2)</a></span>
 The locus of <code class="sourceCode cpp"><em>D</em></code> follows
 immediately after the core constant expression currently under
 evaluation.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_738" id="pnum_738">(10.3)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">(10.3)</a></span>
 If <code class="sourceCode cpp"><em>C</em></code> is a specialization of
 a templated class <code class="sourceCode cpp"><em>T</em></code>, and
 <code class="sourceCode cpp"><em>C</em></code> is not a local class,
 then <code class="sourceCode cpp"><em>D</em></code> is an explicit
 specialization of
 <code class="sourceCode cpp"><em>T</em></code>.</p></li>
-<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_739" id="pnum_739">(10.4)</a></span>
+<li><p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">(10.4)</a></span>
 For each
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>K</em></span></sub></code>, there is a
 corresponding entity
@@ -14229,7 +14339,7 @@ corresponding entity
 class scope of <code class="sourceCode cpp"><em>D</em></code> with the
 following properties:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_740" id="pnum_740">(10.4.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">(10.4.1)</a></span>
 If
 <code class="sourceCode cpp"><span class="math inline"><em>N</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is ⊥,
 <code class="sourceCode cpp"><span class="math inline"><em>M</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is an unnamed
@@ -14238,23 +14348,23 @@ bit-field. Otherwise,
 member whose name is the identifier determined by the character sequence
 encoded by
 <code class="sourceCode cpp"><span class="math inline"><em>N</em></span><sub><span class="math inline"><em>K</em></span></sub></code> in UTF-8.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_741" id="pnum_741">(10.4.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">(10.4.2)</a></span>
 The type of
 <code class="sourceCode cpp"><span class="math inline"><em>M</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is
 <code class="sourceCode cpp"><span class="math inline"><em>T</em></span><sub><span class="math inline"><em>K</em></span></sub></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_742" id="pnum_742">(10.4.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">(10.4.3)</a></span>
 <code class="sourceCode cpp"><span class="math inline"><em>M</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is declared with the
 attribute <code class="sourceCode cpp"><span class="op">[[</span><span class="at">no_unique_address</span><span class="op">]]</span></code>
 if and only if <code class="sourceCode cpp"><span class="math inline"><em>N</em><em>U</em><em>A</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_743" id="pnum_743">(10.4.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">(10.4.4)</a></span>
 If
 <code class="sourceCode cpp"><span class="math inline"><em>W</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is not ⊥,
 <code class="sourceCode cpp"><span class="math inline"><em>M</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is a bit-field whose
 width is that value. Otherwise,
 <code class="sourceCode cpp"><span class="math inline"><em>M</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is not a
 bit-field.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_744" id="pnum_744">(10.4.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">(10.4.5)</a></span>
 If
 <code class="sourceCode cpp"><span class="math inline"><em>A</em></span><sub><span class="math inline"><em>K</em></span></sub></code> is not ⊥,
 <code class="sourceCode cpp"><span class="math inline"><em>M</em></span><sub><span class="math inline"><em>K</em></span></sub></code> has the
@@ -14272,7 +14382,7 @@ the declaration corresponding to
 declaration corresponding to
 <code class="sourceCode cpp"><span class="math inline"><em>r</em></span><sub><span class="math inline"><em>L</em></span></sub></code>.</p></li>
 </ul>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_745" id="pnum_745">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">11</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">class_type</code>.</p>
 </div>
 </blockquote>
@@ -14282,23 +14392,23 @@ Reflection type traits<a href="#meta.reflection.traits-reflection-type-traits" c
 <div class="std">
 <blockquote>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_746" id="pnum_746">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">1</a></span>
 Subclause [meta.reflection.traits] specifies consteval functions to
 query the properties of types ([meta.unary]), query the relationships
 between types ([meta.rel]), or transform types ([meta.trans]) at compile
 time. Each consteval function declared in this class has an associated
 class template declared elsewhere in this document.</p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_747" id="pnum_747">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">2</a></span>
 Every function and function template declared in this subclause has the
 following conditions required for a call to that function or function
 template to be a constant subexpression ([defns.const.subexpr]):</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_748" id="pnum_748">(2.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">(2.1)</a></span>
 For every parameter <code class="sourceCode cpp">p</code> of type
 <code class="sourceCode cpp">info</code>, <code class="sourceCode cpp">is_type<span class="op">(</span>p<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_749" id="pnum_749">(2.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">(2.2)</a></span>
 For every parameter <code class="sourceCode cpp">r</code> whose type is
 constrained on <code class="sourceCode cpp">reflection_range</code>,
 <code class="sourceCode cpp">ranges<span class="op">::</span>all_of<span class="op">(</span>r, is_type<span class="op">)</span></code>
@@ -14457,7 +14567,7 @@ is
 <span id="cb279-150"><a href="#cb279-150" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info invoke_result<span class="op">(</span>info type, R<span class="op">&amp;&amp;</span> type_args<span class="op">)</span>;</span>
 <span id="cb279-151"><a href="#cb279-151" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_reference<span class="op">(</span>info type<span class="op">)</span>;</span>
 <span id="cb279-152"><a href="#cb279-152" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info unwrap_ref_decay<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_750" id="pnum_750">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">3</a></span>
 Each function or function template declared above has the following
 behavior based on the signature and return type of that function or
 function template. <span class="note"><span>[ <em>Note 1:</em>
@@ -14564,12 +14674,12 @@ the corresponding elements of <code class="sourceCode cpp">args</code>
 </td>
 </tr>
 </table>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_751" id="pnum_751">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">4</a></span>
 <span class="note"><span>[ <em>Note 2:</em> </span>For those functions
 or function templates which return a reflection, that reflection always
 represents a type and never a type alias.<span> — <em>end
 note</em> ]</span></span></p>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_752" id="pnum_752">5</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">5</a></span>
 <span class="note"><span>[ <em>Note 3:</em> </span>If
 <code class="sourceCode cpp">t</code> is a reflection of the type
 <code class="sourceCode cpp"><span class="dt">int</span></code> and
@@ -14584,12 +14694,12 @@ is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.<span>
 — <em>end note</em> ]</span></span>.</p>
 <div class="sourceCode" id="cb287"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb287-1"><a href="#cb287-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> rank<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_753" id="pnum_753">6</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">6</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">rank_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb288"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb288-1"><a href="#cb288-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> extent<span class="op">(</span>info type, <span class="dt">unsigned</span> i <span class="op">=</span> <span class="dv">0</span><span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_754" id="pnum_754">7</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">7</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">extent_v<span class="op">&lt;</span>T, I<span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp">T</code> is the type represented by
 <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
@@ -14601,36 +14711,36 @@ and <code class="sourceCode cpp">I</code> is a constant equal to
 <p><span class="ednote" style="color: #0000ff">[ Editor&#39;s note: The
 below inclusion of
 <code class="sourceCode default">meta::type_order</code> assumes the
-acceptance of <span class="citation" data-cites="P2830R10"><a href="https://wg21.link/p2830r10" role="doc-biblioref">[P2830R10]</a></span>. ]</span></p>
+acceptance of <span class="citation" data-cites="P2830R10">[<a href="https://wg21.link/p2830r10" role="doc-biblioref">P2830R10</a>]</span>. ]</span></p>
 <div class="std">
 <blockquote>
 <div class="addu">
 <div class="sourceCode" id="cb289"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb289-1"><a href="#cb289-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> tuple_size<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_755" id="pnum_755">8</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">8</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">tuple_size_v<span class="op">&lt;</span><em>T</em><span class="op">&gt;</span></code>
 where <code class="sourceCode cpp"><em>T</em></code> is the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb290"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb290-1"><a href="#cb290-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info tuple_element<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_756" id="pnum_756">9</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">9</a></span>
 <em>Returns</em>: A reflection representing the type denoted by <code class="sourceCode cpp">tuple_element_t<span class="op">&lt;</span><em>I</em>, <em>T</em><span class="op">&gt;</span></code>
 where <code class="sourceCode cpp"><em>T</em></code> is the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 and <code class="sourceCode cpp"><em>I</em></code> is a constant equal
 to <code class="sourceCode cpp">index</code>.</p>
 <div class="sourceCode" id="cb291"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb291-1"><a href="#cb291-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> <span class="dt">size_t</span> variant_size<span class="op">(</span>info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_757" id="pnum_757">10</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">10</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">variant_size_v<span class="op">&lt;</span><em>T</em><span class="op">&gt;</span></code>
 where <code class="sourceCode cpp"><em>T</em></code> is the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>.</p>
 <div class="sourceCode" id="cb292"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb292-1"><a href="#cb292-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> info variant_alternative<span class="op">(</span><span class="dt">size_t</span> index, info type<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_758" id="pnum_758">11</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">11</a></span>
 <em>Returns</em>: A reflection representing the type denoted by <code class="sourceCode cpp">variant_alternative_t<span class="op">&lt;</span><em>I</em>, <em>T</em><span class="op">&gt;</span></code>
 where <code class="sourceCode cpp"><em>T</em></code> is the type
 represented by <code class="sourceCode cpp">dealias<span class="op">(</span>type<span class="op">)</span></code>
 and <code class="sourceCode cpp"><em>I</em></code> is a constant equal
 to <code class="sourceCode cpp">index</code>.</p>
 <div class="sourceCode" id="cb293"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb293-1"><a href="#cb293-1" aria-hidden="true" tabindex="-1"></a><span class="kw">consteval</span> strong_ordering type_order<span class="op">(</span>info t1, info t2<span class="op">)</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_759" id="pnum_759">12</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">12</a></span>
 <em>Returns</em>: <code class="sourceCode cpp">type_order_v<span class="op">&lt;</span><em>T1</em>, <em>T2</em><span class="op">&gt;</span></code>,
 where <code class="sourceCode cpp"><em>T1</em></code> and
 <code class="sourceCode cpp"><em>T2</em></code> are the types
@@ -14640,46 +14750,46 @@ respectively.</p>
 </div>
 </blockquote>
 </div>
-<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
+<h3 class="unnumbered" id="bit.cast-function-template-bit_cast"><span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span> Function
 template <code class="sourceCode cpp">bit_cast</code><a href="#bit.cast-function-template-bit_cast" class="self-link"></a></h3>
 <p>And we have adjust the requirements of
 <code class="sourceCode cpp">bit_cast</code> to not allow casting to or
 from
 <code class="sourceCode cpp">meta<span class="op">::</span>info</code>,
-in <span>22.11.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
+in <span>22.15.3 <a href="https://wg21.link/bit.cast">[bit.cast]</a></span>/3, which we add
 as a mandates (and then <em>Constant When</em> has to be before
 <em>Returns</em>, but the <em>Returns</em> remains unchanged):</p>
 <div class="std">
 <blockquote>
 <div class="sourceCode" id="cb294"><pre class="sourceCode cpp"><code class="sourceCode cpp"><span id="cb294-1"><a href="#cb294-1" aria-hidden="true" tabindex="-1"></a><span class="kw">template</span><span class="op">&lt;</span><span class="kw">class</span> To, <span class="kw">class</span> From<span class="op">&gt;</span></span>
 <span id="cb294-2"><a href="#cb294-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">constexpr</span> To bit_cast<span class="op">(</span><span class="kw">const</span> From<span class="op">&amp;</span> from<span class="op">)</span> <span class="kw">noexcept</span>;</span></code></pre></div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_760" id="pnum_760">1</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">1</a></span>
 <em>Constraints</em>:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_761" id="pnum_761">(1.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_777" id="pnum_777">(1.1)</a></span>
 <code class="sourceCode cpp"><span class="kw">sizeof</span><span class="op">(</span>To<span class="op">)</span> <span class="op">==</span> <span class="kw">sizeof</span><span class="op">(</span>From<span class="op">)</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_762" id="pnum_762">(1.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_778" id="pnum_778">(1.2)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>To<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">true</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_763" id="pnum_763">(1.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_779" id="pnum_779">(1.3)</a></span>
 <code class="sourceCode cpp">is_trivially_copyable_v<span class="op">&lt;</span>From<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">true</span></code>.</li>
 </ul>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_764" id="pnum_764">*</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_780" id="pnum_780">*</a></span>
 <em>Mandates</em>: Neither <code class="sourceCode cpp">To</code> nor
 <code class="sourceCode cpp">From</code> are consteval-only types
 ([expr.const]).</p>
 </div>
 <div class="rm" style="color: #bf0303">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_765" id="pnum_765">2</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_781" id="pnum_781">2</a></span>
 <em>Returns</em>: […]</p>
 </div>
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_766" id="pnum_766">3</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_782" id="pnum_782">3</a></span>
 <span class="rm" style="color: #bf0303"><del><em>Remarks</em></del></span> <span class="addu"><em>Constant When</em></span>: <span class="rm" style="color: #bf0303"><del>This function is constexpr if and only
 if</del></span> <code class="sourceCode cpp">To</code>,
 <code class="sourceCode cpp">From</code>, and the types of all
@@ -14687,28 +14797,28 @@ subobjects of <code class="sourceCode cpp">To</code> and
 <code class="sourceCode cpp">From</code> are types
 <code class="sourceCode cpp">T</code> such that:</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_767" id="pnum_767">(3.1)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_783" id="pnum_783">(3.1)</a></span>
 <code class="sourceCode cpp">is_union_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_768" id="pnum_768">(3.2)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_784" id="pnum_784">(3.2)</a></span>
 <code class="sourceCode cpp">is_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_769" id="pnum_769">(3.3)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_785" id="pnum_785">(3.3)</a></span>
 <code class="sourceCode cpp">is_member_pointer_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is
 <code class="sourceCode cpp"><span class="kw">false</span></code>;</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_770" id="pnum_770">(3.4)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_786" id="pnum_786">(3.4)</a></span>
 <code class="sourceCode cpp">is_volatile_v<span class="op">&lt;</span>T<span class="op">&gt;</span></code>
 is <code class="sourceCode cpp"><span class="kw">false</span></code>;
 and</li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_771" id="pnum_771">(3.5)</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_787" id="pnum_787">(3.5)</a></span>
 <code class="sourceCode cpp">T</code> has no non-static data members of
 reference type.</li>
 </ul>
 <div class="addu">
-<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_772" id="pnum_772">4</a></span>
+<p><span class="marginalizedparent"><a class="marginalized" href="#pnum_788" id="pnum_788">4</a></span>
 <em>Returns</em>: […]</p>
 </div>
 </blockquote>
@@ -14765,7 +14875,7 @@ usual practice is to provide something like
 since the two pieces are so closely tied together, maybe it really only
 makes sense to provide one?</p>
 <p>For now, we’ll add both.</p>
-<p>To <span>15.12 <a href="https://wg21.link/cpp.predefined">[cpp.predefined]</a></span>:</p>
+<p>To <span>15.11 <a href="https://wg21.link/cpp.predefined">[cpp.predefined]</a></span>:</p>
 <div class="std">
 <blockquote>
 <div>
@@ -14786,13 +14896,13 @@ makes sense to provide one?</p>
 </div>
 <h1 data-number="6" style="border-bottom:1px solid #cccccc" id="appendix-design-changes-approved-in-hagenberg"><span class="header-section-number">6</span> Appendix: Design changes approved
 in Hagenberg<a href="#appendix-design-changes-approved-in-hagenberg" class="self-link"></a></h1>
-<p><span class="citation" data-cites="P2996R4"><a href="https://wg21.link/p2996r4" role="doc-biblioref">[P2996R4]</a></span> was forwarded to CWG in
+<p><span class="citation" data-cites="P2996R4">[<a href="https://wg21.link/p2996r4" role="doc-biblioref">P2996R4</a>]</span> was forwarded to CWG in
 St. Louis (June 2024). In the time after, some minor design changes were
 shown to be necessary. The following changes were confirmed by EWG
 during the Hagenberg 2025 meeting.</p>
 <p>One small change was needed to the reflection operator.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_773" id="pnum_773">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_789" id="pnum_789">1</a></span>
 Application of the
 <code class="sourceCode cpp"><span class="op">^^</span></code> operator
 to a non-type template parameter
@@ -14821,7 +14931,7 @@ as appropriate.</li>
 <p>A few changes were needed to “consteval-only types” to ensure that
 objects of such types cannot reach runtime.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_774" id="pnum_774">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_790" id="pnum_790">2</a></span>
 Relaxed linkage restrictions on objects of consteval-only types
 <ul>
 <li><strong>P2996R4</strong>: Rigid rules prevented objects of
@@ -14839,7 +14949,7 @@ imported across TUs and modules without issue.
 <li>Try it with <a href="https://godbolt.org/z/Y8cdd9sGo">Clang</a>.</li>
 </ul></li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_775" id="pnum_775">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_791" id="pnum_791">3</a></span>
 Immediate-escalation of expressions of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Every expression of consteval-only type
@@ -14849,7 +14959,7 @@ to persist to runtime (e.g., passing a reference to a <code class="sourceCode cp
 to a runtime function).</li>
 <li>Fully implemented; try it with Clang <a href="https://godbolt.org/z/5sfe7vdzE">here</a> and <a href="https://godbolt.org/z/T3MY1Yqo4">here</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_776" id="pnum_776">4</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_792" id="pnum_792">4</a></span>
 Immediate-escalation of non-constexpr variables of consteval-only type
 <ul>
 <li><strong>D2996R10</strong>: Immediate-escalating functions containing
@@ -14860,7 +14970,7 @@ of consteval-only type (for which an expression does not necessarily
 appear) from reaching runtime.</li>
 <li>Fully implemented; try it with <a href="https://godbolt.org/z/3asrnK13G">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_777" id="pnum_777">5</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_793" id="pnum_793">5</a></span>
 No “erasure” of consteval-only-ness from results of constant
 expressions.
 <ul>
@@ -14879,7 +14989,7 @@ seen <a href="https://godbolt.org/z/E4faezfr3">here</a>).</li>
 </ul>
 <p>Two changes were needed for splicers.</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_778" id="pnum_778">6</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_794" id="pnum_794">6</a></span>
 A slight syntactic change is needed for template splicers.
 <ul>
 <li><strong>P2994R4</strong>:
@@ -14900,14 +15010,14 @@ were supposed to work.</li>
 </ul></li>
 <li>Try it on godbolt with <a href="https://godbolt.org/z/GKj5of839">Clang</a>.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_779" id="pnum_779">7</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_795" id="pnum_795">7</a></span>
 Reflections of concepts cannot be spliced.
 <ul>
 <li><strong>P2996R4</strong>: Concepts could be spliced within both
 <code class="sourceCode cpp"><em>type-constraint</em></code>s and
 <code class="sourceCode cpp"><em>concept-id</em></code>s.</li>
 <li><strong>D2996R10</strong>: Splicing a concept is ill-formed.</li>
-<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5"><a href="https://wg21.link/p2841r5" role="doc-biblioref">[P2841R5]</a></span> has already done the work to
+<li><strong>Rationale</strong>: <span class="citation" data-cites="P2841R5">[<a href="https://wg21.link/p2841r5" role="doc-biblioref">P2841R5</a>]</span> has already done the work to
 figure out dependent concepts. CWG requested that we wait for that to
 land first, and revisit concept splicers in a future paper.</li>
 <li><strong>Instead</strong>: For the case of a
@@ -14923,7 +15033,7 @@ after P2996R4. When the evaluation of an expression calls
 evaluation produces an <em>injected declaration</em> of the completed
 type (try it on <a href="https://godbolt.org/z/PTeb9qqcW">godbolt</a>).</p>
 <ul>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_780" id="pnum_780">1</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_796" id="pnum_796">1</a></span>
 Recent revisions lock down the context from which
 <code class="sourceCode cpp">define_aggregate</code> can be called.
 <ul>
@@ -14942,7 +15052,7 @@ for code injection due to e.g., template instantiation behavior,
 immediate-escalating expression behavior, etc.</li>
 <li>Fully implemented with Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_781" id="pnum_781">2</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_797" id="pnum_797">2</a></span>
 The scope that a given expression can inject a declaration <em>into</em>
 has been constrained.
 <ul>
@@ -14957,7 +15067,7 @@ use <code class="sourceCode cpp">define_aggregate</code> to observe
 failed substitutions, overload resolution order, etc.</li>
 <li>Fully implemented in Clang.</li>
 </ul></li>
-<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_782" id="pnum_782">3</a></span>
+<li><span class="marginalizedparent"><a class="marginalized" href="#pnum_798" id="pnum_798">3</a></span>
 Strengthening order of evaluation for core constant expressions removes
 the need for more IFNDR.
 <ul>
@@ -15149,7 +15259,7 @@ Control With Reflection. <a href="https://wg21.link/p3547r1"><div class="csl-blo
 allocation with vector and basic_string. <a href="https://wg21.link/p3554r0"><div class="csl-block">https://wg21.link/p3554r0</div></a>
 </div>
 <div id="ref-P3687R0" class="csl-entry" role="doc-biblioentry">
-[P3687R0] Dan Katz, Wyatt Childers, Daveed Vandevoorde, Ville
+[P3687R0] Wyatt Childers, Dan Katz, Daveed Vandevoorde, Ville
 Voutilainen. 2025-05-15. Final Adjustments to C++26 Reflection. <a href="https://wg21.link/p3687r0"><div class="csl-block">https://wg21.link/p3687r0</div></a>
 </div>
 </div>

--- a/2996_reflection/reflection.md
+++ b/2996_reflection/reflection.md
@@ -30,7 +30,10 @@ Since [@P2996R12]:
 
 * core wording updates
   * handle members of static anonymous unions / integrate suggested fix for [@CWG3026]
-  * removed splice template arguments, following EWG poll for [@P3687R0]{.title}
+  * integrate EWG updates from [@P3687R0]{.title}
+    * removed splice template arguments
+    * unparenthesized `$splice-expression$`s are ill-formed when used as template arguments
+    * `$reflect-expression$`s are ill-formed when the operand names a `$using-declarator$`
 * library wording updates
   * specification of `reflect_constant`/`reflect_object`/`reflect_function`
 
@@ -3756,11 +3759,40 @@ Add a bullet to paragraph 13 and handle `$splice-expression$`s in the existing b
 * [13.2]{.pnum} `$E$` is not a function or function template and `$D$` contains an `$id-expression$`, `$type-specifier$`, `$nested-name-specifier$`, `$template-name$`, or `$concept-name$` denoting `$E$`, or
 * [13.#]{.pnum} `$E$` is a function or function template and `$D$` contains an expression that names `$E$` ([basic.def.odr]) or an `$id-expression$` that refers to a set of overloads that contains `$E$`.
 
+  [Non-dependent names in an instantiated declaration do not refer to a set of overload ([temp.res]).]{.note7}
+
+:::
+
+[No changes are proposed to paragraphs 14-15, but they are reproduced below for ease of reference.]{.draftnote}
+
+::: std
+[14]{.pnum} A declaration is an _exposure_ if it either names a TU-local entity (defined below), ignoring
+
+- [#.#]{.pnum} the `$function-body$` for a non-inline function or function template (but not the deduced return type for a (possibly instantiated) definition of a function with a declared return type that uses a placeholder ytpe ([dcl.spec.auto])),
+- [#.#]{.pnum} the `$initializer$` for a variable or variable template (but not the variable's type),
+- [#.#]{.pnum} friend declarations in a class definition, and
+- [#.#]{.pnum} any reference to a non-volatile const object or reference with internal or no linkage initialized with a constant expression that is not an odr-use ([basic.def.odr]),
+
+or defines a constexpr variable initialized to a TU-local value (defined below).
+
+[An inline function template can be an exposure even though certain explicit specializations of it would be usable in other translation units.]{.note8}
+
+[15]{.pnum} An entity is _TU-local_ if it is
+
+- [#.#]{.pnum} a type, function, variable, or template that
+  - [#.#.#]{.pnum} has a name with internal linkage, or
+  - [#.#.#]{.pnum} does not have a name with linkage and is declared, or introduced by a `$lambda-expression$`, within the definition of a TU-local entity,
+- [#.#]{.pnum} a type with no name that is defined outside a `$class-specifier$`, function body, or `$initializer$` or is introduced by a `$defining-type-specifier$` that is used to declare only TU-local entities,
+- [#.#]{.pnum} a specialization of a TU-local template,
+- [#.#]{.pnum} a specialization of a template with any TU-local template arguments, or
+- [#.#]{.pnum} a specialization of a template whose (possibly instantiated) declaration is an exposure.
+
+  [A specialization can be produced by implicit or explicit instantiation.]{.note9}
 :::
 
 [The below addition of "value or object of a TU-local type" is in part a drive-by fix to make sure that enumerators in a TU-local enumeration are also TU-local]{.ednote}
 
-Extend the definition of _TU-local_ values and objects in p16 to include reflections:
+Extend the definition of _TU-local_ values and objects in paragraph 16 to include reflections:
 
 ::: std
 
@@ -3770,15 +3802,24 @@ Extend the definition of _TU-local_ values and objects in p16 to include reflect
 * [16.1]{.pnum} it is, or is a pointer to, a TU-local function or the object associated with a TU-local variable, [or]{.rm}
 
 :::addu
-* [16.1+]{.pnum} it is a reflection representing either
-  * [16.1+.#]{.pnum} an entity that is either TU-local or introduced by an exposure, or
-  * [16.1+.#]{.pnum} a value, or object that is TU-local, or
-  * [16.1+.#]{.pnum} a direct base class relationship ([class.derived.general]) for which the base class or the derived class is either TU-local or introduced by an exposure, or
-  * [16.1+.#]{.pnum} a data member description (`$T$`, `$N$`, `$A$`, `$W$`, `$NUA$`) ([class.mem.general]) for which `$T$` is either TU-local or introduced by an exposure, or
+* [16.1+]{.pnum} it is a reflection that represents either
+  * [16.1+.#]{.pnum} an entity, value, or object, that is TU-local, or
+  * [16.1+.#]{.pnum} a direct base class relationship ([class.derived.general]) for which the base class or the derived class is TU-local, or
+  * [16.1+.#]{.pnum} a data member description (`$T$`, `$N$`, `$A$`, `$W$`, `$NUA$`) ([class.mem.general]) for which `$T$` is TU-local, or
 :::
 * [16.2]{.pnum} it is an object of class or array type and any of its subobjects or any of the objects or functions to which its non-static data members of reference type refer is TU-local and is usable in constant expressions.
 
 [Values that are TU-local to different translation units are never considered equivalent.]{.addu}
+
+:::
+
+[No changes are proposed to paragraphs 17-18, but they are reproduced below for ease of reference.]{.draftnote}
+
+::: std
+[17]{.pnum} If a (possibly instantiated) declaration of, or a deduction guide for, a non-TU-local entity in a module interface unit (outside the `$private-module-fragment$`, if any) or module partition ([module.unit]) is an exposure, the program is ill-formed. Such a declaration in any other context is deprecated ([depr.local]).
+
+[18]{.pnum} If a declaration that appears in one translation unit names a TU-local entity declared in another translation unit that is not a header unit, the program is ill-formed. A declaration instantiated for a template specialization ([temp.spec]) appears at the point of instantiation of the specialization ([temp.point]).make
+
 
 :::
 
@@ -3789,15 +3830,25 @@ Add examples demonstrating the above rules to the example in paragraph 19:
 Translation unit #1:
 ```cpp
 export module A;
+static void f() {}
+inline void it() { f(); }          // error: is an exposure of f
+static inline void its() { f(); }  // OK
+template<int> void g() { its(); }  // OK
+template void g<0>();
+
 [...]
 
 inline void h(auto x) { adl(x); }  // OK, but certain specializations are exposures
 
-@[`using Alias = int;`]{.addu}@
-@[`template <auto R> struct T {};`]{.addu}@
-@[`static constexpr auto r1 = ^^Alias;  // OK, value is TU-local but so is r1`]{.addu}@
-@[`constexpr auto r2 = ^^Alias;         // error: value is TU-local but r2 is not`]{.addu}@
-@[`export T<^^Alias> t;                 // error: ^^Alias is a TU-local value`]{.addu}@
+@[`constexpr auto r1 = ^^g<0>;  // OK`]{.addu}@
+@[`namespace N2 {`]{.addu}@
+@[`static constexpr auto r2 = ^^g<1>;  // OK, r2 is TU-local`]{.addu}@
+@[`}`]{.addu}@
+@[`constexpr auto r3 = ^^r2;         // error: r3 is an exposure`]{.addu}@
+
+@[`constexpr auto ctx = std::meta::access_context::current();`]{.addu}@
+@[`constexpr auto r4 = std::meta::members_of(^^N2, ctx);`]{.addu}@
+@[\ \ `// error: r4 is an exposure because initializer computes a TU-local value`]{.addu}@
 ```
 
 Translation unit #2:
@@ -4200,6 +4251,8 @@ $splice-expression$:
 
 [#]{.pnum} A `$splice-specifier$` or `$splice-specialization-specifier$` immediately followed by `::` or preceded by `typename` is never interpreted as part of a `$splice-expression$`.
 
+[#]{.pnum} An unparenthesized `$splice-expression$` shall not be used as a template argument.
+
 ::: example
 ```cpp
 struct S { static constexpr int a = 1; };
@@ -4213,8 +4266,13 @@ constexpr int d = template [:^^TCls:]<int>::b;  // OK, template [:^^TCls:]<int> 
 template <auto V> constexpr int e = [:V:];   // OK
 constexpr int f = template [:^^e:]<^^S::a>;  // OK
 
-auto g = typename [:^^int:](42);
+constexpr auto g = typename [:^^int:](42);
   // OK, typename [:^^int:] is a splice-type-specifier
+
+constexpr auto h = ^^g;
+constexpr auto i = e<[:^^h:]>;
+  // error: unparenthesized splice-expression used as template argument
+constexpr auto j = e<([:^^h:])>;  // OK
 ```
 
 :::
@@ -4413,7 +4471,8 @@ consteval void g(std::meta::info r, X<false> xv) {
 
 [#]{.pnum} If a `$reflect-expression$` `$R$` matches the form `^^ $qualified-reflection-name$`, it is interpreted as such and its representation is determined as follows:
 
-- [#.#]{.pnum} If the `$identifier$` is a `$namespace-name$` that names a namespace alias ([namespace.alias]), `$R$` represents that namespace alias. For any other `$namespace-name$`, `$R$` represents the denoted namespace.
+- [#.#]{.pnum} If the `$identifier$` names a `$using-declarator$` ([namespace.udecl]), `$R$` is ill-formed.
+- [#.#]{.pnum} Otherwise, if the `$identifier$` is a `$namespace-name$` that names a namespace alias ([namespace.alias]), `$R$` represents that namespace alias. For any other `$namespace-name$`, `$R$` represents the denoted namespace.
 - [#.#]{.pnum} Otherwise, if the `$identifier$` is a `$concept-name$` ([temp.concept]), `$R$` represents the denoted concept.
 - [#.#]{.pnum} Otherwise, if the `$identifier$` is a `$template-name$` ([temp.names]), the representation of `$R$` is determined as follows:
   - [#.#.#]{.pnum} If the `$template-name$` names an injected-class-name ([class.pre]), then:
@@ -4475,6 +4534,10 @@ typedef struct X {} Y;
 typedef struct Z {} Z;
 constexpr auto e = ^^Y;  // OK, represents the type alias Y
 constexpr auto f = ^^Z;  // OK, represents the type Z (not the type alias)
+
+struct B { int m; };
+struct D : B { using B::m; };
+constexpr auto g = ^^D::m;  // error: D::m names a using-declarator
 ```
 :::
 


### PR DESCRIPTION
- Inline all of the [basic.link] paragraphs pertaining to TU-locality and exposures, for ease of reference during review (Hubert's request).
- Revert the change to make reflections of exposures TU-local (it's not needed).
- Update [basic.link] examples (reflections of aliases are no longer TU-local values 🎉 ).
- `TemplateName<[:R:]>` must now be spelled `TemplateName<([:R:])>` (with example).
- `^^Using::Declarator` is ill-formed (with example).