### PR TITLE
Update mpark/wg21 and revert the Makefile rules.

### DIFF
--- a/2806_do_expr/Makefile
+++ b/2806_do_expr/Makefile
@@ -1,3 +1,2 @@
-PAPER := p2806r4.html
-DEPS := do-expr.md
+p2806r4.html : do-expr.md
 include ../md/mpark-wg21.mk

--- a/md/mpark-wg21.mk
+++ b/md/mpark-wg21.mk
@@ -18,7 +18,5 @@ endif
 #    --bibliography $(THIS_DIR)wg21_fmt.yaml \
 #	$(full_index)
 
-$(PAPER) : $(DEPS) $(SRCDEPS) $(GENDEPS)
+$(OUTDIR)/p%.html $(OUTDIR)/d%.html : $(DEPS)
 	$(PANDOC) --bibliography $(DATADIR)/csl.json --bibliography $(THIS_DIR)wg21_fmt.yaml -f markdown-tex_math_dollars
-
-.DEFAULT_GOAL := $(PAPER)


### PR DESCRIPTION
I made these changes upstream, and reverted the Makefile rules you had to make recently.
- [Split the .md files between user input and auxiliary input from the framework.](https://github.com/mpark/wg21/commit/1dee2869f2c90a244a385719b79467be917adb88)
- [Specify SRCDEPS explicitly. Reverts 691d9ff.](https://github.com/mpark/wg21/commit/35f486dcc2eb3b53776456a58e26798ce73707b6)
- [Re-add DEPS for downstream usage.](https://github.com/mpark/wg21/commit/0c59483ae96a3135c2eed6a89558dfbdf07504ee)