### PR TITLE
Simplifications based on changes upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 .vscode/
 optional/
-md/defaults.yaml
 md/mermaid-images/
 graphviz-images/

--- a/md/defaults.py
+++ b/md/defaults.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-
-import pathlib
-
-print(
-"""\
-css: {datadir}/pandoc.css
-filters: [{datadir}/pandoc.py]
-""".format(datadir=pathlib.Path(__file__).parent.resolve()))

--- a/md/defaults.py
+++ b/md/defaults.py
@@ -6,8 +6,4 @@ print(
 """\
 css: {datadir}/pandoc.css
 filters: [{datadir}/pandoc.py]
-
-metadata:
-  highlighting:
-    inline-code: cpp\
 """.format(datadir=pathlib.Path(__file__).parent.resolve()))

--- a/md/defaults.yaml
+++ b/md/defaults.yaml
@@ -1,3 +1,5 @@
 css: ${.}/pandoc.css
 filters:
   - ${.}/pandoc.py
+
+bibliography: ${.}/wg21_fmt.yaml

--- a/md/defaults.yaml
+++ b/md/defaults.yaml
@@ -1,0 +1,3 @@
+css: ${.}/pandoc.css
+filters:
+  - ${.}/pandoc.py

--- a/md/mpark-wg21.mk
+++ b/md/mpark-wg21.mk
@@ -16,4 +16,4 @@ endif
 #	$(full_index)
 
 $(OUTDIR)/p%.html $(OUTDIR)/d%.html : $(DEPS)
-	$(PANDOC) --bibliography $(DATADIR)/csl.json --bibliography $(THIS_DIR)wg21_fmt.yaml -f markdown-tex_math_dollars
+	$(PANDOC) --bibliography $(THIS_DIR)wg21_fmt.yaml -f markdown-tex_math_dollars

--- a/md/mpark-wg21.mk
+++ b/md/mpark-wg21.mk
@@ -1,19 +1,3 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-
-OUTDIR := .
 DEFAULTS := $(THIS_DIR)defaults.yaml
-include $(THIS_DIR)wg21/Makefile
-
-ifdef NO_BIBLIO
-full_index :=
-else
-full_index := --bibliography $(DATADIR)/index.yaml
-endif
-
-#%.html : $(DEPS)
-#	$(PANDOC) \
-#    --bibliography $(THIS_DIR)wg21_fmt.yaml \
-#	$(full_index)
-
-$(OUTDIR)/p%.html $(OUTDIR)/d%.html : $(DEPS)
-	$(PANDOC) -f markdown-tex_math_dollars
+include $(THIS_DIR)wg21/paper.mk

--- a/md/mpark-wg21.mk
+++ b/md/mpark-wg21.mk
@@ -16,4 +16,4 @@ endif
 #	$(full_index)
 
 $(OUTDIR)/p%.html $(OUTDIR)/d%.html : $(DEPS)
-	$(PANDOC) --bibliography $(THIS_DIR)wg21_fmt.yaml -f markdown-tex_math_dollars
+	$(PANDOC) -f markdown-tex_math_dollars

--- a/md/mpark-wg21.mk
+++ b/md/mpark-wg21.mk
@@ -4,9 +4,6 @@ OUTDIR := .
 DEFAULTS := $(THIS_DIR)defaults.yaml
 include $(THIS_DIR)wg21/Makefile
 
-$(THIS_DIR)defaults.yaml : $(THIS_DIR)defaults.py
-	$< > $@
-
 ifdef NO_BIBLIO
 full_index :=
 else


### PR DESCRIPTION
- Simplified defaults handling.
- Simplified `mpark-wg21.mk` by relying on the new per-paper make setup `paper.mk`.